### PR TITLE
aurbuild: add support for package and database signing

### DIFF
--- a/bin/aurbuild
+++ b/bin/aurbuild
@@ -16,10 +16,10 @@ mkchr_args=(-cu)
 # that pacman now considers packages inside the official repositories
 # as "local", and warns if they are newer than a custom counterpart.
 build_local() {
-    #global database pool root mkpkg_args
+    #global database pool root sign mkpkg_args
 
-    PKGDEST="$pool" LC_MESSAGES=C makepkg "${mkpkg_args[@]}"
-    repose -vf "$database" -r "$root" -p "$pool"
+    PKGDEST="$pool" LC_MESSAGES=C makepkg "${mkpkg_args[@]}" "$sign"
+    repose "$sign" -vf "$database" -r "$root" -p "$pool"
 
     printf '%s\n%s\n' "[$database]" "$(pacconf --repo="$database")" > "$tmp"/config
     sudo pacman -Syu --config="$tmp"/config
@@ -30,13 +30,13 @@ build_local() {
 # '/pkgdest' is hardcoded in makechrootpkg, packages are rebuilt even
 # if already available.
 build_chroot() {
-    #global CHROOT database pool root mkchr_args
+    #global CHROOT database pool root sign mkchr_args
 
     # Skip verification checks in the chroot instance as .gnupg paths
     # are hardcoded in makechrootpkg. Signatures are still verified
     # outside the chroot. Preserve PKGDEST with sudo -E, see FS#44827.
-    sudo -E PKGDEST="$pool" makechrootpkg "${mkchr_args[@]}" -d "$pool" -r "$CHROOT" -- --skippgpcheck
-    repose -vf "$database" -r "$root" -p "$pool"
+    sudo -E PKGDEST="$pool" makechrootpkg -r "$CHROOT" -d "$pool" "${mkchr_args[@]}" -- "$sign"
+    repose "$sign" -vf "$database" -r "$root" -p "$pool"
 }
 
 # If a package is rebuilt (same pkgver), checksums in the database no
@@ -57,9 +57,8 @@ clean_cache() {
 }
 
 usage() {
-    plain "Usage: $argv0 [-c] -a <queue> -d <database> -p <pool> -r <root> [--] [<makepkg/makechrootpkg args>]"
+    plain "Usage: $argv0 [-c] [-s] -a <queue> -d <database> -p <pool> -r <root> [--] [<makepkg/makechrootpkg args>]"
 }
-
 
 trap 'exit' INT
 trap 'rm -rf "$tmp"' EXIT
@@ -68,13 +67,14 @@ source /usr/share/makepkg/util.sh
 
 [[ -t 2 ]] && colorize
 
-while getopts :a:cd:p:r: OPT; do
+while getopts :a:cd:p:r:s OPT; do
     case $OPT in
         a) queue="$OPTARG"    ;;
         c) build=build_chroot ;;
         d) database="$OPTARG" ;;
         p) pool="$OPTARG"     ;;
         r) root="$OPTARG"     ;;
+        s) sign="--sign"      ;;
         :) case $OPTARG in
                 a) error "$argv0: No package queue specified (-a)"; usage; exit 1 ;;
                 d) error "$argv0: No repository database specified (-d)"; usage; exit 1 ;;
@@ -114,6 +114,11 @@ else
     mkpkg_args+=("${@:$OPTIND}")
 fi
 
+if [[ $sign == --sign ]]; then
+    # Pass socket and environment to the build chroot.
+    mkchr_args+=("-d" "$HOME/.gnupg/S.gpg-agent:/build/.gnupg/S.gpg-agent")
+    mkchr_args+=("-e" "GPG_TTY=$(tty)" "-e" "DISPLAY=$DISPLAY")
+fi
 
 if [[ $build == build_chroot ]]; then
     CHROOT=/var/lib/aurbuild

--- a/bin/aurbuild
+++ b/bin/aurbuild
@@ -56,6 +56,11 @@ clean_cache() {
     done < <(makepkg --packagelist)
 }
 
+usage() {
+    plain "Usage: $argv0 [-c] -a <queue> -d <database> -p <pool> -r <root> [--] [<makepkg/makechrootpkg args>]"
+}
+
+
 trap 'exit' INT
 trap 'rm -rf "$tmp"' EXIT
 
@@ -65,15 +70,42 @@ source /usr/share/makepkg/util.sh
 
 while getopts :a:cd:p:r: OPT; do
     case $OPT in
-        a|+a) queue="$OPTARG"    ;;
-        c|+c) build=build_chroot ;;
-        d|+d) database="$OPTARG" ;;
-        p|+p) pool="$OPTARG"     ;;
-        r|+r) root="$OPTARG"     ;;
-        *) plain "usage: $argv0 [-c] -a <queue> -d <database> -p <pool> -r <root> [--] [makepkg args]"
-           exit 1 ;;
+        a) queue="$OPTARG"    ;;
+        c) build=build_chroot ;;
+        d) database="$OPTARG" ;;
+        p) pool="$OPTARG"     ;;
+        r) root="$OPTARG"     ;;
+        :) case $OPTARG in
+                a) error "$argv0: No package queue specified (-a)"; usage; exit 1 ;;
+                d) error "$argv0: No repository database specified (-d)"; usage; exit 1 ;;
+                p) error "$argv0: No package pool specified (-p)"; usage; exit 1 ;;
+                r) error "$argv0: No repository root specified (-r)"; usage; exit 1 ;;
+            esac ;;
+        ?) error "$argv0: Option not recognized (-$OPTARG)"; usage; exit 1; ;;
     esac
 done
+
+# Validate arguments
+re_blank='^[[:space:]]*$'
+if [[ $queue =~ $re_blank || $database =~ $re_blank || $pool =~ $re_blank || $root =~ $re_blank ]]; then
+    error "$argv0: Missing arguments" && usage
+    exit 1
+elif [[ ! -r $queue ]]; then
+    error "$argv0: $queue: Permission denied"
+    exit 13
+elif [[ ! -d $pool ]]; then
+    error "$argv0: $pool: not a directory"
+    exit 20
+elif [[ ! -w $pool ]]; then
+    error "$argv0: $pool: permission denied"
+    exit 13
+elif [[ ! -d $root ]]; then
+    error "$argv0: $root: not a directory"
+    exit 20
+elif [[ ! -w $root ]]; then
+    error "$argv0: $root: permission denied"
+    exit 13
+fi
 
 # Pass all arguments after -- to makepkg/makechrootpkg.
 if [[ $build == build_chroot ]]; then
@@ -82,15 +114,6 @@ else
     mkpkg_args+=("${@:$OPTIND}")
 fi
 
-if [[ ! $database || ! $pool || ! $root ]]; then
-    error "$argv0: Missing arguments (-d, -p, -r)"
-    exit 1
-fi
-
-if [[ ! -r $queue ]]; then
-    error "$argv0: $queue: Permission denied"
-    exit 13
-fi
 
 if [[ $build == build_chroot ]]; then
     CHROOT=/var/lib/aurbuild

--- a/bin/aurbuild
+++ b/bin/aurbuild
@@ -133,6 +133,10 @@ if [[ $build == build_chroot ]]; then
     sudo cp -v "$tmp"/pacman.conf "$CHROOT"/root/etc/pacman.conf
 fi
 
+# Canonicalise paths
+pool="$(realpath "${pool}")"
+root="$(realpath "${root}")"
+
 # Read from FD 3 to choose providers with makepkg (#21)
 exec 3< "$queue"
 


### PR DESCRIPTION
Outside of chroots, this works flawlessly. Repose has had database signing support for quite a while now, just undocumented. Makepkg likewise can sign packages without an issue.

Inside the chroot, things are more complicated. You need to pass two things into the chroot, and indeed all the way to makepkg: the GPG agent socket (with a fixed location of `$GNUPGHOME/S.gpg-agent`, i.e. `$HOME/.gnupg/S.gpg-agent`), and an environment variable telling GPG where to tell the agent to open the pinentry at: either $DISPLAY or $GPG_TTY.

Unmodified makechrootpkg can handle the socket just fine; it accepts the `-d <path>` option, which is translated into the `--bind` option for systemd-nspawn — thus, `-d $HOME/.gnupg/S.gpg-agent:/build/.gnupg/S.gpg-agent` works. With that alone, you can sign packages within the chroot as long as your signing key passphrase is pre-cached in the agent. If it's not, the agent tries to open pinentry-curses on /dev/console and fails.

I have submitted a [patch](https://lists.archlinux.org/pipermail/arch-projects/2016-May/004342.html) for devtools upstream that adds a `-e <var>` option to makechrootpkg, which gets translated into `--setenv` for systemd-nspawn. Thus, `-e DISPLAY=$DISPLAY -e GPG_TTY=$GPG_TTY` will pass those into the environment. A [second patch](https://lists.archlinux.org/pipermail/arch-projects/2016-May/004343.html) allows those variables through the sudo wall in the chroot, letting makepkg and gpg see them and everything function normally.

Finally, this PR includes cleanup of option handling, more error verification, and solves another option-related error.