### PR TITLE
Update chroot once

### DIFF
--- a/bin/aurbuild
+++ b/bin/aurbuild
@@ -122,6 +122,9 @@ if ((chroot)); then
         sudo install -d "$CHROOT"
         sudo mkarchroot "$CHROOT"/root base base-devel
     else
+        # since makechrootpkg restores the user chroot to the state from root chroot
+        # base and base-devel packages are reupdated before each package build
+        # this updates the root once before starting package build process to prevent that
         sudo arch-nspawn "$CHROOT"/root pacman -Syu --noconfirm
     fi
 

--- a/bin/aurbuild
+++ b/bin/aurbuild
@@ -121,6 +121,8 @@ if ((chroot)); then
     if [[ ! -d $CHROOT/root ]]; then
         sudo install -d "$CHROOT"
         sudo mkarchroot "$CHROOT"/root base base-devel
+    else
+        sudo arch-nspawn "$CHROOT"/root pacman -Syu --noconfirm
     fi
 
     # Retrieve settings from pacman.conf and Include directives.


### PR DESCRIPTION
Update the root chroot once before build so that the user chroot doesn't have to update base packages on each subsequent package build