### PR TITLE
Close stdin when invoking pacsift in aurcheck

### DIFF
--- a/bin/aurcheck
+++ b/bin/aurcheck
@@ -9,7 +9,8 @@ readonly PS4 argv0 tmp
 declare -i all=0
 
 syncver() {
-    pacsift --exact --repo="$1" | expac -S '%n\t%v' -
+    # Close stdin so pacsift does not attempt to read packages from it
+    pacsift --exact --repo="$1" 0<&- | expac -S '%n\t%v' -
 }
 
 aurver() {


### PR DESCRIPTION
`aurcheck` raises an error when run with `stdin` open but not connected to a terminal:

```sh
$ 0</dev/null aurcheck -q myrepo        
error: argument '-' specified with empty stdin
    aursearch: no targets specified
```

This is due to `pacsift`'s logic for figuring out whether to read packages from `stdin` -- from `man pacsift`:

> CAVEATS
       pacsift determines whether or not to read packages from stdin based on a naive check using isatty(3).  If pacsift is called in an environment, such as a shell function or script being used in a pipe, where stdin is not connected to a terminal but does not contain packages to filter, pacsift should be called with stdin closed.  For POSIX-compatible shells, this can be done with "<&-".

This PR adds an explicit `stdin` close so that `pacsift` behaves when `aurcheck` is called from within an environment with `stdin` open to something other than a terminal -- for instance, when `aursync` is run as a systemd service (my use case).

TIA for your consideration!