### PR TITLE
Fixed aurqueue example

### DIFF
--- a/man7/aurutils.7
+++ b/man7/aurutils.7
@@ -178,7 +178,7 @@ Build all packages in the \fIpkgbuilds\fR github repository:
   $ git clone https://www.github.com/Earnestly/pkgbuilds
   $ cd pkgbuilds
   $ find -maxdepth 2 -name PKGBUILD -execdir mksrcinfo \\;
-  $ aurqueue ./* > queue # Remove unwanted targets
+  $ aurqueue * > queue # Remove unwanted targets
   $ aurbuild -d custom -a queue
 
 .EE


### PR DESCRIPTION
I'm unsure if this is a bug.
```
λ fox@hackbook AUR » λ git master* → aurqueue i3blocks-git                
i3blocks-git
λ fox@hackbook AUR » λ git master* → aurqueue ./i3blocks-git
λ fox@hackbook AUR » λ git master* → 
```