### PR TITLE
aurbuild: check for built packages

### DIFF
--- a/bin/aurbuild
+++ b/bin/aurbuild
@@ -6,7 +6,7 @@ set -e
 
 declare -a gpg_args=(--detach-sign --no-armor --verbose --batch)
 declare -a makechrootpkg_args=(-cnu) makepkg_args=(-Lcrs)
-declare -i chroot=0 sign_pkg=0
+declare -i chroot=0 sign_pkg=0 find_pkg=1
 
 conf_section() {
     printf '[%s]\n' "$1"
@@ -53,12 +53,13 @@ if [[ -t 2 ]]; then
 fi
 
 unset queue container database root
-while getopts a:cC:d:r:s OPT; do
+while getopts a:cC:d:fr:s OPT; do
     case $OPT in
         a) queue=$OPTARG      ;;
         c) chroot=1           ;;
         C) container=$OPTARG  ;;
         d) database=$OPTARG   ;;
+        f) find_pkg=0         ;;
         r) root=$OPTARG       ;;
         s) sign_pkg=1         ;;
         *) usage              ;;
@@ -141,6 +142,13 @@ fi
 
 while read -r -u "$fd" pkg _; do
     cd_safe "$basedir/$pkg"
+
+    if ((find_pkg)); then
+        while IFS= read -r -d $'\0'; do
+            error "A package has already been built: $(printf '%q' "$REPLY") (use -f to overwrite)"
+            exit 1
+        done < <(makepkg --packagelist | xargs -I{} find "$root" -name '{}*' -print0)
+    fi
 
     if ((chroot)); then
         sudo PKGDEST="$var_tmp" makechrootpkg \

--- a/bin/aurbuild
+++ b/bin/aurbuild
@@ -145,7 +145,7 @@ while read -r -u "$fd" pkg _; do
 
     if ((!force)); then
         while IFS= read -d $'\0' -r; do
-            error "A package has already been built: $(printf '%q' "$REPLY") (use -f to overwrite)"
+            error "A package has already been built: $(printf '%q' "$REPLY") (use -f to ignore)"
             exit 1
         done < <(makepkg --packagelist | xargs -I{} find "$root" -name '{}*' -print0)
     fi

--- a/bin/aurbuild
+++ b/bin/aurbuild
@@ -6,7 +6,7 @@ set -e
 
 declare -a gpg_args=(--detach-sign --no-armor --verbose --batch)
 declare -a makechrootpkg_args=(-cnu) makepkg_args=(-Lcrs)
-declare -i chroot=0 sign_pkg=0 find_pkg=1
+declare -i chroot=0 sign_pkg=0 force=0
 
 conf_section() {
     printf '[%s]\n' "$1"
@@ -59,7 +59,7 @@ while getopts a:cC:d:fr:s OPT; do
         c) chroot=1           ;;
         C) container=$OPTARG  ;;
         d) database=$OPTARG   ;;
-        f) find_pkg=0         ;;
+        f) force=1            ;;
         r) root=$OPTARG       ;;
         s) sign_pkg=1         ;;
         *) usage              ;;
@@ -143,7 +143,7 @@ fi
 while read -r -u "$fd" pkg _; do
     cd_safe "$basedir/$pkg"
 
-    if ((find_pkg)); then
+    if ((!force)); then
         while IFS= read -d $'\0' -r; do
             error "A package has already been built: $(printf '%q' "$REPLY") (use -f to overwrite)"
             exit 1

--- a/bin/aurbuild
+++ b/bin/aurbuild
@@ -40,7 +40,7 @@ trap_exit() {
 }
 
 usage() {
-    plain "usage: $argv0 [-cs] -d <database> [-Car] [--] <makepkg args>"
+    plain "usage: $argv0 [-cfs] -d <database> [-a queue] [-C container] [-r root] [--] <makepkg args>"
     exit 1
 }
 
@@ -144,7 +144,7 @@ while read -r -u "$fd" pkg _; do
     cd_safe "$basedir/$pkg"
 
     if ((find_pkg)); then
-        while IFS= read -r -d $'\0'; do
+        while IFS= read -d $'\0' -r; do
             error "A package has already been built: $(printf '%q' "$REPLY") (use -f to overwrite)"
             exit 1
         done < <(makepkg --packagelist | xargs -I{} find "$root" -name '{}*' -print0)


### PR DESCRIPTION
Possible workaround to #223. This check also applies to makechrootpkg. Ideally this could be checked for the whole queue before proceeding with the build, but `makepkg --packagelist` only works for a single PKGBUILD.