### PR TITLE
aurgrep: support pattern beginning with hyphen

### DIFF
--- a/bin/aurgrep
+++ b/bin/aurgrep
@@ -52,6 +52,6 @@ else
     list_update "$aurweb/$pkglist.gz" "$pkglist" > timestamp
 fi
 
-pcregrep "$@" "$pkglist"
+pcregrep -e "$@" "$pkglist"
 
 # vim: set et sw=4 sts=4 ft=sh:


### PR DESCRIPTION
Example:
```
$ aurgrep -- -nox
vim-nox
cppcheck-nox
erlang-nox-r17
vlc-nox
gst-plugins-bad-rpi-nox
usbguard-nox
qbittorrent-nox-git
virtualbox-guest-utils-nox-svn
emacs-nox-24bit
sdl2-nox
```
