### PR TITLE
Propagate -N (--nosync, --no-sync) aurbuild option to aursync

### DIFF
--- a/bin/aursync
+++ b/bin/aursync
@@ -74,8 +74,8 @@ fi
 
 longopts=allan,bind:,chroot,directory:,force,ignore:,ignorearch,ignore-arch,log
 longopts+=,noconfirm,no-confirm,nover,no-ver,noview,no-view,print,rmdeps,rm-deps
-longopts+=,sign,temp,tar,repo:,root:,update,aurutils,continue
-shortopts=B:C:D:M:AcfLnprstTu
+longopts+=,nosync,no-sync,sign,temp,tar,repo:,root:,update,aurutils,continue
+shortopts=B:C:D:M:AcfLnNprstTu
 
 if TEMP=$(getopt -o "$shortopts" -l "$longopts" -n "$argv0" -- "$@"); then
     eval set -- "$TEMP"
@@ -108,6 +108,9 @@ while true; do
         -M)
             aurbuild_args+=(-M "$2")
             shift 2 ;;
+        -N|--nosync|--no-sync)
+            aurbuild_args+=(-N)
+            shift ;;
         -B|--bind)
             makechrootpkg_args+=(-d "$2")
             shift 2 ;;

--- a/man1/aursync.1
+++ b/man1/aursync.1
@@ -105,9 +105,14 @@ Ignore a missing or incomplete \fIarch\fR field in the build script.
 Enable logging to a text file in the build directory.
 .RE
 
-.B \-n, --no-confirm
+.B \-n, --noconfirm, --no-confirm
 .RS
 Do not wait for user input. (\fImakepkg --noconfirm\fR)
+.RE
+
+.B \-N, --nosync, --no-sync
+.RS
+Do not sync the local repository after building. (\fIaurbuild -N\fR)
 .RE
 
 .B \-r, --rmdeps


### PR DESCRIPTION
I'd like to propagate the `-N` option from aurbuild to aursync for the following reason:

After I review the package files, I want aursync to be able to fully run without my interaction until the very end. Right now it stops on the first `sudo pacman -Sy` after it built the first package and waits for sudo password, which is annoying. I am synchronizing repositories anyway when I'm upgrading (by running `pacman -Syu`), so it's totally fine to not synchronize the repo during `aursync`.