### PR TITLE
[aursrcver] No verbose rm

### DIFF
--- a/bin/aursrcver
+++ b/bin/aursrcver
@@ -22,11 +22,11 @@ mangle() {
                 pkgver+=-
                 pkgver+=$value
                 ;;
-            '') 
+            '')
                 break ;;
         esac
     done
-    
+
     printf '%s\t%s\n' "$pkgbase" "$pkgver"
 }
 
@@ -41,7 +41,7 @@ trap_err() {
 
 trap_exit() {
     # preserve makepkg log on error
-    ((!$?)) && rm -v "$1"
+    ((!$?)) && rm "$1"
 }
 
 readonly -f mangle find_pkgbuild_path


### PR DESCRIPTION
Tiny fix discovered while testing, probably left there by accident:

```
❯ aursrcver ~/.cache/aursync/*-git
alacritty-git   0.1.0.730.gb82622e-1
antigen-git     v2.2.3.r6.gc91f77c-1
aurutils-git    1.5.3.r272.gb84989e-1
dragon-git      r10.24242e7-1
gtk-theme-arc-grey-git  r728.51780e1-1
i3ipc-python-git        r173.1516924861.99cbe2a-1
libva-git       2.0.0.r58.g71fd9ec-1
libva-intel-driver-git  2.0.0.r106.g0b37282-1
lscolors-git    r242.73965bd-1
pam_u2f-git     1.0.4.r76.gb2f46d9-1
py3status-git   3.7.r240.g3a2d0b2a-1
python-azure-git        latest-1
universal-ctags-git     0.r5771.5e4eca42-1
removed '/tmp/tmp.zSnjGOHf5Z'                          <-------- don't need this in my output
```