### PR TITLE
aursearch: allow sort by votes

### DIFF
--- a/bin/aursearch
+++ b/bin/aursearch
@@ -106,12 +106,12 @@ parse() { json_short; }
 by=name-desc
 sort_by=Name
 
-while getopts :imnVrRv OPT; do
+while getopts :imnk:rRv OPT; do
     case $OPT in
         i) by=none ;;
         m) by=maintainer ;;
         n) by=name ;;
-        V) sort_by=NumVotes ;;
+        k) sort_by=$OPTARG ;;
         r) parse() { tee; } ;;
         R) parse() { sed 's/^/[/; s/}{/},{/g; s/$/]/' ; } ;;
         v) parse() { json_long; } ;;

--- a/bin/aursearch
+++ b/bin/aursearch
@@ -34,10 +34,10 @@ dl_stdin() {
 }
 
 json_short() {
-    jq -e -r '[.results[]] | sort_by(.Name)[] | .Name,
+    jq -e -r "[.results[]] | sort_by(.$sort_by)[] | .Name,
         .Version,
         .NumVotes,
-        .Description' | while
+        .Description" | while
     {
         read -r Name
         read -r Version
@@ -50,7 +50,7 @@ json_short() {
 }
 
 json_long() {
-    jq -e -r '[.results[]] | sort_by(.Name)[] | .Name,
+    jq -e -r "[.results[]] | sort_by(.$sort_by)[] | .Name,
         .PackageBase,
         .Version,
         .Description,
@@ -60,7 +60,7 @@ json_long() {
         .OutOfDate,
         .Maintainer,
         .FirstSubmitted,
-        .LastModified' | while
+        .LastModified" | while
     {
         read -r Name
         read -r PackageBase
@@ -104,12 +104,14 @@ fi
 
 parse() { json_short; }
 by=name-desc
+sort_by=Name
 
-while getopts :imnrRv OPT; do
+while getopts :imnVrRv OPT; do
     case $OPT in
         i) by=none ;;
         m) by=maintainer ;;
         n) by=name ;;
+        V) sort_by=NumVotes ;;
         r) parse() { tee; } ;;
         R) parse() { sed 's/^/[/; s/}{/},{/g; s/$/]/' ; } ;;
         v) parse() { json_long; } ;;

--- a/bin/aursearch
+++ b/bin/aursearch
@@ -44,7 +44,7 @@ json_short() {
         read -r NumVotes
         read -r Description
     }; do
-        printf "${BLUE}aur/${ALL_OFF}${BOLD}%s ${GREEN}%s ${ALL_OFF}(%s)\n    %s\n" \
+        printf "${BLUE}aur/${ALL_OFF}${BOLD}%s ${GREEN}%s ${ALL_OFF}(%s)\\n    %s\\n" \
                "$Name" "$Version" "$NumVotes" "$Description"
     done
 }


### PR DESCRIPTION
This adds `-V` to sort by votes.

It turns out I don't need reversed search, because I just realized that ascending sorting by votes already puts most voted packages in the bottom - that's exactly what I wanted 🙂

I'm fine to close #279 with this PR, and implement reverse order only if someone actually needs this.