### PR TITLE
aur: allow execution of user defined scripts

### DIFF
--- a/bin/aur
+++ b/bin/aur
@@ -2,19 +2,28 @@
 readonly argv0=aur
 readonly cmd_dir=/usr/lib/aurutils
 readonly cmd=("$cmd_dir"/*)
-readonly custom_cmd_prefix='aur-'
+readonly usrcmd_prefix='aur-'
+readonly usrcmd=($(compgen -c $usrcmd_prefix))
 
 if [[ -z $1 ]]; then
     printf >&2 -- 'usage: %s [command]\n\n' "$argv0"
     printf >&2 -- 'available commands:\n'
-    printf >&2 -- '    %q\n' "${cmd[@]##*/}"
+    printf -- '%q\n' "${cmd[@]##*/}" | column 1>&2
+
+    if [[ ${#usrcmd[@]} -gt 0 ]]; then
+        printf >&2 -- '\navailable user commands:\n'
+        #ignore user commands that clash with official ones.
+        sort <(printf -- "%q\n" ${usrcmd[@]#aur-}) \
+             <(printf -- "%q\n" ${cmd[@]##*/}) \
+             <(printf -- "%q\n" ${cmd[@]##*/}) | uniq -u | column 1>&2
+    fi
     exit 1
 fi
 
 if [[ -x $cmd_dir/$1 ]]; then
     exec "$cmd_dir/$1" "${@:2}"
-elif command -v "$custom_cmd_prefix$1" > /dev/null 2>&1 ; then
-    exec "$custom_cmd_prefix$1" "${@:2}"
+elif command -v "$usrcmd_prefix$1" > /dev/null 2>&1 ; then
+    exec "$usrcmd_prefix$1" "${@:2}"
 else
     printf >&2 -- '%s: %q is not an aur command\n' "$argv0" "$1"
     exit 1

--- a/bin/aur
+++ b/bin/aur
@@ -2,6 +2,7 @@
 readonly argv0=aur
 readonly cmd_dir=/usr/lib/aurutils
 readonly cmd=("$cmd_dir"/*)
+readonly custom_cmd_prefix='aur-'
 
 if [[ -z $1 ]]; then
     printf >&2 -- 'usage: %s [command]\n\n' "$argv0"
@@ -12,6 +13,8 @@ fi
 
 if [[ -x $cmd_dir/$1 ]]; then
     exec "$cmd_dir/$1" "${@:2}"
+elif command -v "$custom_cmd_prefix$1" > /dev/null 2>&1 ; then
+    exec "$custom_cmd_prefix$1" "${@:2}"
 else
     printf >&2 -- '%s: %q is not an aur command\n' "$argv0" "$1"
     exit 1


### PR DESCRIPTION
Provide a similar mechanism that `git` has for user defined sub-commands.
`git` allows the use of any executable in `$PATH` with prefix `'git-'` to be used with the main `git` command.
E.g. `'git-name'` can be invoked with `$git name`.

In aa59551, I used executables on `$PATH` that were prefixed by `'aur-'`. But in retrospect that was probably a poor choice since [there are already some packages](https://aur.archlinux.org/packages/?K=aur-) which use executables with the `'aur-'` prefix that would end up there.
One alternative is to use another prefix, something like `'aurutils-'`.

Another would be having a dedicated directory for sub-commands scripts. E.g.
```bash
USER_CMDS_DIR=${XDG_CONFIG_HOME:-$HOME/.config}/aurutils/usrcommands
```
Besides giving the user free choice over the naming convention, not having unexpected results due to similar executables by other packages, this would also make listing available scripts (for use in completions or help messages) easier.

I think the second option is preferable, but i'll wait some feedback before pushing another commit.