### PR TITLE
preliminary bash completion

### DIFF
--- a/completions/Makefile
+++ b/completions/Makefile
@@ -1,0 +1,8 @@
+PREFIX ?= /usr
+SHRDIR ?= $(PREFIX)/share
+
+bash/aur: command_opts.m4 bash/aurutils.in
+	m4 $^ >$@
+
+install: bash/aur
+	@install -Dm644 bash/aur $(DESTDIR)$(SHRDIR)/bash-completion/completions

--- a/completions/bash/aurutils.in
+++ b/completions/bash/aurutils.in
@@ -1,0 +1,32 @@
+_aur_completion()
+{
+    local cur prev words cword
+    _get_comp_words_by_ref cur prev words cword
+
+    SUBCOMMANDS
+
+    # complete subcommands
+    if [[ $cword -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "${subcommands[*]}" -- "$cur") )
+        return
+    fi
+
+    # If there's an override for subcommand, use it
+    if declare -F "_aurutils_${words[1]}" >/dev/null ; then
+        "_aurutils_${words[1]}"
+        return
+    fi
+
+    # Complete with the generated opts stored above, unless the previous option
+    # is stored with an : suffix, because the option requires an argument.
+    # Fallback to default (files) completion in such cases.
+
+    opts=($(_get_default_opts ${words[1]} ))
+    if [[ ${opts[*]} != *$prev:* ]]; then
+        COMPREPLY=($(compgen -W "${opts[*]%:}" -- "$cur"));
+    fi
+}
+
+DEFAULT_OPTS
+
+complete -o bashdefault -o default -F _aur_completion aur

--- a/completions/command_opts.m4
+++ b/completions/command_opts.m4
@@ -1,0 +1,41 @@
+divert(-1)dnl
+dnl List of commands to be completed
+dnl
+define(`CORECOMMANDS',
+HAVE_OPTDUMP(build,fetch-snapshot,search,fetch,repo-filter,
+             repo,chroot,pkglist,fetch-git,vercmp,sync,rpc)dnl
+NO_OPTDUMP(depends,jobs,graph,srcver))
+
+dnl recursively print all elements
+dnl How the element is ultimately printed depends on the
+dnl wrap_has_dump and wrap_no_dump macros
+dnl
+define(`HAVE_OPTDUMP',`ifelse(`$#',`0', ,`$#',`1',`wrap_has_dump(`$1') ',`wrap_has_dump($1)' `HAVE_OPTDUMP(shift($@))')')
+define(`NO_OPTDUMP',`ifelse(`$#',`0', ,`$#',`1',`wrap_no_dump(`$1') ',`wrap_no_dump($1)' `NO_OPTDUMP(shift($@))')')
+
+dnl override how elements are printed for SUBCOMMANDS macro
+dnl which defines an array with all avaliable subcommands
+dnl
+pushdef(`wrap_has_dump','$1')
+pushdef(`wrap_no_dump','$1')
+define(SUBCOMMANDS,subcommands=(CORECOMMANDS))
+
+dnl override how elements are printed for the DEFAULT_OPTS
+dnl which is a simple function that returns the options available for a
+dnl subcommand using case statement construct.
+dnl
+pushdef(`wrap_has_dump',`
+	$1) printf -- GET_OPTS($1) ;;')
+pushdef(`wrap_no_dump',`
+	$1) : nothing to print ;;')
+define(DEFAULT_OPTS,
+`_get_default_opts() {
+    case "`$'1" in CORECOMMANDS
+    esac
+}')
+
+dnl Helper macro to retrieves options from subcommand --dump-options
+dnl
+define(GET_OPTS,'`translit(esyscmd(aur $1 --dump-options),`
+',` ')'')
+divert(0)dnl

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -57,8 +57,9 @@ opt_short='a:d:r:D:cfNRsv'
 opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:'
           'makepkg-conf:' 'remove')
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -78,6 +79,9 @@ while true; do
         -R|--remove)    repo_add_args+=(-R) ;;
         --pacman-conf)  shift; chroot_args+=(-C "$1") ;;
         --makepkg-conf) shift; chroot_args+=(-M "$1") ;;
+        --dump-options) printf -- '--%s\n' ${opt_long[@]} ;
+                        printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                        exit ;;
         --) shift; break ;;
     esac
     shift

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -52,12 +52,6 @@ if [[ -t 2 && ! -o xtrace ]]; then
     colorize
 fi
 
-tmp=$(mktemp -d "${TMPDIR:-/tmp}/$argv0".XXXXXXXX)
-var_tmp=$(mktemp -d "${TMPDIR:-/var/tmp}/$argv0".XXXXXXXX)
-
-trap 'trap_exit' EXIT
-trap 'exit' INT
-
 ## option parsing
 opt_short='a:d:r:D:cfNRsv'
 opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign'
@@ -89,6 +83,12 @@ while true; do
     shift
 done
 unset opt_short opt_long OPTRET
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/$argv0".XXXXXXXX)
+var_tmp=$(mktemp -d "${TMPDIR:-/var/tmp}/$argv0".XXXXXXXX)
+
+trap 'trap_exit' EXIT
+trap 'exit' INT
 
 # reset default makechrootpkg arguments
 if (($#)); then

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -52,8 +52,9 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='d:r:C:D:M:'
 opt_long=('no-build' 'no-prepare')
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -68,6 +69,9 @@ while true; do
         -M) shift; makepkg_conf=$1 ;;
         --no-build) build=0 ;;
         --no-prepare) prepare=0 ;;
+        --dump-options) printf -- '--%s\n' ${opt_long[@]} ;
+                        printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                        exit ;;
         --) shift; break ;;
     esac
     shift

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -30,8 +30,9 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='L:rgth'
 opt_long=('log-dir:' 'recurse' 'git' 'tar' 'help')
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -44,6 +45,9 @@ while true; do
         -g|--git)     mode=git ;;
         -t|--tar)     mode=snapshot ;;
         -h|--help)    usage ;;
+        --dump-options) printf -- '--%s\n' ${opt_long[@]} ;
+                        printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                        exit ;;
         --) shift; break ;;
     esac
     shift

--- a/lib/aur-fetch-git
+++ b/lib/aur-fetch-git
@@ -40,8 +40,9 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='L:h'
 opt_long=('log-dir:' 'help')
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -50,6 +51,9 @@ while true; do
     case "$1" in
         -L|--log-dir) shift; log_dir=$1; log=directory ;;
         -h|--help) usage ;;
+        --dump-options) printf -- '--%s\n' ${opt_long[@]} ;
+                        printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                        exit ;;
         --) shift; break ;;
     esac
     shift

--- a/lib/aur-fetch-snapshot
+++ b/lib/aur-fetch-snapshot
@@ -31,8 +31,9 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='L:h'
 opt_long=('log-dir:' 'help')
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -41,6 +42,9 @@ while true; do
     case "$1" in
         -L|--log-dir) shift; log_dir=$1; log=directory ;;
         -h|--help) usage ;;
+        --dump-options) printf -- '--%s\n' ${opt_long[@]} ;
+                        printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                        exit ;;
         --) shift; break ;;
     esac
     shift

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -44,8 +44,9 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='F:P:bth'
 opt_long=('pkgbase' 'fixed-strings' 'perl-regexp' 'help')
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -57,6 +58,9 @@ while true; do
         -F|--fixed-strings) shift; pcre_opt=('-e' "$1" '-F') ;;
         -P|--perl-regexp) shift; pcre_opt=('-e' "$1") ;;
         -h|--help) usage ;;
+        --dump-options) printf -- '--%s\n' ${opt_long[@]} ;
+                        printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                        exit ;;
         --) shift; break ;;
     esac
     shift

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -58,8 +58,9 @@ fi
 opt_short='d:o:r:ahlSu'
 opt_long=('all' 'database:' 'list' 'root:' 'pacman' 'upgrades'
           'repo-list' 'status-file:' 'help')
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -75,6 +76,9 @@ while true; do
         -S|--pacman)   mode=list_pacman ;;
         -u|--upgrades) mode=list_upgrades ;;
         --repo-list)   mode=repo_list ;;
+        --dump-options) printf -- '--%s\n' ${opt_long[@]} ;
+                        printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                        exit ;;
         -h|--help) usage ;;
         --) shift; break ;;
     esac

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -25,8 +25,9 @@ fi
 
 opt_short='ad:h'
 opt_long=('all' 'database:' 'help')
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -37,6 +38,9 @@ while true; do
         -a|--all) sync_repo=1 ;;
         -d|--database) shift; argv_repo+=("$1") ;;
         -h|--help) usage ;;
+        --dump-options) printf -- '--%s\n' ${opt_long[@]} ;
+                        printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                        exit ;;
         --) shift; break;;
     esac
     shift

--- a/lib/aur-rpc
+++ b/lib/aur-rpc
@@ -38,8 +38,9 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='b:t:h'
 opt_long=('by:' 'type:' 'help')
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -50,6 +51,9 @@ while true; do
         -b|--by)   shift; by=$1 ;;
         -t|--type) shift; type=$1 ;;
         -h|--help) usage ;;
+        --dump-options) printf -- '--%s\n' ${opt_long[@]} ;
+                        printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                        exit ;;
         --) shift; break ;;
     esac
     shift

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -113,8 +113,9 @@ fi
 opt_short='k:aisdmnqvh'
 opt_long=('any' 'info' 'search' 'desc' 'maintainer' 'name' 'depends'
           'makedepends' 'optdepends' 'checkdepends' 'key:' 'help')
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -135,8 +136,11 @@ while true; do
         -q|--short)      format=short ;;
         -v|--verbose)    format=long ;;
         -k|--key)        shift; sort_key=$1 ;;
-	-h|--help) usage ;;
-        --) shift; break ;;
+        -h|--help)       usage ;;
+        --dump-options)  printf -- '--%s\n' ${opt_long[@]} ;
+                         printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                         exit ;;
+        --)              shift; break ;;
     esac
     shift
 done

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -88,8 +88,9 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:'
           'no-ver-shallow' 'no-view' 'noview' 'print' 'provides'
           'rm-deps' 'keep' 'sign' 'temp' 'tar' 'upgrades' 'git'
           'rebuild' 'rebuildtree' 'rebuild-tree' 'help')
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -128,6 +129,9 @@ while true; do
         --rebuild)            build_args+=(-f); chkver_depth=1 ;;
         --rebuild?(-)tree)    build_args+=(-f); chkver_depth=0 ;;
         -h|--help) usage ;;
+        --dump-options)       printf -- '--%s\n' ${opt_long[@]} ;
+                              printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                              exit ;;
         --) shift; break ;;
     esac
     shift

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -81,8 +81,9 @@ fi
 
 opt_short='d:p:u:ach'
 opt_long=()
+opt_hidden=('dump-options')
 
-if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
@@ -95,6 +96,9 @@ while true; do
         -p) target='file'
             shift; aux=$1 ;;
         -u) shift; upair=$1 ;;
+        --dump-options) printf -- '--%s\n' ${opt_long[@]} ;
+                        printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
+                        exit ;;
         --) shift; break ;;
     esac
     shift


### PR DESCRIPTION
This is still in a very early state. Just opening the PR in order to get some feedback and/or help. 😊 
~~The main idea here is to get autocompletion from the output of `-h` pages. So as long as the help pages get updated, completions for short and long options come for free.~~

~~While this is convenient, in some cases we might want to define completions for other things, e.g repos for `-d` option etc. This will provide completions based of `-h` flags unless there's a function defining how the command should complete.~~ (moving away from parsing help text. see: https://github.com/AladW/aurutils/pull/311#issuecomment-401462680).

Stuff to consider
- [x] ~~Better and shorter help lines. Some need proper wrapping, some probably need to be rewritten. It's hard to be short without being _too_ short.~~ (moved away from parsing help text)
- [x] ~~Symlinks for standalone commands. Right now, standalone commands like `aur-build` only get completions after the completion for `aur` is called at least once. This can be fixed by adding symbolic links to the main completion. E.g. `aur-build -> aur` . (probably rename the completion file to _aurutils_ and do `'aur{,-*}' -> aurutils`~~
- [x] ~~Overrides for other scripts providing extra functionality. ( e.g. autocomplete repos for -d )~~ Override mechanism is there (call to `_aurutils_${words[1]}`) but no functions are implemented for now.
- [x] ~~Better code? This is my first autocompletion script. There is probably stuff done wrong all over.~~ 😁  Good enough. 
