### PR TITLE
Add aurbuild -R, -v

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -1,13 +1,19 @@
 #!/bin/bash
+# aur-build - build packages to a local repository
+set -o errexit
 readonly argv0=build
 readonly startdir=$PWD
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-set -o errexit
 
-declare -a gpg_args=(--detach-sign --no-armor --batch)
-declare -a makepkg_args=(-rs --noconfirm) makechrootpkg_args=(-cu)
-declare -a chroot_args=() repo_add_args=()
-declare -i chroot=0 no_sync=0 overwrite=0 sign_pkg=0
+gpg_args=(--detach-sign --no-armor --batch)
+makechrootpkg_args=(-cu)
+makepkg_args=(-rs --noconfirm)
+chroot_args=()
+chroot=0
+no_sync=0
+overwrite=0
+repo_add_args=()
+sign_pkg=0
 
 conf_single() {
     printf '[options]\n'
@@ -16,32 +22,27 @@ conf_single() {
     printf '[%s]\n' "$1"
     pacconf --repo="$1" --raw
 }
-readonly -f conf_single
 
 db_replaces() {
     bsdcat "$1" | awk '/%REPLACES%/ {
         while(NF != 0) {getline; print}
     }'
 }
-readonly -f db_replaces
 
 find_pkg_dupes() {
     xargs -I{} find "$1" -name '{}*' | grep -Exv '.+(~|_namcap\.log|\.part|\.sig)$' -
 }
-readonly -f find_pkg_dupes
 
 trap_exit() {
     if ! [[ -o xtrace ]]; then
         rm -rf "$tmp" "$var_tmp"
     fi
 }
-readonly -f trap_exit
 
 usage() {
     plain "usage: $argv0 -d database [-afNrs] [--] <makepkg args>"
     exit 1
 }
-readonly -f usage
 
 source /usr/share/makepkg/util/util.sh
 source /usr/share/makepkg/util/message.sh
@@ -85,8 +86,6 @@ if ! [[ -r $db_path && -w $db_path ]]; then
     exit 13
 fi
 
-readonly chroot database server db_root db_path queue overwrite no_sync sign_pkg
-
 if [[ -v queue ]]; then
     exec {fd}< "$queue"
 else
@@ -125,12 +124,10 @@ fi
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/$argv0".XXXXXXXX)
 var_tmp=$(mktemp -d "${TMPDIR:-/var/tmp}/$argv0".XXXXXXXX)
 
-readonly chroot_args makepkg_args repo_add_args gpg_args tmp var_tmp
 trap 'trap_exit' EXIT
 trap 'exit' INT
 
 if ((chroot)); then
-    # XXX Move sudo call to /bin/aur to allow easy sudo whitelisting?
     sudo aur build-nspawn -d "$database" -u "${chroot_args[@]}"
 else
     conf_single "$database" >"$tmp"/custom.conf

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -10,10 +10,8 @@ gpg_args=(--detach-sign --no-armor --batch)
 makechrootpkg_args=(-cu)
 makepkg_args=(-rs --noconfirm)
 repo_add_args=()
-chroot=0
-no_sync=0
-overwrite=0
-sign_pkg=0
+
+chroot=0 no_sync=0 overwrite=0 sign_pkg=0
 
 conf_single() {
     printf '[options]\n'

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -5,14 +5,14 @@ readonly argv0=build
 readonly startdir=$PWD
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
+chroot_args=()
 gpg_args=(--detach-sign --no-armor --batch)
 makechrootpkg_args=(-cu)
 makepkg_args=(-rs --noconfirm)
-chroot_args=()
+repo_add_args=()
 chroot=0
 no_sync=0
 overwrite=0
-repo_add_args=()
 sign_pkg=0
 
 conf_single() {
@@ -40,7 +40,7 @@ trap_exit() {
 }
 
 usage() {
-    plain "usage: $argv0 -d database [-afNrs] [--] <makepkg args>"
+    plain "usage: $argv0 -d database [-afNRsv] [--] <makepkg args>"
     exit 1
 }
 
@@ -52,7 +52,7 @@ if [[ -t 2 && ! -o xtrace ]]; then
 fi
 
 unset database db_root queue
-while getopts a:d:r:C:D:M:cfNs opt; do
+while getopts a:d:r:C:D:M:cfNRsv opt; do
     case $opt in
         a) queue=$OPTARG    ;;
         c) chroot=1         ;;
@@ -60,10 +60,13 @@ while getopts a:d:r:C:D:M:cfNs opt; do
         f) overwrite=1      ;;
         N) no_sync=1        ;;
         r) db_root=$OPTARG  ;;
-        s) sign_pkg=1       ;;
         C) chroot_args+=(-C "$OPTARG") ;;
         D) chroot_args+=(-D "$OPTARG") ;;
         M) chroot_args+=(-M "$OPTARG") ;;
+        R) repo_add_args+=(-R) ;;
+        s) repo_add_args+=(-s)
+           sign_pkg=1          ;;
+        v) repo_add_args+=(-v) ;;
         *) usage ;;
     esac
 done
@@ -92,6 +95,7 @@ else
     exec {fd}< <(printf '\n')
 fi
 
+# reset default makechrootpkg arguments
 if (($#)); then
     if ((chroot)); then
         makechrootpkg_args=("$@")
@@ -100,23 +104,19 @@ if (($#)); then
     fi
 fi
 
-if command -v xdelta3 >/dev/null; then
+if type -P xdelta3 >/dev/null; then
     repo_add_args+=(-d)
+fi
+
+if ((sign_pkg)) && [[ -v GPGKEY ]]; then
+    gpg --list-keys "$GPGKEY"
+    gpg_args+=(-u "$GPGKEY")
 fi
 
 mapfile -t db_sigs < <(find "$db_root" -maxdepth 1 -name "$database*.sig" -type f)
 
-if ((sign_pkg)); then
-    repo_add_args+=(-v -s)
-
-    if [[ -v GPGKEY ]]; then
-        gpg --list-keys "$GPGKEY"
-        gpg_args+=(-u "$GPGKEY")
-    fi
-
-elif [[ ${db_sigs[*]} ]]; then
+if ((!sign_pkg)) && [[ ${db_sigs[*]} ]]; then
     error "$argv0: signature found, but signing is disabled"
-
     printf -- '%q\n' "${db_sigs[@]}" >&2
     exit 1
 fi

--- a/lib/aur-build-nspawn
+++ b/lib/aur-build-nspawn
@@ -1,14 +1,15 @@
 #!/bin/bash
+# aur-build-nspawn - build packages using systemd-nspawn
+set -o errexit
 readonly argv0=build-nspawn
 readonly PATH=/bin:/usr/bin
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-set -o errexit
 
 machine=$(uname -m)
 directory=/var/lib/aurbuild/$machine
+makechrootpkg_args=(-cu)
 makepkg_conf=/usr/share/devtools/makepkg-$machine.conf
 pacman_conf=/usr/share/devtools/pacman-extra.conf
-makechrootpkg_args=(-cu)
 mode=build
 
 conf_devtools() {
@@ -18,7 +19,6 @@ conf_devtools() {
     # https://git.archlinux.org/devtools.git/tree/mkarchroot.in#n54
     printf '#CacheDir=\n'
 }
-readonly -f conf_devtools
 
 conf_repo() {
     while IFS= read -r; do
@@ -26,20 +26,17 @@ conf_repo() {
         pacconf --repo="$REPLY" --raw
     done
 }
-readonly -f conf_repo
 
 trap_exit() {
     if ! [[ -o xtrace ]]; then
         rm -rf "$tmp"
     fi
 }
-readonly -f trap_exit
 
 usage() {
     printf >&2 -- 'usage: %s [-CDMu] [-d db] -- <args>' "$argv0" >&2
     exit 1
 }
-readonly -f usage
 
 unset database
 while getopts :C:D:M:d:u opt; do
@@ -64,6 +61,7 @@ readonly pacman_conf makepkg_conf directory database prepare
 trap 'trap_exit' EXIT
 tmp=$(mktemp -d)
 
+# XXX Duplication between "update" mode and makechrootpkg -u
 case $mode in
     update)
         { conf_devtools "$pacman_conf"
@@ -73,7 +71,7 @@ case $mode in
         if [[ -f $directory/root/.arch-chroot ]]; then
             # locking is done by systemd-nspawn
             arch-nspawn -C "$tmp"/pacman.conf -M "$makepkg_conf" \
-                        "$directory"/root pacman -Syu --noconfirm   
+                        "$directory"/root pacman -Syu --noconfirm
         else
             install -d "$directory" -m 755 -v || exit
             mkarchroot  -C "$tmp"/pacman.conf -M "$makepkg_conf" \

--- a/lib/aur-deps
+++ b/lib/aur-deps
@@ -1,28 +1,31 @@
 #!/bin/bash
+# aur-deps - order package dependencies
 readonly argv0=deps
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-declare mode=rpc
+mode=json
 
 find_srcinfo() {
     find "$@" -maxdepth 1 -type f -name .SRCINFO -print0
 }
-readonly -f find_srcinfo
 
 usage() {
     printf -- 'usage: %s [-sr] package [package...]\n' "$argv0" >&2
     exit 1
 }
-readonly -f usage
 
 while getopts :jp opt; do
     case $opt in
-        p) mode=src ;;
-        j) mode=rpc ;;
-        *) usage    ;;
+        p) mode=src  ;;
+        j) mode=json ;;
+        *) usage     ;;
     esac
 done
 shift $((OPTIND -1))
 OPTIND=1
+
+if ((!$#)); then
+    usage
+fi
 
 case $mode in
     src)
@@ -34,9 +37,7 @@ case $mode in
 
         find_srcinfo "${arg_path[@]}" | aur deps-src | grep -Fxf <(basename -a "$@")
         ;;
-    rpc)
+    json)
         printf -- '%s\n' "$@" | aur deps-rpc
         ;;
 esac
-
-

--- a/lib/aur-deps-rpc
+++ b/lib/aur-deps-rpc
@@ -1,21 +1,13 @@
 #!/bin/bash
+# aur-deps-rpc - order package dependencies using AurJson
+set -o noclobber
 readonly argv0=deps-rpc
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-set -o noclobber
-
-declare mode=aur
+mode=aur
 
 count() {
-    declare -i num
-
-    if num=$(jq -r '.resultcount' "$1" | awk '{s += $1} END {print s}'); then
-        printf '%d' "$num"
-    else
-        printf '%s: invalid argument\n' "$argv0" >&2
-        exit 22
-    fi
+    jq -r '.resultcount' "$1" | awk '{s += $1} END {print s}'
 }
-readonly -f count
 
 sort_by() {
     awk 'FNR == NR {
@@ -25,12 +17,10 @@ sort_by() {
             print a[$0]
     }' "$@"
 }
-readonly -f sort_by
 
 tr_ver() {
     sed -r 's/[<>=].*$//g'
 }
-readonly -f tr_ver
 
 tabulate() {
     jq -r '.results[]
@@ -41,21 +31,20 @@ tabulate() {
         | ([$name] + .Depends + .MakeDepends + .CheckDepends)[]?
         | [$name, ., $base, $ver, $url] | @tsv' "$1"
 }
-readonly -f tabulate
 
 chain() {
-    declare -i num
+    local num sub
 
     aur rpc -t info > json/0 || exit
     num=$(count json/0)
 
-    if [[ $num -lt 1 ]]; then
+    if ((num < 1)); then
         printf '%s: no packages found\n' "$argv0" >&2
         exit 1
     fi
 
     for ((a = 1; a <= 30; ++a)); do
-        declare -i sub=$((a-1))
+        sub=$((a-1))
 
         tabulate json/$sub | tee -a tsv/n > tsv/$sub
 
@@ -88,22 +77,19 @@ chain() {
         exit 22
     fi
  
-    cut -f2 --complement tsv/n | sort -uk1,1 > pkginfo
+    cut -f2 --complement tsv/n | sort -uk 1,1 > pkginfo
 }
-readonly -f chain
 
 trap_exit() {
     if [[ ! -o xtrace ]]; then
         rm -rf "$tmp"
     fi
 }
-readonly -f trap_exit
 
 usage() {
     printf 'usage: %s [-at] pkgname...\n' "$argv0" >&2
     exit 1
 }
-readonly -f usage
 
 while getopts :at opt; do
     case $opt in
@@ -121,12 +107,12 @@ trap 'trap_exit' EXIT
 if cd "$tmp" && mkdir json tsv; then
     chain > order
 else
-    exit
+    exit "$?"
 fi
 
 case $mode in
     aur) grep -Fxf pkgname order | tac ;;
-    all) tac order ;;
+    all) tac order                     ;;
     tab) tac order | sort_by pkginfo - ;;
 esac
 

--- a/lib/aur-deps-src
+++ b/lib/aur-deps-src
@@ -1,7 +1,8 @@
 #!/bin/bash
+# aur-deps-src - order package dependencies using .SRCINFO
+set -o pipefail
 readonly argv0=deps-src
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-set -o pipefail
 
 deps_paired() {
     awk -v FS='[<=>]' '
@@ -17,7 +18,6 @@ deps_paired() {
             read = 0 # split package
     }' "$@"
 }
-readonly -f deps_paired
 
 # XXX Output of form " pkgname pkgbase" (leading space)
 base() {
@@ -29,7 +29,6 @@ base() {
         printf("%s %s\n", $2, pb)
     }' "$@"
 }
-readonly -f base
 
 sub() {
     awk 'NR == FNR {
@@ -40,19 +39,18 @@ sub() {
         }
     }' "$@"
 }
-readonly -f sub
 
 trap_exit() {
     if [[ ! -o xtrace ]]; then
         rm -rf "$tmp"
     fi
 }
-readonly -f trap_exit
 
 tmp=$(mktemp -t "$argv0".XXXXXXXX) || exit
 trap 'trap_exit' EXIT
 
-xargs -0 cat >"$tmp"
+# take file names from stdin, null-separated
+xargs -0 cat > "$tmp"
 
 if [[ -s "$tmp" ]]; then
     deps_paired "$tmp" | tsort | sub <(base "$tmp") -

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -1,21 +1,20 @@
 #!/bin/bash
-# For default values, see:
-# https://git.archlinux.org/aurweb.git/tree/conf/config.proto
+# aur-fetch - retrieve build files from the AUR
 readonly argv0=fetch
 readonly aur_location='https://aur.archlinux.org'
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-declare mode=git
-declare log_dir=/dev/null
+
+log_dir=/dev/null
+mode=git
 
 fmt_snapshot() {
+    # https://git.archlinux.org/aurweb.git/tree/conf/config.proto
     printf -- "$aur_location/cgit/aur.git/snapshot/%s.tar.gz\\n" "$@"
 }
-readonly -f fmt_snapshot
 
 fmt_git_clone() {
     printf -- "$aur_location/%s.git\\n" "$@"
 }
-readonly -f fmt_git_clone
 
 usage() {
     base64 -d <<EOF
@@ -25,7 +24,6 @@ EOF
     printf -- 'usage: %s [-gt] [-L log_dir] pkgname [pkgname...]\n' "$argv0" >&2
     exit 1
 }
-readonly -f usage
 
 # XXX add recursive mode (aur-deps-rpc)
 while getopts :gtL: opt; do

--- a/lib/aur-fetch-git
+++ b/lib/aur-fetch-git
@@ -1,8 +1,10 @@
 #!/bin/bash
+# aur-fetch-git - retrieve build files using git
+set -o errexit
 readonly argv0=fetch-git
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-set -o errexit
-declare log_dir=/dev/null
+
+log_dir=/dev/null
 
 merge_upstream() {
     git fetch -v
@@ -16,18 +18,16 @@ merge_upstream() {
         git merge
     fi
 }
-readonly -f merge_upstream
 
 usage() {
     printf -- 'usage: %s [-L log_dir]\n' "$argv0" >&2
     exit 1
 }
-readonly -f usage
 
 while getopts :L: opt; do
     case $opt in
         L) log_dir=$OPTARG ;;
-        *) usage       ;;
+        *) usage ;;
     esac
 done
 shift $((OPTIND - 1))
@@ -38,7 +38,7 @@ while IFS= read -r uri; do
     pkg=${pkg%%.git} # strip .git suffix
 
     if [[ -d $pkg/.git ]]; then
-        # Avoid issues with exotic file system layouts (#274)
+        # Avoid issues file system boundaries (#274)
         GIT_DIR="$pkg/.git" GIT_WORK_TREE="$pkg" merge_upstream "$pkg"
     else
         git clone "$uri"

--- a/lib/aur-fetch-snapshot
+++ b/lib/aur-fetch-snapshot
@@ -1,9 +1,13 @@
 #!/bin/bash
+# aur-fetch-snapshot - retrieve build files using tar archives
+set -o errexit
+shopt -s nullglob
 readonly argv0=fetch-snapshot
 readonly startdir=$PWD
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-set   -o errexit
-shopt -s nullglob
+
+# XXX default to outputting logs to /dev/stdout
+logdir=/dev/null
 
 dl_stdin() {
     if type -P aria2c >/dev/null; then
@@ -12,7 +16,6 @@ dl_stdin() {
         wget -i -
     fi
 }
-readonly -f dl_stdin
 
 tar_no_mode_diff() {
     if [[ -d $2/${1%%.tar*} ]]; then
@@ -22,7 +25,6 @@ tar_no_mode_diff() {
         return 1
     fi
 }
-readonly -f tar_no_mode_diff
 
 usage() {
     printf -- 'usage: %s [-L logdir]\n' "$argv0" >&2
@@ -34,9 +36,7 @@ trap_exit() {
         rm -rf "$tmp"
     fi
 }
-readonly -f trap_exit
 
-logdir=/dev/null
 while getopts :L: opt; do
     case $opt in
         L) logdir=$OPTARG ;;

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -1,19 +1,19 @@
 #!/bin/bash
+# aur-pkglist - print the AUR package list
+set -o pipefail
 readonly argv0=pkglist
 readonly aurweb='https://aur.archlinux.org'
 readonly cache=${XDG_CACHE_HOME:-$HOME/.cache}/aurutils/$argv0
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-set -o pipefail
 
-declare -i delay=300
-declare -i update=0
-declare    pkglist=packages
+delay=300
+pkglist=packages
+update=0
 
 extract_date() {
     sed -n '1p' "$1" | awk -F', ' '{print $3}'
     sed -i '1d' "$1"
 }
-readonly -f extract_date
 
 list_update() {
     if wget -O - -o last_transfer "$1" | gzip -d - > "$2"; then
@@ -22,7 +22,6 @@ list_update() {
         printf >&2 'warning: failed to retrieve package list\n'
     fi
 }
-readonly -f list_update
 
 list_http_date() {
     if wget -S --spider -o last_transfer "$1"; then
@@ -31,13 +30,11 @@ list_http_date() {
         printf >&2 'warning: failed to retrieve HTTP date\n'
     fi
 }
-readonly -f list_http_date
 
 usage() {
     printf >&2 'usage: %s: [-bt] [-FP pattern]\n' "$argv0"
     exit 1
 }
-readonly -f usage
 
 # default to any match
 pcre_opt=('.*')
@@ -70,7 +67,7 @@ else
 fi
 
 if ((update)); then
-    list_update "$aurweb/$pkglist.gz" "$pkglist" >timestamp
+    list_update "$aurweb/$pkglist.gz" "$pkglist" > timestamp
 fi
 
 pcregrep "${pcre_opt[@]}" < "$pkglist"

--- a/lib/aur-rfilter
+++ b/lib/aur-rfilter
@@ -1,4 +1,5 @@
 #!/bin/bash
+# aur-rfilter - filter repository packages
 readonly argv0=rfilter
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 readonly arch_repo=(core extra testing community{,-testing} multilib{,-testing})

--- a/lib/aur-rpc
+++ b/lib/aur-rpc
@@ -1,6 +1,5 @@
 #!/bin/bash
-# aur-rpc - send GET requests to aurweb
-# https://bugs.archlinux.org/task/49089
+# aur-rpc - interface with AurJson
 readonly argv0=rpc
 readonly aur_location='https://aur.archlinux.org'
 readonly PS4='+(${BASH_SOURCE}:${LINENO}):${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
@@ -17,21 +16,18 @@ info() {
         printf "\n"
     }'
 }
-readonly -f info
 
 search() {
     awk -v rpc="$aur_location/rpc/?v=5&type=search&by=$1&arg" '{
         printf "%s=%s\n", rpc, $0
     }'
 }
-readonly -f search
 
 cat_ifne() {
-    if [[ -n $* && -e $1 ]]; then
+    if [[ -n $* ]] && [[ -e $1 ]]; then
         cat -- "$@"
     fi
 }
-readonly -f cat_ifne
 
 dl_stdin() {
     if type -P aria2c >/dev/null; then
@@ -46,20 +42,17 @@ dl_stdin() {
         wget --quiet -i - -O -
     fi
 }
-readonly -f dl_stdin
 
 trap_exit() {
     if ! [[ -o xtrace ]]; then
         rm -rf "$tmp"
     fi
 }
-readonly -f trap_exit
 
 usage() {
-    printf >&2 'usage: %s [-t type] [-b by] package [package...]\n' "$argv0"
+    printf >&2 'usage: %s [-t info] [-t search] [-b by]\n' "$argv0"
     exit 1
 }
-readonly -f usage
 
 unset by type
 while getopts :b:t: opt; do
@@ -75,12 +68,14 @@ OPTIND=1
 tmp=$(mktemp -dt "$argv0".XXXXXXXX) || exit
 trap 'trap_exit' EXIT
 
+# set filters
 case $type in
       info) query() { info; }                      ;;
     search) query() { search "${by:-name-desc}"; } ;;
-         *) usage ;;
+         *) usage                                  ;;
 esac
 
+# pipeline
 jq -R -r '@uri' | query | dl_stdin
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -1,14 +1,17 @@
 #!/bin/bash
+# aur-search - search for AUR packages
+set -o pipefail
 readonly argv0=search
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-set -o pipefail
 
-declare by=name-desc
-declare format=brief
-declare sort_key=Name
-declare type=search
+format=brief
+sort_key=Name
+search_by=name-desc
+search_type=search
 
 json_short() {
+    local Name Version NumVotes Description
+
     jq -r --arg key "$1" '[.results[]] | sort_by(.[$key])[] | .Name,
         .Version,
         .NumVotes,
@@ -23,9 +26,11 @@ json_short() {
                "$Name" "$Version" "$NumVotes" "$Description"
     done
 }
-readonly -f json_short
 
 json_long() {
+    local Name PackageBase Version Description URL NumVotes Popularity
+    local OutOfDate Maintainer FirstSubmitted LastModified
+
     jq -r --arg key "$1" '[.results[]] | sort_by(.[$key])[] | .Name,
         .PackageBase,
         .Version,
@@ -64,13 +69,11 @@ json_long() {
         printf '\n'
     done
 }
-readonly -f json_long
 
 usage() {
     printf >&2 'usage: %s: [-imnrv] [-k key] package [package...]\n' "$argv0"
     exit 1
 }
-readonly -f usage
 
 source /usr/share/makepkg/util/message.sh || exit
 
@@ -80,13 +83,15 @@ fi
 
 while getopts :imnrvk: opt; do
     case $opt in
-        i) type=info                  ;;
-        m) type=search; by=maintainer ;;
-        n) type=search; by=name       ;;
-        k) sort_key=$OPTARG           ;;
-        r) format=json                ;;
-        v) format=verbose             ;;
-        *) usage                      ;;
+        i) search_type=info     ;;
+        m) search_type=search
+           search_by=maintainer ;;
+        n) search_type=search
+           search_by=name       ;;
+        k) sort_key=$OPTARG     ;;
+        r) format=json          ;;
+        v) format=verbose       ;;
+        *) usage                ;;
     esac
 done
 shift $((OPTIND - 1))
@@ -96,12 +101,14 @@ if ((!$#)); then
     usage
 fi
 
+# set filters
 case $format in
       brief) parse() { json_short "$sort_key"; } ;;
     verbose) parse() { json_long  "$sort_key"; } ;;
        json) parse() { tee; }                    ;;
 esac
 
-printf -- '%s\n' "$@" | aur rpc -t "$type" -b "$by" | parse
+# pipeline
+printf -- '%s\n' "$@" | aur rpc -t "$search_type" -b "$search_by" | parse
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -1,5 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2016
+# aur-srcver - update and print package revisions
 readonly argv0=srcver
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 readonly startdir=$PWD
@@ -17,24 +18,21 @@ get_pkgbuild_info() {
         printf %s\\t%s\\n "${pkgbase:-$pkgname}" "$fullver"
     '
 }
-readonly -f get_pkgbuild_info
 
 find_pkgbuild_path() {
     find "$@" -maxdepth 1 -type f -name PKGBUILD -printf '%h\n'
 }
-readonly -f find_pkgbuild_path
 
 usage() {
     printf 'usage: %s path [path...]\n' "$argv0" >&2
     exit 1
 }
-readonly -f usage
 
 if ((!$#)); then
     usage
 fi
 
-# trickery for hyphen and absolute path arguments
+# XXX trickery for hyphen and absolute path arguments
 mapfile -t arg_path < <(readlink -e -- "$@")
 
 makepkg_log=$(mktemp -t makepkg.XXXXXXXX) || exit

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -85,7 +85,7 @@ trap_exit() {
 }
 
 usage() {
-    plain "usage: $argv0 [-ABcCDflLMnprstTu] [long options] [--] pkgname..."
+    plain "usage: $argv0 [-ABcCDflLMprstTu] [long options] [--] pkgname..."
     exit 1
 }
 
@@ -126,7 +126,7 @@ while true; do
             aurbuild_args+=(-f)
             shift ;;
         -s|--sign)
-            aurbuild_args+=(-s)
+            aurbuild_args+=(-sv)
             shift ;;
         -C)
             aurbuild_args+=(-C "$2")
@@ -150,11 +150,11 @@ while true; do
         -L|--log)
             makepkg_args+=(-L)
             shift ;;
+        --noconfirm|--no-confirm)
+            makepkg_args+=(--noconfirm)
+            shift ;;
         -l|--list)
             list=1
-            shift ;;
-        -n|--noconfirm|--no-confirm)
-            makepkg_args+=(--noconfirm)
             shift ;;
         -r|--rmdeps|--rm-deps)
             makepkg_args+=(-r)

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -12,15 +12,9 @@ aurbuild_args=()
 makechrootpkg_args=(-cu)
 makechrootpkg_makepkg_args=()
 makepkg_args=(-cs)
-build=1
-chkver=1
-chroot=0
-download=1
-list=0
-rotate=0
-snapshot=0
-update=0
-view=1
+
+build=1 chkver=1 download=1 view=1
+chroot=0 list=0 rotate=0 snapshot=0 update=0
 
 viewer() {
     if hash 2>/dev/null vifm; then

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -1,16 +1,26 @@
 #!/bin/bash
+# aur-sync - download and build AUR packages automatically
+set -o errexit -o pipefail -o noclobber
+shopt -s nullglob
 readonly argv0=sync
 readonly XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 readonly AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
 readonly AURDEST_SNAPSHOT=${AURDEST_SNAPSHOT:-$XDG_CACHE_HOME/aurutils/snapshot}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-set   -o errexit -o pipefail -o noclobber
-shopt -s nullglob
 
-declare -a makepkg_args=(-cs) aurbuild_args=()
-declare -a makechrootpkg_args=(-cu) makechrootpkg_makepkg_args=()
-declare -i chroot=0 update=0 snapshot=0 rotate=0 list=0
-declare -i build=1 download=1 view=1 chkver=1
+aurbuild_args=()
+makechrootpkg_args=(-cu)
+makechrootpkg_makepkg_args=()
+makepkg_args=(-cs)
+build=1
+chkver=1
+chroot=0
+download=1
+list=0
+rotate=0
+snapshot=0
+update=0
+view=1
 
 viewer() {
     if hash 2>/dev/null vifm; then
@@ -19,7 +29,6 @@ viewer() {
         command -- "${PAGER:-less}"
     fi
 }
-readonly -f viewer
 
 lib32() {
     awk -v arch="$(uname -m)" '{
@@ -29,7 +38,6 @@ lib32() {
         }; print
     }'
 }
-readonly -f lib32
 
 conf_file_repo() {
     awk -F'= ' '
@@ -40,7 +48,6 @@ conf_file_repo() {
             printf("%s\n%s\n", repo, $2)
         }'
 }
-readonly -f conf_file_repo
 
 db_namever() {
     awk '/%NAME%/ {
@@ -52,7 +59,6 @@ db_namever() {
         printf("%s\n", $1)
     }'
 }
-readonly -f db_namever
 
 db_fill_empty() {
     awk '{print} END {
@@ -60,7 +66,6 @@ db_fill_empty() {
             printf("%s\t%s\n", "(none)", "(none)")
     }'
 }
-readonly -f db_fill_empty
 
 uniq_by() {
     awk -v "i=$1" -v "j=$2" '
@@ -72,20 +77,17 @@ uniq_by() {
             }
         }' "$3" "$4"
 }
-readonly -f uniq_by
 
 trap_exit() {
     if [[ ! -o xtrace ]]; then
         rm -rf "$tmp"
     fi
 }
-readonly -f trap_exit
 
 usage() {
     plain "usage: $argv0 [-ABcCDflLMnprstTu] [long options] [--] pkgname..."
     exit 1
 }
-readonly -f usage
 
 source /usr/share/makepkg/util/util.sh
 source /usr/share/makepkg/util/message.sh
@@ -110,7 +112,7 @@ else
     usage
 fi
 
-tmp=$(mktemp -dt "$argv0".XXXXXXXX); readonly tmp
+tmp=$(mktemp -dt "$argv0".XXXXXXXX)
 trap 'trap_exit' EXIT
 
 unset pkg pkg_i root repo

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -1,13 +1,16 @@
 #!/bin/bash
 # shellcheck disable=SC2209
+# aur-vercmp - check packages for AUR updates
+set -o pipefail
 readonly argv0=vercmp
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-set -o pipefail
 
-declare    format=all target=aur
-declare -i all=0
+format=all
+target=aur
 
 cmp_equal_or_newer() {
+    local pkg v_cmp v_in op
+
     while read -r pkg v_cmp v_in; do
         case $v_cmp in
             -) op=2 ;; # - on field 2
@@ -23,17 +26,18 @@ cmp_equal_or_newer() {
         esac
     done
 }
-readonly -f cmp_equal_or_newer
 
 cmp_checkupdates() {
+    local pkg v_cmp v_in op
+
     while read -r pkg v_cmp v_in; do
         case $v_in in
             -) op=2 ;; # - on field 3
             *) op=$(my_vercmp "$v_in" "$v_cmp") ;;
         esac
 
-        if ((!all)) && ((op > -1)); then
-            continue #global all
+        if ((!$1)) && ((op > -1)); then
+            continue
         fi
 
         case $op in
@@ -44,7 +48,6 @@ cmp_checkupdates() {
         esac
     done
 }
-readonly -f cmp_checkupdates
 
 my_vercmp() {
     if [[ $1 == "$2" ]]; then
@@ -53,12 +56,10 @@ my_vercmp() {
         vercmp "$1" "$2"
     fi
 }
-readonly -f my_vercmp
 
 parse_aur() {
     aur rpc -t info | jq -r '.results[] | [.Name, .Version] | @tsv'
 }
-readonly -f parse_aur
 
 parse_sync() {
     pacconf --repo="$1" >/dev/null || return
@@ -66,20 +67,17 @@ parse_sync() {
     pacsift --repo="$1" --exact <&- | xargs -r \
         pacman -Sddp --print-format '%n %v'
 }
-readonly -f parse_sync
 
 trap_exit() {
     if [[ ! -o xtrace ]]; then
         rm -rf "$tmp"
     fi
 }
-readonly -f trap_exit
 
 usage() {
     plain "usage: $argv0 [-d repo] [-p file] [-ac]"
     exit 1
 }
-readonly -f usage
 
 source /usr/share/makepkg/util/message.sh || exit
 
@@ -87,7 +85,7 @@ if [[ -t 2 && ! -o xtrace ]]; then
     colorize
 fi
 
-unset aux repo upair
+unset all aux repo upair
 while getopts :acd:p:u: opt; do
     case $opt in
         a) all=1         ;;
@@ -123,7 +121,7 @@ esac
 
 # set filters (2)
 case $format in
-      all) cmp() { cmp_checkupdates; }
+      all) cmp() { cmp_checkupdates "${all-0}"; }
            upair=${upair-1} ;; # join unpaired of target
     equal) cmp() { cmp_equal_or_newer; }
            upair=${upair-2} ;; # join unpaired of input

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Alad Wenter <https://github.com/AladW>
 pkgname=aurutils-git
-pkgver=1.5.3.r377.g270e4af
+pkgver=1.5.3.r421.g44baaac
 pkgrel=1
 pkgdesc='helper tools for the arch user repository'
 url='https://github.com/AladW/aurutils'
@@ -12,11 +12,12 @@ conflicts=('aurutils')
 provides=('aurutils')
 depends=('pacman>=5.0' 'git' 'jq' 'pacutils' 'wget')
 makedepends=('git')
-optdepends=('devtools: aur-build-nspawn'
+optdepends=('aria2: thread downloads'
+            'devtools: aur-build-nspawn'
             'diffstat: aur-fetch-snapshot'
             'expac: aur-rfilter'
-            'aria2: threaded downloads'
-            'vifm: build file interaction')
+            'vifm: build file interaction'
+            'xdelta3: generate delta files')
 
 pkgver() {
     cd aurutils

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -6,7 +6,7 @@ aur\-build \- build packages to a local repository
 .SY aur
 .B build
 .I \-d database
-.OP \-cfNs
+.OP \-cfNRsv
 .OP \-a queue
 .OP \-r root
 .OP \--
@@ -60,9 +60,21 @@ as the files database (\fIfoo.files\fR). This defaults to the
 \fIServer\fR value of the configured repository.
 .RE
 
+.B \-R
+.RS
+Remove old package files from disk when updating their entry in the
+database (\fIrepo-add -R\fR).
+.RE
+
 .B \-s
 .RS
-Sign built packages and the database with gpg.
+Sign built packages and the database (\fIrepo-add -s\fR) with gpg.
+.RE
+
+.B \-v
+.RS
+Verify the PGP signature of the database before updating. (\fIrepo-add
+-v\fR).
 .RE
 
 .SH NOTES

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -65,7 +65,7 @@ Print target packages and their paths instead of building them.
 
 .B \-s, --sign
 .RS
-Sign built packages and the database with gpg. (\fIaur-build -s\fR)
+Sign built packages and verify the database with gpg. (\fIaur-build -sv\fR)
 .RE
 
 .B \-t, --tar
@@ -79,12 +79,12 @@ repositories.
 Update all AUR packages in a local repository that are out-of-date.
 .RE
 
-.B \--no-ver
+.B \--nover, --no-ver
 .RS
 Disable version checking for packages in the queue.
 .RE
 
-.B \--no-view
+.B \--noview, --no-view
 .RS
 Do not view downloaded files before building.
 .RE
@@ -108,7 +108,7 @@ Skip downloading package files.
 .SS makepkg
 The default set of options is \fImakepkg -cs\fR.
 
-.B \-A, --ignore-arch
+.B \-A, --ignorearch, --ignore-arch
 .RS
 Ignore a missing or incomplete \fIarch\fR field in the build script.
 .RE
@@ -118,7 +118,7 @@ Ignore a missing or incomplete \fIarch\fR field in the build script.
 Enable logging to a text file in the build directory.
 .RE
 
-.B \-n, --no-confirm
+.B \--noconfirm, --no-confirm
 .RS
 Do not wait for user input. (\fImakepkg --noconfirm\fR)
 .RE


### PR DESCRIPTION
This branch removes some unused constructs in a vain attempt to improve readability. It also adds the following options to `aur-build`:

* `-R`, corresponds to `repo-add -R` (partially related to #305)
* `-v`, corresponds to `repo-add -v`. This was priorly part of `aur-build -s`.

The short option `-n` was also removed from `aur-sync`, as it might be confused with `repo-add -n`. The long `--noconfirm` option to `makepkg` and `pacman` was kept.