### PR TITLE
man formatting

### DIFF
--- a/man1/aur-build-nspawn.1
+++ b/man1/aur-build-nspawn.1
@@ -1,17 +1,16 @@
 .TH AUR-BUILD-NSPAWN 1 2018-02-01 AURUTILS
 .SH NAME
-aur-build-nspawn \- build packages to a local repository inside a chroot
+aur\-build\-nspawn \- build packages to a local repository inside a chroot
 
 .SH SYNOPSIS
-.SY aur
-.B build-nspawn
+.SY "aur build\-nspawn"
 .OP \-C pacman_conf
 .OP \-D directory
 .OP \-M makepkg_conf
 .OP \-d database
 .OP \-u
 .OP \--
-.OP "makechrootpkg args"
+[\fImakechrootpkg args\fR]
 .YS
 
 .SH DESCRIPTION
@@ -21,26 +20,26 @@ repository. See also \fBaur\-build\fR(1).
 .SH OPTIONS
 All arguments after \-\- are passed to \fBmakechrootpkg\fR.
 
-.B \-C
+.BI "\-C " pacman_conf
 .RS
 The \fIpacman.conf\fR file to be used in the container. Defaults to
 \fIpacman-extra.conf\fR from devtools.
 .RE
 
-.B \-D
+.BI "\-D " directory
 .RS
 The base directory for containers. This directory usually contains a
 \fB/root\fR subdirectory that serves as template for user containers
 (named after \fI$SUDO_USER\fR, or \fB/copy\fR if unset).
 .RE
 
-.B \-M
+.BI "\-M " makepkg_conf
 .RS
 The makepkg.conf file to be used in the container. Defaults to
 \fImakepkg\-<machine>.conf\fR from devtools.
 .RE
 
-.B \-d
+.BI "\-d " database
 .RS
 Check if the specified repository is configured in the /root container.
 Only effective for \fB-u\fR.

--- a/man1/aur-build-nspawn.1
+++ b/man1/aur-build-nspawn.1
@@ -16,10 +16,10 @@ aur-build-nspawn \- build packages to a local repository inside a chroot
 
 .SH DESCRIPTION
 Build packages in an nspawn container, adding the results to a local
-repository. See also \fIaur-build\fR(1).
+repository. See also \fBaur\-build\fR(1).
 
 .SH OPTIONS
-All arguments after -- are passed to \fImakechrootpkg\fR.
+All arguments after \-\- are passed to \fBmakechrootpkg\fR.
 
 .B \-C
 .RS
@@ -30,20 +30,20 @@ The \fIpacman.conf\fR file to be used in the container. Defaults to
 .B \-D
 .RS
 The base directory for containers. This directory usually contains a
-\fI/root\fR subdirectory that serves as template for user containers
-(named after \fI$SUDO_USER\fR, or \fI/copy\fR if unset).
+\fB/root\fR subdirectory that serves as template for user containers
+(named after \fI$SUDO_USER\fR, or \fB/copy\fR if unset).
 .RE
 
 .B \-M
 .RS
 The makepkg.conf file to be used in the container. Defaults to
-\fImakepkg-<machine>.conf\fR from devtools.
+\fImakepkg\-<machine>.conf\fR from devtools.
 .RE
 
 .B \-d
 .RS
 Check if the specified repository is configured in the /root container.
-Only effective for \fI-u\fR.
+Only effective for \fB-u\fR.
 .RE
 
 .B \-u
@@ -52,35 +52,35 @@ Update or create the /root copy of the container; do not build a package.
 .RE
 
 .SH ENVIRONMENT
-Packages are placed in the directory specified in \fIPKGDEST\fR. If not
+Packages are placed in the directory specified in \fBPKGDEST\fR. If not
 set, the current directory (\fI$PWD\fR) is used. See also
-\fImakepkg.conf\fR(5).
+\fBmakepkg.conf\fR(5).
 
 .SH NOTES
 .SS Building with \fBmakechrootpkg\fR
-Changes to the pacman database are \fBnot\fR propagated from the
+Changes to the pacman database are \fInot\fR propagated from the
 container to the local system. Packages must be installed and updated
-separately, typically through \fIpacman -Syu <package_name>\fR.
+separately, typically through \fBpacman \-Syu \fIpackage_name\fR.
 
 Package conflicts inside the container must be solved manually, as
-\fBmakechrootpkg\fR uses \fImakepkg --confirm -s\fR internally. For
-example, to replace \fBgcc\fR with \fBgcc-multilib\fR, run \fIarch-nspawn
-/var/lib/aurbuild/root pacman -S gcc-multilib\fR as root.
+\fBmakechrootpkg\fR uses \fBmakepkg \-\-confirm \-s\fR internally. For
+example, to replace \fIgcc\fR with \fIgcc-multilib\fR, run \fBarch\-nspawn
+/var/lib/aurbuild/root pacman \-S gcc\-multilib\fR as root.
 
 Signature verification requires that \fBgpg2\fR(1) configuration is
 stored in \fI~/.gnupg\fR. See Github issue #151 for details.
 
 .SS Building for a different architecture
 To build packages for a different architecture, prepend \fBsetarch
-<arch>\fR to the aurbuild command line. The target architecture must
-both be supported by the current system (run \fIsetarch --list\fR for an
+\fIarch\fR to the aurbuild command line. The target architecture must
+both be supported by the current system (run \fBsetarch \-\-list\fR for an
 approximation) and have a respective \fImakepkg.conf\fR file available
 in \fI/usr/share/devtools\fR (such as
-\fI/usr/share/devtools/makepkg-i686.conf\fR for \fIi686\fR).
+\fI/usr/share/devtools/makepkg\-i686.conf\fR for \fIi686\fR).
 
 .SH SEE ALSO
 .BR aur (1),
-.BR aur-build (1),
+.BR aur\-build (1),
 .BR pacconf (1),
 .BR pacman (1),
 .BR makepkg.conf (5),

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -3,9 +3,8 @@
 aur\-build \- build packages to a local repository
 
 .SH SYNOPSIS
-.SY aur
-.B build
-.I \-d database
+.SY "aur build"
+.BI "\-d " database
 .OP \-cfNRsv
 .OP \-a queue
 .OP \-r root
@@ -24,7 +23,7 @@ directory, and described in a text file which is taken as argument.
 All arguments after \-\- are passed to \fBmakepkg\fR, or
 \fBaur\-build\-nspawn\fR when \fB\-c\fR is specified.
 
-.B \-a
+.BI "\-a " queue
 .RS
 A text file with directories containing a PKGBUILD. If none is
 specified, the current directory is assumed.
@@ -35,7 +34,7 @@ specified, the current directory is assumed.
 Build packages with \fBaurbuild_chroot\fR(1).
 .RE
 
-.B \-d
+.BI "\-d " database
 .RS
 The name of the pacman database.
 .RE
@@ -52,7 +51,7 @@ Continue the build process if a package with the same name is found
 Do not sync the local repository after building.
 .RE
 
-.B \-r
+.BI "\-r " root
 .RS
 The root for the repository. The \fIroot\fR is the location for the
 pacman database (\fIfoo.db\fR), built packages, and secondary files such

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -21,8 +21,8 @@ It is assumed that build directories are located in the current
 directory, and described in a text file which is taken as argument.
 
 .SH OPTIONS
-All arguments after -- are passed to \fImakepkg\fR, or
-\fIaur-build-nspawn\fR when \fI-c\fR is specified.
+All arguments after \-\- are passed to \fBmakepkg\fR, or
+\fBaur\-build\-nspawn\fR when \fB\-c\fR is specified.
 
 .B \-a
 .RS
@@ -32,7 +32,7 @@ specified, the current directory is assumed.
 
 .B \-c
 .RS
-Build packages with \fIaurbuild_chroot(1)\fR.
+Build packages with \fBaurbuild_chroot\fR(1).
 .RE
 
 .B \-d
@@ -54,7 +54,7 @@ Do not sync the local repository after building.
 
 .B \-r
 .RS
-The root for the repository. The \fBroot\fR is the location for the
+The root for the repository. The \fIroot\fR is the location for the
 pacman database (\fIfoo.db\fR), built packages, and secondary files such
 as the files database (\fIfoo.files\fR). This defaults to the
 \fIServer\fR value of the configured repository.
@@ -63,24 +63,24 @@ as the files database (\fIfoo.files\fR). This defaults to the
 .B \-R
 .RS
 Remove old package files from disk when updating their entry in the
-database (\fIrepo-add -R\fR).
+database (\fBrepo\-add \-R\fR).
 .RE
 
 .B \-s
 .RS
-Sign built packages and the database (\fIrepo-add -s\fR) with gpg.
+Sign built packages and the database (\fBrepo\-add \-s\fR) with gpg.
 .RE
 
 .B \-v
 .RS
-Verify the PGP signature of the database before updating. (\fIrepo-add
--v\fR).
+Verify the PGP signature of the database before updating. (\fBrepo\-add
+\-v\fR).
 .RE
 
 .SH NOTES
-When building locally (outside a container), \fIpacman -Syu \fR is run
+When building locally (outside a container), \fBpacman \-Syu\fR is run
 while restricted to a local repository. This is comparable to
-\fImakepkg -i\fR, but without subsequent package installation (if a
+\fBmakepkg \-i\fR, but without subsequent package installation (if a
 package was installed before, it is updated to the latest available
 version). An interesting side-effect is that pacman considers packages
 inside the official repositories "local", and warns if they are newer
@@ -88,13 +88,13 @@ than any custom counterpart. Packages which define a \fIreplaces\fR
 field are ignored if the target package is installed on the local
 system.
 
-Databases are built with \fILANG=C\fR to avoid libalpm from skipping
+Databases are built with \fBLANG=C\fR to avoid libalpm from skipping
 entries if the locale is not set (FS#49342). Packages are signed
-manually with \fIgpg --verbose --detach-sign --no-armor\fR (FS#49946).
+manually with \fBgpg \-\-verbose \-\-detach\-sign \-\-no\-armor\fR (FS#49946).
 
 .SS Avoiding password prompts
 makepkg must be run as a regular user as of version 4.2, with
-privileged operations done via \fIsudo\fR. As such, \fIaurbuild\fR can
+privileged operations done via \fBsudo\fR. As such, \fBaurbuild\fR can
 not be run directly as root. To avoid password prompts,
 \fBsudoers\fR(5) can be used instead.
 
@@ -114,7 +114,7 @@ For precautions when using wildcards with \fBsudo\fR, see the
 
 .SH SEE ALSO
 .BR aur (1),
-.BR aur-build-nspawn (1),
+.BR aur\-build\-nspawn (1),
 .BR pacconf (1),
 .BR pacman (1),
 .BR makepkg.conf (5),

--- a/man1/aur-deps-rpc.1
+++ b/man1/aur-deps-rpc.1
@@ -29,7 +29,7 @@ Version information is ignored for dependencies. See \fIFS#54096\fR.
 
 .SH SEE ALSO
 .BR aur (1),
-.BR aur-rpc (1),
+.BR aur\-rpc (1),
 .BR jq (1),
 .BR tsort (1)
 

--- a/man1/aur-deps-rpc.1
+++ b/man1/aur-deps-rpc.1
@@ -1,10 +1,9 @@
 .TH AUR-DEPS-RPC 1 2018-02-01 AURUTILS
 .SH NAME
-aur-deps-rpc \- order dependencies using the aur rpc
+aur\-deps\-rpc \- order dependencies using the aur rpc
 
 .SH SYNOPSIS
-.SY aur
-.B deps-rpc
+.SY "aur deps\-rpc"
 .OP \-at
 .YS
 

--- a/man1/aur-deps-src.1
+++ b/man1/aur-deps-src.1
@@ -1,12 +1,10 @@
 .TH AUR-DEPS-SRC 1 2018-02-01 AURUTILS
 .SH NAME
-aur-deps-src \- order dependencies using .SRCINFO files
+aur\-deps\-src \- order dependencies using .SRCINFO files
 
 .SH SYNOPSIS
-.SY aur
-.B deps-src
-.OP pkgbase
-.OP pkgbase...
+.SY "aur deps\-src"
+[\fIpkgbase\fR...]
 .YS
 
 .SH DESCRIPTION

--- a/man1/aur-deps-src.1
+++ b/man1/aur-deps-src.1
@@ -10,11 +10,11 @@ aur-deps-src \- order dependencies using .SRCINFO files
 .YS
 
 .SH DESCRIPTION
-\fBaur-deps-src\fR takes the names of packages and orders the dependency chains
+\fBaur\-deps\-src\fR takes the names of packages and orders the dependency chains
 using tsort.
 
 It is assumed that source directories are already available, and that
-\fIaur-deps-src\fR is used in the same directory as those source directories.
+\fBaur\-deps\-src\fR is used in the same directory as those source directories.
 
 .SH SEE ALSO
 .BR aur (1),

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -11,12 +11,12 @@ aur-fetch \- fetches packages from a location
 .YS
 
 .SH DESCRIPTION
-\fBaur-fetch\fR accepts URIs to packages from stdin, and attempts to
+\fBaur\-fetch\fR accepts URIs to packages from stdin, and attempts to
 download them. It's capable of handling \fItar\fR archives and \fIgit\fR
 repositories.
 
 .SH OPTIONS
-.B \-L
+.BI "\-L " log_dir
 .RS
 The location of where to store the diffs of previously unpacked
 archives.
@@ -24,12 +24,12 @@ archives.
 
 .B \-t
 .RS
-Downloads the package as a \fItar\fR archive with \fIaur-fetch-snapshot\fR.
+Downloads the package as a \fItar\fR archive with \fBaur\-fetch\-snapshot\fR.
 .RE
 
 .B \-g
 .RS
-Downloads the package as a \fIgit\fR repository with \fIaur-fetch-git\fR.
+Downloads the package as a \fIgit\fR repository with \fBaur\-fetch\-git\fR.
 .RE
 
 .SH SEE ALSO

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -1,13 +1,12 @@
 .TH AUR-FETCH 1 2018-02-14 AURUTILS
 .SH NAME
-aur-fetch \- fetches packages from a location
+aur\-fetch \- fetches packages from a location
 
 .SH SYNOPSIS
-.SY aur
-.B fetch
-.OP -L log_dir
-.OP -t
-.OP -g
+.SY "aur fetch"
+.OP \-L log_dir
+.OP \-t
+.OP \-g
 .YS
 
 .SH DESCRIPTION

--- a/man1/aur-pkglist.1
+++ b/man1/aur-pkglist.1
@@ -1,10 +1,9 @@
 .TH AUR.PKGLIST 1 2018-01-31 AURUTILS
 .SH NAME
-aur-pkglist \- print the AUR packagelist
+aur\-pkglist \- print the AUR packagelist
 
 .SH SYNOPSIS
-.SY aur
-.B pkglist
+.SY "aur pkglist"
 .OP \-bt
 .OP \-FP pattern
 .YS
@@ -30,13 +29,13 @@ Defaults to \fB300\fR seconds.
 Retrieve \fIpkgbase.gz\fR instead of \fIpackages.gz\fR.
 .RE
 
-.B \-F
+.BI "\-F " pattern
 .RS
 Interpret the given pattern as a list of fixed strings, separated by
 newlines, any of which is to be matched.
 .RE
 
-.B \-P
+.BI "\-P " pattern
 .RS
 Interpret the given pattern as a Perl-compatible regular expression
 (PCRE).

--- a/man1/aur-pkglist.1
+++ b/man1/aur-pkglist.1
@@ -10,9 +10,9 @@ aur-pkglist \- print the AUR packagelist
 .YS
 
 .SH DESCRIPTION
-\fBaur-pkglist\fR prints the list of `pkgname`s that are available in the
+\fBaur\-pkglist\fR prints the list of \fIpkgname\fRs that are available in the
 AUR to standard output. Optionally a pattern can be specified that is
-matched with \fIpcregrep\fR.
+matched with \fBpcregrep\fR.
 
 This list is available at:
 .UR https://aur.archlinux.org/packages.gz
@@ -43,15 +43,15 @@ Interpret the given pattern as a Perl-compatible regular expression
 .RE
 
 .SH NOTES
-To avoid retrieving the package list on every query, \fIaur-pkglist\fR uses a
+To avoid retrieving the package list on every query, \fBaur\-pkglist\fR uses a
 caching logic which stores the list together with its timestamp in
-\fI$XDG_CACHE_HOME/aur-pkglist\fR. New lists are generated every 5 minutes,
-thus setting a lower interval with \fI-t\fR yields no benefit. 
+\fI$XDG_CACHE_HOME/aur\-pkglist\fR. New lists are generated every 5 minutes,
+thus setting a lower interval with \fB\-t\fR yields no benefit.
 
 See also:
 
 .UR https://lists.archlinux.org/pipermail/aur-dev/2016-May/004036.html
-[aur-dev] Making the package list more useful
+[aur\-dev] Making the package list more useful
 .UE
 
 .SH SEE ALSO

--- a/man1/aur-rfilter.1
+++ b/man1/aur-rfilter.1
@@ -9,15 +9,15 @@ aur-rfilter \- filter packages in the Arch Linux repositories
 .YS
 
 .SH DESCRIPTION
-\fBaur-rfilter\fR checks if \fIpkgname\fR (provided on stdin) is in the
-official Arch Linux repositories, and print it to stdout if
+\fBaur\-rfilter\fR checks if \fIpkgname\fR (provided on \fIstdin\fR) is
+in the official Arch Linux repositories, and print it to \fIstdout\fR if
 not. Virtual packages, when found, are solved and printed to stderr.
 
 .SH OPTIONS
 .B \-d
 .RS
 Check a given repository instead of those from Arch Linux. Multiple
-repositories can be specified by repeating \fI-d\fR.
+repositories can be specified by repeating \fB\-d\fR.
 .RE
 
 .SH SEE ALSO

--- a/man1/aur-rfilter.1
+++ b/man1/aur-rfilter.1
@@ -1,11 +1,10 @@
 .TH AUR-RFILTER 1 2017-10-04 AURUTILS
 .SH NAME
-aur-rfilter \- filter packages in the Arch Linux repositories
+aur\-rfilter \- filter packages in the Arch Linux repositories
 
 .SH SYNOPSIS
-.SY aur
-.B rfilter
-.OP -d database
+.SY "aur rfilter"
+.OP \-d database
 .YS
 
 .SH DESCRIPTION
@@ -14,7 +13,7 @@ in the official Arch Linux repositories, and print it to \fIstdout\fR if
 not. Virtual packages, when found, are solved and printed to stderr.
 
 .SH OPTIONS
-.B \-d
+.BI "\-d " database
 .RS
 Check a given repository instead of those from Arch Linux. Multiple
 repositories can be specified by repeating \fB\-d\fR.

--- a/man1/aur-rpc.1
+++ b/man1/aur-rpc.1
@@ -15,7 +15,7 @@ aur-rpc \- send GET requests to aurweb
 
 .SH NOTES
 As the AUR RPC is limited to GET requests, queries are split by 150
-arguments to avoid HTTP 414 errors (FS#49089).
+arguments to avoid HTTP 414 errors (\fIFS#49089\fR).
 
 .SH SEE ALSO
 .BR aria2c (1),

--- a/man1/aur-rpc.1
+++ b/man1/aur-rpc.1
@@ -1,10 +1,9 @@
 .TH AUR-RPC 1 2018-02-02 AURUTILS
 .SH NAME
-aur-rpc \- send GET requests to aurweb
+aur\-rpc \- send GET requests to aurweb
 
 .SH SYNOPSIS
-.SY aur
-.B rpc
+.SY "aur rpc"
 .OP \-t type
 .OP \-b by
 .YS

--- a/man1/aur-search.1
+++ b/man1/aur-search.1
@@ -12,7 +12,7 @@ aur-search \- search for AUR package
 .YS
 
 .SH DESCRIPTION
-\fBaur-search\fR searches the AUR by multiple strings of packages. The
+\fBaur\-search\fR searches the AUR by multiple strings of packages. The
 union of all results is returned. By default, searches are performed
 by name and description using the \fIsearchby\fR interface, and
 displayed in a brief format.
@@ -52,7 +52,7 @@ Possible choices are \fIName\fR, \fIVersion\fR, \fINumVotes\fR,
 
 .SH SEE ALSO
 .BR aur (1),
-.BR aur-rpc (1),
+.BR aur\-rpc (1),
 .BR jq (1)
 
 .SH AUTHORS

--- a/man1/aur-search.1
+++ b/man1/aur-search.1
@@ -1,14 +1,12 @@
 .TH AUR-SEARCH 1 2018-02-01 AURUTILS
 .SH NAME
-aur-search \- search for AUR package
+aur\-search \- search for AUR package
 
 .SH SYNOPSIS
-.SY aur
-.B search
+.SY "aur search"
 .OP \-imnv
 .OP \-k key
-.I package
-.OP package...
+.IR package ...
 .YS
 
 .SH DESCRIPTION
@@ -39,7 +37,7 @@ Search by maintainer.
 Search by package name.
 .RE
 
-.B \-k
+.BI "\-k " key
 .RS
 Sort results via a key, defaulting to \fIName\fR.
 

--- a/man1/aur-srcver.1
+++ b/man1/aur-srcver.1
@@ -1,12 +1,10 @@
 .TH AUR-SRCVER 1 2018-02-01 AURUTILS
 .SH NAME
-aur-srcver \- lists version of VCS packages
+aur\-srcver \- lists version of VCS packages
 
 .SH SYNOPSIS
-.SY aur
-.B srcver
-.OP pkgbase
-.OP pkgbase...
+.SY "aur srcver"
+.IR pkgbase ...
 .YS
 
 .SH DESCRIPTION

--- a/man1/aur-srcver.1
+++ b/man1/aur-srcver.1
@@ -10,12 +10,12 @@ aur-srcver \- lists version of VCS packages
 .YS
 
 .SH DESCRIPTION
-\fBaur-srcver\fR takes the names of packages and lists the current
-\fIpkgver\fR of VCS packages. This is achieved by running \fImakepkg
---skipinteg --noprepare -od\fR and parsing the output.
+\fBaur\-srcver\fR takes the names of packages and lists the current
+\fIpkgver\fR of VCS packages. This is achieved by running \fBmakepkg
+\-\-skipinteg \-\-noprepare \-od\fR and parsing the output.
 
 It is assumed that source directories are already available, and that
-\fIaur-srcver\fR is used in the same directory as those source directories.
+\fBaur\-srcver\fR is used in the same directory as those source directories.
 
 .SH SEE ALSO
 .BR makepkg (1),

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -16,7 +16,7 @@ aur-sync \- download and build aur packages automatically
 .YS
 
 .SH DESCRIPTION
-\fBaur-sync\fR downloads and builds packages automatically to a local
+\fBaur\-sync\fR downloads and builds packages automatically to a local
 repository. Package names serve as arguments.
 
 If \fIvifm\fR is installed, the downloaded files are shown using vifm
@@ -26,36 +26,36 @@ and can be edited. If not, the files are shown in \fIless\fR, or
 .SH OPTIONS
 .B \-c, --chroot
 .RS
-Build packages with makechrootpkg. (\fIaur-build -c\fR)
+Build packages with makechrootpkg. (\fBaur build \-c\fR)
 .RE
 
 .B \-C
 .RS
 Set the \fIpacman.conf\fR file to be used in the container.
-(\fIaur-build -C\fR)
+(\fBaur build \-C\fR)
 .RE
 
 .B \-D, --directory
 .RS
-Set the container path. (\fIaur-build -D\fR)
+Set the container path. (\fBaur build \-D\fR)
 .RE
 
 .B \-M
 .RS
 Set the \fImakepkg.conf\fR file to be used in the container.
-(\fIaur-build -M\fR)
+(\fBaur build \-M\fR)
 .RE
 
 .B \-f, --force
 .RS
 Continue the build process if a package with the same name already
-exists. (\fIaur-build -f\fR)
+exists. (\fBaur build \-f\fR)
 .RE
 
 .B \--ignore
 .RS
 Ignore a package upgrade. Multiple packages can be specified by
-separating them with a comma, or by repeating the \fI--ignore\fR option.
+separating them with a comma, or by repeating the \fB\-\-ignore\fR option.
 .RE
 
 .B \-p, --print
@@ -65,7 +65,7 @@ Print target packages and their paths instead of building them.
 
 .B \-s, --sign
 .RS
-Sign built packages and verify the database with gpg. (\fIaur-build -sv\fR)
+Sign built packages and verify the database with gpg. (\fBaur build \-sv\fR)
 .RE
 
 .B \-t, --tar
@@ -106,7 +106,7 @@ Skip downloading package files.
 .RE
 
 .SS makepkg
-The default set of options is \fImakepkg -cs\fR.
+The default set of options is \fBmakepkg \-cs\fR.
 
 .B \-A, --ignorearch, --ignore-arch
 .RS
@@ -120,16 +120,16 @@ Enable logging to a text file in the build directory.
 
 .B \--noconfirm, --no-confirm
 .RS
-Do not wait for user input. (\fImakepkg --noconfirm\fR)
+Do not wait for user input. (\fBmakepkg \-\-noconfirm\fR)
 .RE
 
 .B \-r, --rmdeps
 .RS
-Remove dependencies installed by makepkg. (\fImakepkg -r\fR)
+Remove dependencies installed by makepkg. (\fBmakepkg \-r\fR)
 .RE
 
 .SS makechrootpkg
-The default set of options is \fImakechrootpkg -cu\fR.
+The default set of options is \fBmakechrootpkg \-cu\fR.
 
 .B \-B, --bind
 .RS
@@ -152,7 +152,7 @@ Default: \fI$XDG_CACHE_HOME/aurutils/snapshot\fR
 .B AURDEST_SNAPSHOT
 .RS
 Determines where build files will be copied when using snapshots
-(\fIaur-sync -t\fR). This must be an absolute path.
+(\fBaur sync \-t\fR). This must be an absolute path.
 
 Default: \fI$XDG_CACHE_HOME/aurutils/sync\fR
 .RE
@@ -163,26 +163,26 @@ Parent directory for temporary files.
 .RE
 
 .SH NOTES
-When version checks are enabled (\fI--no-ver\fR is not specified),
+When version checks are enabled (\fB\-\-no\-ver\fR is not specified),
 build files are only retrieved if the remote (RPC) version is newer
 than a version in the pacman database. Checks assume there are no
-mismatches between \fI.SRCINFO\fR and \fIPKGBUILD\fR files.
+mismatches between \fB.SRCINFO\fR and \fBPKGBUILD\fR files.
 
 Architecture-specific depends (as introduced with pacman 4.2) are
-merged with regular depends in RPC queries. \fBaur-sync\fR workarounds
-this by stripping the \fIlib32-\fR suffix from packages and removing
-\fIgcc-multilib\fR if the i686 architecture is detected.
+merged with regular depends in RPC queries. \fBaur\-sync\fR works around
+this by stripping the \fIlib32\-\fR prefix from packages and removing
+\fIgcc\-multilib\fR if the i686 architecture is detected.
 
 \fItar\fR snapshots are extracted to the \fI$AURDEST_SNAPSHOT\fR
-directory, in order to avoid conflicts with \fIgit\fR.
+directory, in order to avoid conflicts with \fBgit\fR.
 
 .SH SEE ALSO
 .BR aur (1),
-.BR aur-build (1),
-.BR aur-fetch (1),
-.BR aur-rpc (1),
-.BR aur-deps-rpc (1),
-.BR aur-updates (1),
+.BR aur\-build (1),
+.BR aur\-fetch (1),
+.BR aur\-rpc (1),
+.BR aur\-deps\-rpc (1),
+.BR aur\-updates (1),
 .BR jq (1),
 .BR less (1),
 .BR pacconf (1),

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -1,18 +1,17 @@
 .TH AUR-SYNC 1 2018-02-01 AURUTILS
 .SH Name
-aur-sync \- download and build aur packages automatically
+aur\-sync \- download and build aur packages automatically
 
 .SH SYNOPSIS
-.SY aur
-.B sync
+.SY "aur sync"
 .OP \-AcDfLnprstu
-.OP \--ignore
-.OP \--no-ver
-.OP \--no-view
-.OP \--repo
-.OP \--root
-.OP \--
-.I pkgname...
+.OP \-\-ignore
+.OP \-\-no\-ver
+.OP \-\-no\-view
+.OP \-\-repo
+.OP \-\-root
+.OP \-\-
+.IR pkgname ...
 .YS
 
 .SH DESCRIPTION
@@ -24,7 +23,7 @@ and can be edited. If not, the files are shown in \fIless\fR, or
 \fI$PAGER\fR if configured.
 
 .SH OPTIONS
-.B \-c, --chroot
+.BR \-c ", " \-\-chroot
 .RS
 Build packages with makechrootpkg. (\fBaur build \-c\fR)
 .RE
@@ -35,7 +34,7 @@ Set the \fIpacman.conf\fR file to be used in the container.
 (\fBaur build \-C\fR)
 .RE
 
-.B \-D, --directory
+.BR \-D ", " \-\-directory
 .RS
 Set the container path. (\fBaur build \-D\fR)
 .RE
@@ -46,61 +45,61 @@ Set the \fImakepkg.conf\fR file to be used in the container.
 (\fBaur build \-M\fR)
 .RE
 
-.B \-f, --force
+.BR \-f ", " \-\-force
 .RS
 Continue the build process if a package with the same name already
 exists. (\fBaur build \-f\fR)
 .RE
 
-.B \--ignore
+.B \-\-ignore
 .RS
 Ignore a package upgrade. Multiple packages can be specified by
 separating them with a comma, or by repeating the \fB\-\-ignore\fR option.
 .RE
 
-.B \-p, --print
+.BR \-p ", " \-\-print
 .RS
 Print target packages and their paths instead of building them.
 .RE
 
-.B \-s, --sign
+.BR \-s ", " \-\-sign
 .RS
 Sign built packages and verify the database with gpg. (\fBaur build \-sv\fR)
 .RE
 
-.B \-t, --tar
+.BR \-t ", " \-\-tar
 .RS
 Download AUR snapshots (\fI.tar.gz\fR) instead of cloning git
 repositories.
 .RE
 
-.B \-u, --upgrades
+.BR \-u ", " \-\-upgrades
 .RS
 Update all AUR packages in a local repository that are out-of-date.
 .RE
 
-.B \--nover, --no-ver
+.BR \-\-nover ", " \-\-no-ver
 .RS
 Disable version checking for packages in the queue.
 .RE
 
-.B \--noview, --no-view
+.BR \-\-noview ", " \-\-no-view
 .RS
 Do not view downloaded files before building.
 .RE
 
-.B \--repo
+.B \-\-repo
 .RS
 Use the specified repository instead of an interactive selection.
 .RE
 
-.B \--root
+.B \-\-root
 .RS
 The location of the repository root. Defaults to the \fIServer\fR
 value of the configured repository.
 .RE
 
-.B \--continue
+.B \-\-continue
 .RS
 Skip downloading package files.
 .RE
@@ -108,22 +107,22 @@ Skip downloading package files.
 .SS makepkg
 The default set of options is \fBmakepkg \-cs\fR.
 
-.B \-A, --ignorearch, --ignore-arch
+.BR \-A ", " \-\-ignorearch ", " \-\-ignore-arch
 .RS
 Ignore a missing or incomplete \fIarch\fR field in the build script.
 .RE
 
-.B \-L, --log
+.BR \-L ", " \-\-log
 .RS
 Enable logging to a text file in the build directory.
 .RE
 
-.B \--noconfirm, --no-confirm
+.BR \-\-noconfirm ", " \-\-no-confirm
 .RS
 Do not wait for user input. (\fBmakepkg \-\-noconfirm\fR)
 .RE
 
-.B \-r, --rmdeps
+.BR \-r ", " \-\-rmdeps
 .RS
 Remove dependencies installed by makepkg. (\fBmakepkg \-r\fR)
 .RE
@@ -131,12 +130,12 @@ Remove dependencies installed by makepkg. (\fBmakepkg \-r\fR)
 .SS makechrootpkg
 The default set of options is \fBmakechrootpkg \-cu\fR.
 
-.B \-B, --bind
+.BR \-B ", " \-\-bind
 .RS
 Bind a directory read-only.
 .RE
 
-.B \-T, --temp
+.BR \-T ", " \-\-temp
 .RS
 Build in a temporary container.
 .RE

--- a/man1/aur-vercmp.1
+++ b/man1/aur-vercmp.1
@@ -1,10 +1,9 @@
 .TH AUR-VERCMP 1 2018-02-01 AURUTILS
 .SH NAME
-aur-vercmp \- check packages for AUR updates
+aur\-vercmp \- check packages for AUR updates
 
 .SH SYNOPSIS
-.SY aur
-.B vercmp
+.SY "aur vercmp"
 .OP \-aclq
 .OP \-d repository
 .OP \-r root

--- a/man1/aur-vercmp.1
+++ b/man1/aur-vercmp.1
@@ -12,7 +12,7 @@ aur-vercmp \- check packages for AUR updates
 .SH OPTIONS
 .B \-a
 .RS
-If \fI-c\fR is \fBnot\fR specified, this option also shows packages with
+If \fB-c\fR is \fInot\fR specified, this option also shows packages with
 older or the same version in the AUR. If specified twice, packages that
 are not available in AUR are also shown.
 .RE
@@ -22,14 +22,14 @@ are not available in AUR are also shown.
 Takes packages and their versions from stdin (\fIpkgname\fR as the first
 field, \fIpkgver\fR as the second, both separated by tabs), printing
 packages with equal or newer versions in a repository specified with
-\fI\-d\fR to stdout. If this argument or \fI\-d\fR is \fBnot\fR
+\fB\-d\fR to stdout. If this argument or \fB\-d\fR is \fInot\fR
 specified, compare packages in the repository with their respective
 versions in the AUR, and print updates to stdout.
 .RE
 
 .B \-d
 .RS
-The name of a pacman repository. If \fBnot\fR specified, packages and their
+The name of a pacman repository. If \fInot\fR specified, packages and their
 versions are taken from stdin (tab-separated).
 .RE
 
@@ -45,12 +45,12 @@ For all comparisons, show only package names.
 
 .B \-r
 .RS
-Path for the repository root. Used in conjuction with \fI\-c\fR.
+Path for the repository root. Used in conjuction with \fB\-c\fR.
 .RE
 
 .SH SEE ALSO
 .BR aur (1),
-.BR aur-rpc (1),
+.BR aur\-rpc (1),
 .BR jq (1),
 .BR pacman (1),
 .BR vercmp (1)

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -7,55 +7,55 @@ aur \- helper tool for the arch user repository
 The below gives a short overview; see the respective documentation for
 details.
 .P
-.BR aur-build (1)
+.BR aur\-build (1)
 .RS 4
 Build packages to a local repository.
 .RE
 
 .P
-.BR aur-deps (1)
+.BR aur\-deps (1)
 .RS 4
 Order package dependencies.
 .RE
 
 .P
-.BR aur-fetch (1)
+.BR aur\-fetch (1)
 .RS 4
 Retrieve build files from the AUR.
 .RE
 
 .P
-.BR aur-pkglist (1)
+.BR aur\-pkglist (1)
 .RS 4
 Print the AUR package list.
 .RE
 
 .P
-.BR aur-rfilter (1)
+.BR aur\-rfilter (1)
 .RS 4
 Filter packages in the Arch Linux repositories.
 .RE
 
 .P
-.BR aur-search (1)
+.BR aur\-search (1)
 .RS 4
 Search for AUR packages.
 .RE
 
 .P
-.BR aur-srcver (1)
+.BR aur\-srcver (1)
 .RS 4
 Update and print package revisions.
 .RE
 
 .P
-.BR aur-sync (1)
+.BR aur\-sync (1)
 .RS 4
 Download and build AUR packages automatically
 .RE
 
 .P
-.BR aur-vercmp (1)
+.BR aur\-vercmp (1)
 .RS 4
 Check packages for AUR updates.
 .RE
@@ -92,7 +92,7 @@ Include the configuration in \fI/etc/pacman.conf\fR:
   Include = /etc/pacman.d/custom
 
 .EE
-Add \fIInclude \fRto the \fBend \fRof pacman.conf, where possible.
+Add \fBInclude\fR to the \fIend\fR of pacman.conf, where possible.
 .P
 Create the repository root and database:
 .EX
@@ -115,7 +115,7 @@ Synchronize pacman:
 
 .EE
 .SY Note:
-It is recommended to use a pacman cache directory (\fICacheDir\fR) as
+It is recommended to use a pacman cache directory (\fBCacheDir\fR) as
 the package pool. This avoids checksum mismatches between built
 packages and any cached versions.
 .YS
@@ -139,17 +139,17 @@ and the local filesystem:
 
 .EE
 If mismatches occur, consider rebuilding the respective
-packages. Otherwise, recreate the packages with \fIbacman\fR:
+packages. Otherwise, recreate the packages with \fBbacman\fR:
 .EX
 
   $ pacman -Qqm | xargs -L1 bacman
 
 .EE
-Results will be saved to \fIPKGDEST\fR, or to the current directory if
+Results will be saved to \fBPKGDEST\fR, or to the current directory if
 this variable is not set.
 
 .SH EXAMPLES
-Examples below assume \fIbash\fR as the interactive shell.
+Examples below assume \fBbash\fR as the interactive shell.
 
 Run actions on the dependency tree of an AUR package:
 .EX
@@ -249,7 +249,7 @@ For example, create the following script in
  pacman --config=/usr/share/devtools/pacman-extra.conf "$@"
 
 .EE
-This script can then be propagated through the \fIPACMAN\fR variable
+This script can then be propagated through the \fBPACMAN\fR variable
 for programs supporting it.
 
 .SH AUTHORS


### PR DESCRIPTION
While reading the man pages *a lot* yesterday, it bothered me that usage of bold and italics was rather inconsistent. This PR aims to:

- Unify bold and italic usage
- Repeat option arguments in the OPTIONS sections

And while working on those, I noticed that a couple (read: many) hyphens needed escapation, because otherwise they become subject to line wrapping.

The only non-formatting changes were changing one "workarounds" to "works around" and changing a "suffix" to "prefix", both in aur-sync(1).