### PR TITLE
aur-search: Add indicator of orphaned and out-of-date packages

### DIFF
--- a/lib/aur-search
+++ b/lib/aur-search
@@ -26,8 +26,8 @@ json_short() {
         read -r OutOfDate
         read -r Description
     }; do
-        [[ "$OutOfDate" ]] && OutOfDate="(Out-of-date: $(date -d @"$OutOfDate" '+%d %B %Y'))"
-        [[ "$Maintainer" == "" ]] && Maintainer="(Orphaned)" || Maintainer=""
+        [[ -n "$OutOfDate" ]] && OutOfDate="(Out-of-date: $(date -d @"$OutOfDate" '+%d %B %Y'))"
+        [[ -z "$Maintainer" ]] && Maintainer="(Orphaned)" || Maintainer=""
         printf "${BLUE}aur/${ALL_OFF}${BOLD}%s ${GREEN}%s ${ALL_OFF}(%s) ${RED}%s %s${ALL_OFF}\\n    %s\\n" \
                "$Name" "$Version" "$NumVotes" "$Maintainer" "$OutOfDate" "$Description"
     done

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -15,16 +15,23 @@ json_short() {
     jq -r --arg key "$1" '[.results[]] | sort_by(.[$key])[] | .Name,
         .Version,
         .NumVotes,
+        .Maintainer,
+        .OutOfDate,
         .Description' | while
     {
         read -r Name
         read -r Version
         read -r NumVotes
+        read -r Maintainer
+        read -r OutOfDate
         read -r Description
     }; do
-        printf "${BLUE}aur/${ALL_OFF}${BOLD}%s ${GREEN}%s ${ALL_OFF}(%s)\\n    %s\\n" \
-               "$Name" "$Version" "$NumVotes" "$Description"
+        [[ "$OutOfDate" == "null" ]] && OutOfDate="" || OutOfDate="(Out-of-date: $(date -d @"$OutOfDate" '+%d %B %Y'))"
+        [[ "$Maintainer" != "null" ]] && Maintainer="" || Maintainer="(Orphaned)"
+        printf "${BLUE}aur/${ALL_OFF}${BOLD}%s ${GREEN}%s ${ALL_OFF}(%s) ${RED}%s %s${ALL_OFF}\\n    %s\\n" \
+               "$Name" "$Version" "$NumVotes" "$Maintainer" "$OutOfDate" "$Description"
     done
+
 }
 
 # XXX Add additional info fields: make/check/depends, license, keyword (#207)

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -10,13 +10,13 @@ search_by=name-desc
 sort_key=Name
 
 json_short() {
-    local Name Version NumVotes Description
+    local Name Version NumVotes Maintainer OutOfDate Description
 
     jq -r --arg key "$1" '[.results[]] | sort_by(.[$key])[] | .Name,
         .Version,
         .NumVotes,
-        .Maintainer,
-        .OutOfDate,
+        .Maintainer // "",
+        .OutOfDate // "",
         .Description' | while
     {
         read -r Name
@@ -26,8 +26,8 @@ json_short() {
         read -r OutOfDate
         read -r Description
     }; do
-        [[ "$OutOfDate" == "null" ]] && OutOfDate="" || OutOfDate="(Out-of-date: $(date -d @"$OutOfDate" '+%d %B %Y'))"
-        [[ "$Maintainer" != "null" ]] && Maintainer="" || Maintainer="(Orphaned)"
+        [[ "$OutOfDate" ]] && OutOfDate="(Out-of-date: $(date -d @"$OutOfDate" '+%d %B %Y'))"
+        [[ "$Maintainer" == "" ]] && Maintainer="(Orphaned)" || Maintainer=""
         printf "${BLUE}aur/${ALL_OFF}${BOLD}%s ${GREEN}%s ${ALL_OFF}(%s) ${RED}%s %s${ALL_OFF}\\n    %s\\n" \
                "$Name" "$Version" "$NumVotes" "$Maintainer" "$OutOfDate" "$Description"
     done

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -31,7 +31,6 @@ json_short() {
         printf "${BLUE}aur/${ALL_OFF}${BOLD}%s ${GREEN}%s ${ALL_OFF}(%s) ${RED}%s %s${ALL_OFF}\\n    %s\\n" \
                "$Name" "$Version" "$NumVotes" "$Maintainer" "$OutOfDate" "$Description"
     done
-
 }
 
 # XXX Add additional info fields: make/check/depends, license, keyword (#207)


### PR DESCRIPTION
Inspired by yay 🙂

I realized what I'm missing from yay - indicators "orphaned" and "out-of-date". I don't think any configuration options are needed to disable this behavior.

![image](https://user-images.githubusercontent.com/1177900/37680255-a5149d64-2c83-11e8-92b8-b0694283d72c.png)


