### PR TITLE
additional documentation fixes (follow-up to #322)

### DIFF
--- a/man1/aur-build-nspawn.1
+++ b/man1/aur-build-nspawn.1
@@ -20,35 +20,30 @@ repository. See also \fBaur\-build\fR(1).
 .SH OPTIONS
 All arguments after \-\- are passed to \fBmakechrootpkg\fR.
 
+.TP
 .BI "\-C " pacman_conf
-.RS
 The \fIpacman.conf\fR file to be used in the container. Defaults to
 \fIpacman-extra.conf\fR from devtools.
-.RE
 
+.TP
 .BI "\-D " directory
-.RS
 The base directory for containers. This directory usually contains a
 \fB/root\fR subdirectory that serves as template for user containers
 (named after \fI$SUDO_USER\fR, or \fB/copy\fR if unset).
-.RE
 
+.TP
 .BI "\-M " makepkg_conf
-.RS
 The makepkg.conf file to be used in the container. Defaults to
 \fImakepkg\-<machine>.conf\fR from devtools.
-.RE
 
+.TP
 .BI "\-d " database
-.RS
 Check if the specified repository is configured in the /root container.
 Only effective for \fB-u\fR.
-.RE
 
+.TP
 .B \-u
-.RS
 Update or create the /root copy of the container; do not build a package.
-.RE
 
 .SH ENVIRONMENT
 Packages are placed in the directory specified in \fBPKGDEST\fR. If not

--- a/man1/aur-build-nspawn.1
+++ b/man1/aur-build-nspawn.1
@@ -10,7 +10,7 @@ aur\-build\-nspawn \- build packages to a local repository inside a chroot
 .OP \-d database
 .OP \-u
 .OP \--
-[\fImakechrootpkg args\fR]
+.RI [ "makechrootpkg args" ]
 .YS
 
 .SH DESCRIPTION

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -20,8 +20,8 @@ It is assumed that build directories are located in the current
 directory, and described in a text file which is taken as argument.
 
 .SH OPTIONS
-All arguments after \-\- are passed to \fBmakepkg\fR, or
-\fBaur\-build\-nspawn\fR when \fB\-c\fR is specified.
+All arguments after \-\- are passed to \fBmakepkg\fR(8), or
+\fBaur\-build\-nspawn\fR(1) when \fB\-c\fR is specified.
 
 .TP
 .BI "\-a " queue
@@ -30,7 +30,7 @@ specified, the current directory is assumed.
 
 .TP
 .B \-c
-Build packages with \fBaurbuild_chroot\fR(1).
+Build packages with \fBaur\-build\-nspawn\fR(1).
 
 .TP
 .BI "\-d " database
@@ -83,10 +83,10 @@ entries if the locale is not set (FS#49342). Packages are signed
 manually with \fBgpg \-\-verbose \-\-detach\-sign \-\-no\-armor\fR (FS#49946).
 
 .SS Avoiding password prompts
-makepkg must be run as a regular user as of version 4.2, with
-privileged operations done via \fBsudo\fR. As such, \fBaurbuild\fR can
-not be run directly as root. To avoid password prompts,
-\fBsudoers\fR(5) can be used instead.
+\fBmakepkg\fR(8) must be run as a regular user as of version 4.2, with
+privileged operations done via \fBsudo\fR(8). As such,
+\fBaur\-build\fR(1) can not be run directly as root. To avoid password
+prompts, \fBsudoers\fR(5) can be used instead.
 
 For example:
 .EX
@@ -96,10 +96,11 @@ For example:
 .EE
 
 .SY Note:
-For precautions when using wildcards with \fBsudo\fR, see the
-\fIWildcards\fR section in \fBsudoers\fR (5). Whitelisting
+For precautions when using wildcards with \fBsudo\fR(8), see the
+\fIWildcards\fR section in \fBsudoers\fR(5). Whitelisting
 \fI/usr/bin/aur\fR should generally be avoided, as this allows to run
-\fIany\fR \fBaur\fR command as root without prompting.
+\fIany\fR \fBaur\fR command as root without prompting. (Including
+scripts found in $PATH using the 'aur-' prefix)
 .YS
 
 .SH SEE ALSO
@@ -110,6 +111,7 @@ For precautions when using wildcards with \fBsudo\fR, see the
 .BR makepkg.conf (5),
 .BR pacman.conf (5),
 .BR makepkg (8),
+.BR repo-add (8),
 .BR setarch (8)
 
 .SH AUTHORS

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -9,7 +9,7 @@ aur\-build \- build packages to a local repository
 .OP \-a queue
 .OP \-r root
 .OP \--
-.OP "makepkg args"
+.RI [ "makepkg args" ]
 .YS
 
 .SH DESCRIPTION

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -23,58 +23,49 @@ directory, and described in a text file which is taken as argument.
 All arguments after \-\- are passed to \fBmakepkg\fR, or
 \fBaur\-build\-nspawn\fR when \fB\-c\fR is specified.
 
+.TP
 .BI "\-a " queue
-.RS
 A text file with directories containing a PKGBUILD. If none is
 specified, the current directory is assumed.
-.RE
 
+.TP
 .B \-c
-.RS
 Build packages with \fBaurbuild_chroot\fR(1).
-.RE
 
+.TP
 .BI "\-d " database
-.RS
 The name of the pacman database.
-.RE
 
+.TP
 .B \-f
-.RS
 Continue the build process if a package with the same name is found
 (ignoring the extension). Existing packages will be moved with a
 \fI~\fR suffix.
-.RE
 
+.TP
 .B \-N
-.RS
 Do not sync the local repository after building.
-.RE
 
+.TP
 .BI "\-r " root
-.RS
 The root for the repository. The \fIroot\fR is the location for the
 pacman database (\fIfoo.db\fR), built packages, and secondary files such
 as the files database (\fIfoo.files\fR). This defaults to the
 \fIServer\fR value of the configured repository.
-.RE
 
+.TP
 .B \-R
-.RS
 Remove old package files from disk when updating their entry in the
 database (\fBrepo\-add \-R\fR).
-.RE
 
+.TP
 .B \-s
-.RS
 Sign built packages and the database (\fBrepo\-add \-s\fR) with gpg.
-.RE
 
+.TP
 .B \-v
-.RS
 Verify the PGP signature of the database before updating. (\fBrepo\-add
 \-v\fR).
-.RE
 
 .SH NOTES
 When building locally (outside a container), \fBpacman \-Syu\fR is run

--- a/man1/aur-deps-rpc.1
+++ b/man1/aur-deps-rpc.1
@@ -13,15 +13,13 @@ and orders the dependencies for those packages using the AUR RPC
 interface.
 
 .SH OPTIONS
+.TP
 .B \-a
-.RS
 Print the full dependency tree instead of only AUR packages.
-.RE
 
+.TP
 .B \-t
-.RS
 Copy retrieved JSON files to a specified directory.
-.RE
 
 .SH NOTES
 Version information is ignored for dependencies. See \fIFS#54096\fR.

--- a/man1/aur-deps-src.1
+++ b/man1/aur-deps-src.1
@@ -4,7 +4,7 @@ aur\-deps\-src \- order dependencies using .SRCINFO files
 
 .SH SYNOPSIS
 .SY "aur deps\-src"
-[\fIpkgbase\fR...]
+.RI [ pkgbase ...]
 .YS
 
 .SH DESCRIPTION

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -15,21 +15,18 @@ download them. It's capable of handling \fItar\fR archives and \fIgit\fR
 repositories.
 
 .SH OPTIONS
+.TP
 .BI "\-L " log_dir
-.RS
 The location of where to store the diffs of previously unpacked
 archives.
-.RE
 
+.TP
 .B \-t
-.RS
 Downloads the package as a \fItar\fR archive with \fBaur\-fetch\-snapshot\fR.
-.RE
 
+.TP
 .B \-g
-.RS
 Downloads the package as a \fIgit\fR repository with \fBaur\-fetch\-git\fR.
-.RE
 
 .SH SEE ALSO
 .BR git (1),

--- a/man1/aur-pkglist.1
+++ b/man1/aur-pkglist.1
@@ -18,28 +18,24 @@ This list is available at:
 .UE
 
 .SH OPTIONS
+.TP
 .B \-t
-.RS
 Set the delay in seconds before a new package list is retrieved.
 Defaults to \fB300\fR seconds.
-.RE
 
+.TP
 .B \-b
-.RS
 Retrieve \fIpkgbase.gz\fR instead of \fIpackages.gz\fR.
-.RE
 
+.TP
 .BI "\-F " pattern
-.RS
 Interpret the given pattern as a list of fixed strings, separated by
 newlines, any of which is to be matched.
-.RE
 
+.TP
 .BI "\-P " pattern
-.RS
 Interpret the given pattern as a Perl-compatible regular expression
 (PCRE).
-.RE
 
 .SH NOTES
 To avoid retrieving the package list on every query, \fBaur\-pkglist\fR uses a

--- a/man1/aur-pkglist.1
+++ b/man1/aur-pkglist.1
@@ -11,7 +11,7 @@ aur\-pkglist \- print the AUR packagelist
 .SH DESCRIPTION
 \fBaur\-pkglist\fR prints the list of \fIpkgname\fRs that are available in the
 AUR to standard output. Optionally a pattern can be specified that is
-matched with \fBpcregrep\fR.
+matched with \fBpcregrep\fR(1).
 
 This list is available at:
 .UR https://aur.archlinux.org/packages.gz

--- a/man1/aur-rfilter.1
+++ b/man1/aur-rfilter.1
@@ -13,11 +13,10 @@ in the official Arch Linux repositories, and print it to \fIstdout\fR if
 not. Virtual packages, when found, are solved and printed to stderr.
 
 .SH OPTIONS
+.TP
 .BI "\-d " database
-.RS
 Check a given repository instead of those from Arch Linux. Multiple
 repositories can be specified by repeating \fB\-d\fR.
-.RE
 
 .SH SEE ALSO
 .BR expac (1),

--- a/man1/aur-search.1
+++ b/man1/aur-search.1
@@ -17,38 +17,32 @@ displayed in a brief format.
 
 .SH OPTIONS
 
+.TP
 .B \-q
-.RS
 Only display package name, version and description.
-.RE
 
+.TP
 .B \-v
-.RS
 Display more package information.
-.RE
 
+.TP
 .B \-i
-.RS
 Use the \fIinfo\fR interface instead of \fIsearchby\fR.
-.RE
 
+.TP
 .B \-d
-.RS
 Search by package name and description.
-.RE
 
+.TP
 .B \-m
-.RS
 Search by maintainer.
-.RE
 
+.TP
 .B \-n
-.RS
 Search by package name.
-.RE
 
+.TP
 .BI "\-k " key
-.RS
 Sort results via a key, defaulting to \fIName\fR.
 
 Possible choices are \fIName\fR, \fIVersion\fR, \fINumVotes\fR,
@@ -56,7 +50,6 @@ Possible choices are \fIName\fR, \fIVersion\fR, \fINumVotes\fR,
 \fIVersion\fR, \fIDescription\fR, \fIURL\fR, \fINumVotes\fR,
 \fIPopularity\fR, \fIOutOfDate\fR, \fIMaintainer\fR,
 \fIFirstSubmitted\fR, \fILastModified\fR (for \fB-v\fR verbose output).
-.RE
 
 .SH SEE ALSO
 .BR aur (1),

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -24,149 +24,126 @@ and can be edited. If not, the files are shown in \fIless\fR, or
 
 .SH OPTIONS
 .SS Build options
+.TP
 .BR \-f ", " \-\-force
-.RS
 Continue the build process if a package with the same name exists
 already. (\fBaur build \-f\fR)
-.RE
 
+.TP
 .B \-\-ignore=\fIPACKAGE\fR
-.RS
 Ignore a package upgrade. Multiple packages can be specified by
 separating them with a comma, or by repeating the \fB\-\-ignore\fR option.
-.RE
 
-.BR \-\-nover ", " \-\-no-ver
-.RS
+.TP
+.BR \-\-nover ", " \-\-no\-ver
 Disable version checking for packages in the queue.
-.RE
 
+.TP
 .BR \-p ", " \-\-print
-.RS
 Print target packages and their paths instead of building them.
-.RE
 
+.TP
 .BR \-s ", " \-\-sign
-.RS
 Sign built packages and verify the database with gpg. (\fBaur build \-sv\fR)
-.RE
 
 .SS Container options
+.TP
 .BR \-c ", " \-\-chroot
-.RS
 Build packages with makechrootpkg. (\fBaur build \-c\fR)
-.RE
 
+.TP
 .BR "\-C \fIFILE\fR" ", " \-\-pacman\-conf=\fIFILE\fR
-.RS
 Set the \fIpacman.conf\fR file to be used in the container. (\fBaur
 build \-C\fR)
 .RE
 
+.TP
 .BR "\-M \fIFILE\fR" ", " \-\-makepkg\-conf=\fIFILE\fR
-.RS
 Set the \fImakepkg.conf\fR file to be used in the container. (\fBaur
 build \-M\fR)
-.RE
 
+.TP
 .BR "\-D \fIDIR\fR" ", " \-\-directory=\fIDIR\fR
-.RS
 Set the container path to \fIDIR\fR. (\fBaur build \-D\fR)
-.RE
 
 .SS Download options
+.TP
 .B \-\-continue
-.RS
 Skip downloading package files.
-.RE
 
+.TP
 .BR \-g ", " \-\-git
-.RS
 Clone AUR repositories with \fBgit-clone\fR(1).
-.RE
 
-.BR \-\-noview ", " \-\-no-view
-.RS
+.TP
+.BR \-\-noview ", " \-\-no\-view
 Do not view downloaded files before building.
-.RE
 
+.TP
 .BR \-t ", " \-\-tar
-.RS
 Download AUR snapshots (\fIpkgbase.tar.gz\fR) and extract them with
 \fBtar\fR(1).
-.RE
 
 .SS Repository options
+.TP
 .B \-\-list
-.RS
 List repository contents in the JSON output format.
-.RE
 
+.TP
 .B \-\-provides
-.RS
 Take virtual dependencies (\fBprovides\fR) in the local repository into
 account. Packages specified on the command line or available upgrades
 are considered regardless of this setting.
 
 Note: Ensure the local repository is propagated to \fBpacman\fR before
 using this option, for example with \fBpacsync\fR(1).
-.RE
 
+.TP
 .B \-\-repo=\fINAME\fR
-.RS
 Use the \fINAME\fR repository. If this option is not specified,
 \fBaur\-sync\fR defaults to the first \fIfile://\fR repository in
 \fBpacman.conf\fR(5), or aborts if multiple are available.
-.RE
 
+.TP
 .B \-\-root=\fIDIR\fR
-.RS
 The location of the repository root. Defaults to the \fIServer\fR
 value of the configured repository.
-.RE
 
+.TP
 .BR \-u ", " \-\-upgrades
-.RS
 Update all AUR packages in a local repository that are out-of-date.
-.RE
 
 .SS makepkg
 The default set of options is \fBmakepkg \-cs\fR.
 
-.BR \-A ", " \-\-ignorearch ", " \-\-ignore-arch
-.RS
+.TP
+.BR \-A ", " \-\-ignorearch ", " \-\-ignore\-arch
 Ignore a missing or incomplete \fIarch\fR field in the build script.
 (\fBmakepkg \-A\fR)
-.RE
 
+.TP
 .BR \-L ", " \-\-log
-.RS
 Enable logging to a text file in the build directory. (\fBmakepkg
 \-L\fR)
-.RE
 
-.BR \-\-noconfirm ", " \-\-no-confirm
-.RS
+.TP
+.BR \-\-noconfirm ", " \-\-no\-confirm
 Do not wait for user input. (\fBmakepkg \-\-noconfirm\fR)
-.RE
 
+.TP
 .BR \-r ", " \-\-rmdeps
-.RS
 Remove dependencies installed by makepkg. (\fBmakepkg \-r\fR)
-.RE
 
 .SS makechrootpkg
 The default set of options is \fBmakechrootpkg \-cu\fR.
 
+.TP
 .B \-\-bind=\fIDIR\fR
-.RS
 Bind a directory read-only. (\fBmakechrootpkg \-D\fR)
-.RE
 
+.TP
 .BR \-T ", " \-\-temp
-.RS
 Build in a temporary container. (\fBmakechrootpkg \-T\fR)
-.RE
 
 .SH ENVIRONMENT
 .B AURDEST

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -18,8 +18,8 @@ aur\-sync \- download and build aur packages automatically
 \fBaur\-sync\fR downloads and builds packages automatically to a local
 repository. Package names serve as arguments.
 
-If \fIvifm\fR is installed, the downloaded files are shown using vifm
-and can be edited. If not, the files are shown in \fIless\fR, or
+If \fBvifm\fR(1) is installed, the downloaded files are shown using vifm
+and can be edited. If not, the files are shown in \fBless\fR(1), or
 \fI$PAGER\fR if configured.
 
 .SH OPTIONS
@@ -95,8 +95,8 @@ Take virtual dependencies (\fBprovides\fR) in the local repository into
 account. Packages specified on the command line or available upgrades
 are considered regardless of this setting.
 
-Note: Ensure the local repository is propagated to \fBpacman\fR before
-using this option, for example with \fBpacsync\fR(1).
+Note: Ensure the local repository is propagated to \fBpacman\fR(8)
+before using this option, for example with \fBpacsync\fR(1).
 
 .TP
 .B \-\-repo=\fINAME\fR

--- a/man1/aur-vercmp.1
+++ b/man1/aur-vercmp.1
@@ -9,33 +9,29 @@ aur\-vercmp \- check packages for AUR updates
 .OP \-p path
 
 .SH OPTIONS
+.TP
 .B \-a
-.RS
 If \fB-c\fR is \fInot\fR specified, this option also shows packages with
 older or the same version in the AUR. If specified twice, packages that
 are not available in AUR are also shown.
-.RE
 
+.TP
 .B \-c
-.RS
 Takes packages and their versions from stdin (\fIpkgname\fR as the first
 field, \fIpkgver\fR as the second, both separated by tabs), printing
 packages with equal or newer versions in a repository specified with
 \fB\-d\fR to stdout. If this argument or \fB\-d\fR is \fInot\fR
 specified, compare packages in the repository with their respective
 versions in the AUR, and print updates to stdout.
-.RE
 
+.TP
 .B \-d
-.RS
 The name of a pacman repository. If \fInot\fR specified, packages and their
 versions are taken from stdin (tab-separated).
-.RE
 
+.TP
 .B \-q
-.RS
 For all comparisons, show only package names.
-.RE
 
 .SH SEE ALSO
 .BR aur (1),


### PR DESCRIPTION
Here are some documentation improvements that I failed to get ready in time to piggyback #322.

Align options with descriptions if there is space for it.
Add some missing section numbers.
Add mention that sudo wildcarding aur might run aur- prefixed scripts from $PATH
Add some missed escapes for -
Fix inconsistency between manpage formatting of arguments inside square brackets