### PR TITLE
Make sure every field has a fallback during jq parsing

### DIFF
--- a/lib/aur-search
+++ b/lib/aur-search
@@ -13,17 +13,17 @@ sort_key=Name
 tabulate() {
     # XXX Add missing fields (depends, makedepends, checkdepends)
     jq -r --arg key "$1" '[.results[]] | sort_by(.[$key])[] | [
-        .Name,
-        .PackageBase,
-        .Version,
-        .Description,
-        .URL,
-        (.Keywords | select (length > 0) // ["(null)"] | join(" ")),
-        (.License  | select (length > 0) // ["(null)"] | join(" ")),
-        .NumVotes,
-        .Popularity,
-        .Maintainer // "-",
-        .OutOfDate  // "-",
+        .Name            // "-",
+        .PackageBase     // "-",
+        .Version         // "-",
+        .Description     // "-",
+        .URL             // "-",
+        (.Keywords       | select (length > 0) // ["-"] | join(" ")),
+        (.License        | select (length > 0) // ["-"] | join(" ")),
+        .NumVotes        // "-",
+        .Popularity      // "-",
+        .Maintainer      // "-",
+        .OutOfDate       // "-",
         (.FirstSubmitted | todate),
         (.LastModified   | todate)
     ] | @tsv'


### PR DESCRIPTION
Fixes #336.

![image](https://user-images.githubusercontent.com/1177900/37923116-ad564aa4-312e-11e8-8af3-db4d82e448a1.png)


If I understood [your comment](https://github.com/AladW/aurutils/pull/338#issuecomment-376244193) correctly, you agreed to change `(null)` to `-` for consistency. Here's how it looks:


![image](https://user-images.githubusercontent.com/1177900/37923010-604785a2-312e-11e8-8223-a64422d75374.png)
