### PR TITLE
Make sure the is no extra space when package is not orphaned

### DIFF
--- a/lib/aur-search
+++ b/lib/aur-search
@@ -71,11 +71,11 @@ parse_short() {
         esac
 
         case $Maintainer in
-            -) Maintainer='(Orphaned)' ;;
+            -) Maintainer='(Orphaned) ' ;;
             *) unset Maintainer ;;
         esac
 
-        printf "${BLUE}aur/${ALL_OFF}${BOLD}%s ${GREEN}%s ${ALL_OFF}(%s) ${RED}%s %s${ALL_OFF}\\n    %s\\n" \
+        printf "${BLUE}aur/${ALL_OFF}${BOLD}%s ${GREEN}%s ${ALL_OFF}(%s) ${RED}%s%s${ALL_OFF}\\n    %s\\n" \
                "$Name" "$Version" "$NumVotes" "$Maintainer" "$OutOfDate" "$Description"
     done
 }


### PR DESCRIPTION
Just to be done with aur-search bugs 🙂

This fix kinda depends on the fact that `(Oprhaned)` is always before `Out Of Date`, not sure if you want something more sophisticated that this...

![image](https://user-images.githubusercontent.com/1177900/37924796-372840f8-3133-11e8-8398-9ee19f2901da.png)

P.S. I found `-a` useful for showing relevant screenshots, it allows to gather all important cases in one picture 🙂

Fixes #337.