### PR TITLE
specify absolute paths for GIT_DIR & GIT_WORK_TREE

### DIFF
--- a/lib/aur-fetch-git
+++ b/lib/aur-fetch-git
@@ -22,7 +22,7 @@ merge_upstream() {
 
 merge_across_fs() {
     # avoid issues with filesystem boundaries (#274)
-    GIT_DIR="$1"/.git GIT_WORK_TREE="$1" merge_upstream "$2"
+    GIT_DIR="$PWD/$1"/.git GIT_WORK_TREE="$PWD/$1" merge_upstream "$2"
 }
 
 usage() {


### PR DESCRIPTION
Specifying a relative directory will trigger a regression under some
circumstances.

  $ GIT_DIR=spotify/.git GIT_WORK_TREE=spotify git reset HEAD
  fatal: couldn't read spotify/.git/packed-refs: Not a directory

  $ GIT_DIR=$PWD/spotify/.git GIT_WORK_TREE=$PWD/spotify git reset HEAD