### PR TITLE
Add documentation for GPGKEY variable

### DIFF
--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -61,6 +61,8 @@ database (\fBrepo\-add \-R\fR).
 .TP
 .B \-s
 Sign built packages and the database (\fBrepo\-add \-s\fR) with gpg.
+To use another key than the default, the GPGKEY environment variable can be
+set to the appopriate key identifier.
 
 .TP
 .B \-v

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -61,7 +61,7 @@ database (\fBrepo\-add \-R\fR).
 .TP
 .B \-s
 Sign built packages and the database (\fBrepo\-add \-s\fR) with gpg.
-To use another key than the default, the GPGKEY environment variable can be
+To use another key than the default, the \fBGPGKEY\fR environment variable can be
 set to the appopriate key identifier.
 
 .TP


### PR DESCRIPTION
Added mention to the GPGKEY variable to use another key for signing. This variable doesn't seem to be documented at all.