### PR TITLE
Optimize aur-srcver using git ls-remote

### DIFF
--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -9,13 +9,14 @@ get_pkgbuild_info() {
     env -C "$1" -i bash -c '
         PATH= source PKGBUILD
 
-        if [[ -v epoch ]]; then
-            fullver=$epoch:$pkgver-$pkgrel
-        else
-            fullver=$pkgver-$pkgrel
-        fi
+        source="${source#*::}"                           # remove custom name of a source
+        source="${source#*+}"                            # keep only one protocol (TODO: do we need many?)
 
-        printf %s\\t%s\\n "${pkgbase:-$pkgname}" "$fullver"
+        branch="${source#*#branch=}"                     # detect custom branch if it is specified
+        source="${source%#*}"                            # remove branch from the source string
+        [[ "$branch" == "$source" ]] && branch="HEAD"    # use HEAD if custom branch is not specified
+
+        printf "%s\\t%s\\t%s\\n" "${pkgbase:-$pkgname}" "$source" "$branch"
     '
 }
 
@@ -35,22 +36,11 @@ fi
 # XXX trickery for hyphen and absolute path arguments
 mapfile -t arg_path < <(readlink -e -- "$@")
 
-makepkg_log=$(mktemp -t makepkg.XXXXXXXX) || exit
-trap 'rm $makepkg_log' EXIT
-
 find_pkgbuild_path "${arg_path[@]}" | while read -r; do
-    cd "$REPLY" || exit
-
-    if makepkg --skipinteg --noprepare -od >"$makepkg_log" 2>&1; then
-        get_pkgbuild_info "$REPLY"
-    else
-        makepkg_exit=$?
-        printf >&2 '%s: error on package %s\n' "$argv0" "$REPLY"
-        printf >&2 '8<----\n'
-
-        cat  "$makepkg_log"
-        exit "$makepkg_exit"
-    fi
+    get_pkgbuild_info "$REPLY" | while IFS=$'\t' read -r pkgname source branch; do
+        latest="$(git ls-remote "$source" "$branch" | awk '{print $1}')"
+        printf "%s\\t%s\\n" "$pkgname" "$latest"
+    done
 done
 
 # vim: set et sw=4 sts=4 ft=sh:


### PR DESCRIPTION
This is how `aur-srcver` would look like when using `git ls-remote`.

As I shared in #286, `aur-out-of-date` doesn't produce good results for me, that's why I went for looking into this approach.

For my packages, the runtime of `aur-srcver` decreases from `18s` to `8s`.

How this works:

- Read `source` out of PKGBUILD (e.g. `source = alacritty::git+https://github.com/jwilm/alacritty.git#branch=master`)
- Remove custom name (e.g. `alacritty::`)
- Remove all but the last protocol (e.g. `git+`) - do we need to keep it?
- Detect branch name, if it is specified
- Run `git ls-remote` on the source to get their last commit hash

#### Big problems:

1. This approach doesn't work for non-vcs packages, and I'm not sure how to make it work. Should we somehow detect non-vcs packages in the input and for them fallback to aur-rpc?

2. This now reports version as `<pkg-name>    <commit-hash>`, so it's not compatible with `aur-vercmp` anymore. This breaks #283 😞

Do you have some ideas how to overcome these issues?