### PR TITLE
Use parallel to speed up aur-srcver

### DIFF
--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -28,6 +28,12 @@ usage() {
     exit 1
 }
 
+trap_exit() {
+    if ! [[ -o xtrace ]]; then
+        rm -rf "$tmp"
+    fi
+}
+
 if ((!$#)); then
     usage
 fi
@@ -35,22 +41,30 @@ fi
 # XXX trickery for hyphen and absolute path arguments
 mapfile -t arg_path < <(readlink -e -- "$@")
 
-makepkg_log=$(mktemp -t makepkg.XXXXXXXX) || exit
-trap 'rm $makepkg_log' EXIT
+tmp=$(mktemp -dt "$argv0".XXXXXXXX) || exit
+trap 'trap_exit' EXIT
+
+cd "$tmp" || exit
+parallel --will-cite --nice 10 -j +2 --joblog makepkg_log --results '{#}_makepkg' \
+  'cd {}; makepkg --skipinteg --noprepare -od' &>/dev/null ::: "${arg_path[@]}"
+num_failed=$?
+
+if [[ "$num_failed" -gt 0 ]]; then
+    printf >&2 '%s: failed to update %s packages\n\n' "$argv0" "$num_failed"
+
+    while IFS=$'\t' read -r seq _ _ _ _ _ exitcode _ command; do
+        [[ "$exitcode" -eq 0 ]] && continue
+
+        printf >&2 '8<----\n'
+        printf >&2 '%s\n' "$command"
+        cat "${seq}_makepkg" >&2
+        cat "${seq}_makepkg.err" >&2
+        printf >&2 '8<----\n\n'
+    done <makepkg_log
+fi
 
 find_pkgbuild_path "${arg_path[@]}" | while read -r; do
-    cd "$REPLY" || exit
-
-    if makepkg --skipinteg --noprepare -od >"$makepkg_log" 2>&1; then
-        get_pkgbuild_info "$REPLY"
-    else
-        makepkg_exit=$?
-        printf >&2 '%s: error on package %s\n' "$argv0" "$REPLY"
-        printf >&2 '8<----\n'
-
-        cat  "$makepkg_log"
-        exit "$makepkg_exit"
-    fi
+    get_pkgbuild_info "$REPLY"
 done
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -16,6 +16,7 @@ optdepends=('aria2: thread downloads'
             'devtools: aur-build-nspawn'
             'diffstat: aur-fetch-snapshot'
             'expac: aur-rfilter'
+            'parallel: aur-srcver'
             'vifm: build file interaction'
             'xdelta3: generate delta files')
 


### PR DESCRIPTION
How it works:

1. `--halt soon,fail=1` is **not used**, I want to update as many packages as possible, if one keeps failing it shouldn't block the rest
2. `--results '{#}_makepkg'` saves stdout and stderr of every makepkg run, `{#}` is the sequence number, used later to determine which run failed
3. `--joblog makepkg_log` saves the `tsv` table of which command finished and which failed, in there I can see a command, its exit code and its sequence number.

`parallel` exits with a code that corresponds to the number of jobs that failed. If any job failed, look in `makepkg_log` which jobs failed, find corresponding stdout and stderr files using the sequence number and print all of this to stderr.

In the end, print out the latest known versions. Even if one or two updates failed, the rest have been updated and can be used later in the pipeline. 

![image](https://user-images.githubusercontent.com/1177900/38337603-4561d492-3866-11e8-9dd2-bb7e547838bd.png)


Fixes #286 