### PR TITLE
aur-build: Sync pacman database after building everything in chroot

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -182,6 +182,10 @@ while read -r -u "$fd" pkg _; do
     fi
 done
 
+if ((chroot)) && ! ((no_sync)); then
+    sudo pacman -Sy
+fi
+
 exec {fd}<&-
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -93,7 +93,7 @@ prompts, \fBsudoers\fR(5) can be used instead.
 For example:
 .EX
 
-  %build localhost = (root) NOPASSWD: SETENV: /usr/bin/aur build-nspawn *
+  %build localhost = (root) NOPASSWD: SETENV: /usr/bin/pacman -Sy, /usr/bin/aur build-nspawn *
 
 .EE
 


### PR DESCRIPTION
I build everything in chroot, and I noticed that I _always_ need to sync pacman db afterwards, every single time. I have not seen a case yet when I would not want to sync pacman db after the build.

When building _not_ in chroot, I believe pacman db is being synced after building every package. When building in chroot, it is enough to sync it once after all packages are built.

P.S. I think it's pretty safe to add `/usr/bin/pacman -Sy` in `/etc/sudoers` to not require sudo password for the sync - because there is no `*` in the end, commands like `/usr/bin/pacman -Sy evil` will still require password. I made this change to `man` page in a separate commit - if you disagree, I can remove that commit.