### PR TITLE
fetch: add recursive mode (-d)

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -2,36 +2,33 @@
 # aur-fetch - retrieve build files from the AUR
 readonly argv0=fetch
 readonly aur_location='https://aur.archlinux.org'
+readonly fmt_git_clone=$aur_location/%s.git
+readonly fmt_snapshot=$aur_location/cgit/aur.git/snapshot/%s.tar.gz
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
+# default arguments
+fetch_args=()
+
 # default options
-log_dir=/dev/stdout
+deps=0
 mode=git
-
-fmt_snapshot() {
-    # https://git.archlinux.org/aurweb.git/tree/conf/config.proto
-    printf -- "$aur_location/cgit/aur.git/snapshot/%s.tar.gz\\n" "$@"
-}
-
-fmt_git_clone() {
-    printf -- "$aur_location/%s.git\\n" "$@"
-}
 
 usage() {
     base64 -d <<EOF
 ICAgICAgICAgICAgIC4tLX5+LF9fCjotLi4uLiwtLS0tLS0tYH5+Jy5fLicKIGAtLCwsICAsXyAg
 ICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
 EOF
-    printf -- 'usage: %s [-gt] [-L log_dir] pkgname [pkgname...]\n' "$argv0" >&2
+    printf >&2 'usage: %s [-dgt] [-L log_dir] pkgname [pkgname...]\n' "$argv0"
     exit 1
 }
 
-# XXX add recursive mode (aur-deps-rpc)
-while getopts :gtL: opt; do
+unset log_dir
+while getopts :dgtL: opt; do
     case $opt in
         L) log_dir=$OPTARG ;;
+        d) deps=1   ;;
         g) mode=git ;;
-        t) mode=tar ;;
+        t) mode=snapshot ;;
         *) usage    ;;
     esac
 done
@@ -42,7 +39,28 @@ if ((!$#)); then
     usage
 fi
 
-case $mode in
-    git) fmt_git_clone "$@" | aur fetch-git      -L "$log_dir" ;;
-    tar) fmt_snapshot  "$@" | aur fetch-snapshot -L "$log_dir" ;;
+if [[ -v log_dir ]]; then
+    fetch_args+=(-L "$log_dir")
+
+    if ! [[ -d $log_dir ]]; then
+        printf >&2 '%s: %q: not a directory' "$argv0" "$log_dir"
+        exit 21
+    fi
+fi
+
+# set filters (1)
+case $deps in
+    1) print_deps() { printf '%s\n' "$@" | aur deps-rpc; } ;;
+    0) print_deps() { printf '%s\n' "$@"; } ;;
 esac
+
+# set filters (2)
+case $mode in
+         git) format() { xargs printf "$fmt_git_clone\n"; } ;;
+    snapshot) format() { xargs printf "$fmt_snapshot\n" ; } ;;
+esac
+
+# pipeline
+print_deps "$@" | format | aur "fetch-$mode" "${fetch_args[@]}"
+
+# vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-fetch-git
+++ b/lib/aur-fetch-git
@@ -5,7 +5,7 @@ readonly argv0=fetch-git
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
-log_dir=/dev/stdout
+log=stdout
 
 merge_upstream() {
     git fetch -v >&2
@@ -25,27 +25,25 @@ merge_across_fs() {
 }
 
 usage() {
-    printf -- >&2 'usage: %s [-L log_dir]\n' "$argv0"
+    printf >&2 'usage: %s [-L log_dir]\n' "$argv0"
     exit 1
 }
 
 while getopts :L: opt; do
     case $opt in
-        L) log_dir=$OPTARG ;;
-        *) usage   ;;
+        L) log_dir=$OPTARG
+           log=directory ;;
+        *) usage ;;
     esac
 done
 shift $((OPTIND - 1))
 OPTIND=1
 
-if [[ -d $log_dir ]]; then
-    merge() { merge_across_fs "$1" "$log_dir/$1".patch; }
-elif [[ $log_dir == /dev/stdout ]]; then
-    merge() { merge_across_fs "$1"; }
-else
-    printf -- >&2 '%s: %q: not a directory or /dev/stdout\n' "$argv0" "$log_dir"
-    exit 1
-fi
+# set filters
+case $log in
+    directory) merge() { merge_across_fs "$log_dir/$1".patch; } ;;
+    stdout)    merge() { merge_across_fs; } ;;
+esac
 
 while IFS= read -r uri; do
     pkg=${uri##*/}   # strip path

--- a/lib/aur-fetch-snapshot
+++ b/lib/aur-fetch-snapshot
@@ -6,7 +6,7 @@ readonly startdir=$PWD
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
-log_dir=/dev/stdout
+log=stdout
 
 dl_stdin() {
     if type -P aria2c >/dev/null; then
@@ -37,24 +37,22 @@ trap_exit() {
 
 while getopts :L: opt; do
     case $opt in
-        L) log_dir=$OPTARG ;;
+        L) log_dir=$OPTARG
+           log=directory ;;
         *) usage ;;
     esac
 done
 shift $((OPTIND - 1))
 OPTIND=1
 
-if [[ -d $log_dir ]]; then
-    diff_log() { tee -a "$log_dir/$1".diff | diffstat -CKq -f3; }
-elif [[ $log_dir == /dev/stdout ]]; then
-    diff_log() { tee; }
-else
-    printf -- >&2 '%s: %q: not a directory or /dev/stdout\n' "$argv0" "$log_dir"
-    exit 1
-fi
-
 tmp=$(mktemp -dt "$argv0".XXXXXXXX)
 trap trap_exit EXIT
+
+# set filters
+case $log in
+    directory) diff_log() { tee -a "$log_dir/$1".diff | diffstat -Ckq -f3; } ;;
+       stdout) diff_log() { tee; } ;;
+esac
 
 cd "$tmp"
 dl_stdin
@@ -62,10 +60,11 @@ dl_stdin
 for a in ./*.tar.gz; do
     if [[ -f $a ]]; then
         tar -kxf "$a"
-        x=${a%%.tar.gz}
     else
         continue
     fi
+
+    x=${a%%.tar.gz}
 
     if tar_no_mode_diff "$a" "$startdir"; then
         diff -ur "$startdir/$x" "$x" | diff_log "$x"


### PR DESCRIPTION
This is achieved easily by adapting a polymorphic approach in aur-fetch,
as is done in other scripts.

Directory checks were moved from -git/-snapshot to the main script; if
no valid path is specified to tee -a, it will default to stdout (and
exit with an error).