### PR TITLE
 aur-sync: Allow reading package names from standard input 

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -88,7 +88,7 @@ trap_exit() {
 }
 
 usage() {
-    plain "usage: $argv0 [-ABcDfglLprstTu] [long options] [--] pkgname..."
+    plain "usage: $argv0 [-ABcDfglLprstTu] [long options] [--] pkgname... [-]"
     exit 1
 }
 
@@ -274,9 +274,12 @@ if ((list)); then
     exit
 fi
 
-{ if (($#)); then
-      printf -- '%s\n' "$@"
-  fi
+{ for arg in "$@"; do
+      case $arg in
+          -) cat ;;
+          *) printf -- '%s\n' "$arg" ;;
+      esac
+  done
 
   if ((update)); then
       aur vercmp <db_info | cut -d: -f1

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -13,6 +13,7 @@ aur\-sync \- download and build aur packages automatically
 .OP \-\-root
 .OP \-\-
 .IR pkgname ...
+.OP \-
 .YS
 
 .SH DESCRIPTION
@@ -86,6 +87,10 @@ Download AUR snapshots (\fIpkgbase.tar.gz\fR) and extract them with
 Do not view downloaded files before building.
 
 .SS Repository options
+.TP
+.B \-
+Read package names from standard input (newline-delimited, one per line).
+
 .TP
 .B \-\-list
 List repository contents in the JSON output format.


### PR DESCRIPTION
For when you want the latest commit of *everything*.