### PR TITLE
Create update-devel

### DIFF
--- a/contrib/update-devel
+++ b/contrib/update-devel
@@ -4,10 +4,9 @@ readonly XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 readonly AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/sync}
 readonly AURVCS=${AURVCS:-.*-(bzr|git|hg|svn)$}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-tmp=$(mktemp -d)
 
 db_tsv() {
-    jq '.[][] | [.pkgname, .pkgver] | @tsv'
+    jq -r '.[][] | [.pkgname, .pkgver] | @tsv'
 }
 
 db_join() {
@@ -18,8 +17,17 @@ ifne() {
     xargs -r "$@"
 }
 
-cd "$tmp"
+trap_exit() {
+    if [[ ! -o xtrace ]]; then
+        rm -rf "$tmp"
+    fi
+}
+
+tmp=$(mktemp -d)
+trap 'trap_exit' EXIT
+
 # get repo contents
+cd "$tmp"
 aur sync --list | db_tsv >db_info
 
 # checkout latest revision for existing pkgbuilds


### PR DESCRIPTION
This example script is based on `aur-sync` changes proposed in #283. 

It is a simple reuse of `aurutils` components, similar to the examples in `aur(1)`. As such it is part of a new `examples` directory. This directory could include other scripts such as `aur-remove` (#305) and `aur-gc` (#317).

To use a script from the examples directory, it may be either copied to or symlinked in a directory in `PATH`. A symlink should be preferable unless local changes to the file are prefered.
```
$ cp -s /usr/share/aurutils/examples/aur-update-devel /usr/local/bin
$ aur update-devel
```