### PR TITLE
contrib: Extract aur-vercmp-devel

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -3,6 +3,6 @@ The __contrib__ directory showcases use of various aurutils components, similar 
 To use a script with `aur(1)`, copy it to a directory in `PATH`. Alternatively, create a symbolic link if you have no local changes and always want to use the latest version.
 
 ```
-$ cp -s /usr/share/aurutils/contrib/aur-update-devel /usr/local/bin
-$ aur update-devel
+$ cp -s /usr/share/aurutils/contrib/aur-vercmp-devel /usr/local/bin
+$ aur vercmp-devel
 ```

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -6,3 +6,13 @@ To use a script with `aur(1)`, copy it to a directory in `PATH`. Alternatively, 
 $ cp -s /usr/share/aurutils/contrib/aur-vercmp-devel /usr/local/bin
 $ aur vercmp-devel
 ```
+
+You can build upon these scripts to fit your own workflow. For example, you can use `aur-vercmp-devel` to make a script that updates both regular and VCS packages:
+
+```
+#!/usr/bin/env bash
+
+# sync VCS packages that are outdated according to aur-vercmp-devel
+# sync all packages that are outdated according to AurJson (--upgrades)
+aur vercmp-devel "$@" | cut -d: -f1 | xargs -r aur sync --no-ver-shallow --upgrades "$@"
+```

--- a/contrib/aur-vercmp-devel
+++ b/contrib/aur-vercmp-devel
@@ -35,6 +35,5 @@ aur sync --list "$@" | db_tsv >db_info
 # this sources the pkgbuilds assuming they have been viewed priorly
 cut -f1 db_info | db_join "$AURVCS" "$AURDEST" | ifne aur srcver >vcs_info
 
-# sync VCS packages that are outdated according to aur-srcver
-# sync all packages that are outdated according to AurJson (--upgrades)
-aur vercmp -p vcs_info < db_info | cut -d: -f1 | ifne aur sync --no-ver-shallow --upgrades "$@"
+# find VCS packages that are outdated according to aur-srcver
+aur vercmp -p vcs_info <db_info


### PR DESCRIPTION
I realized that I would actually benefit more from having a script that _detects_ outdated VCS packages, and extracted it into `aur-vercmp-devel`. The `aur-update-devel` becomes a one-liner, I still find it useful, but I'm not sure if you are OK with keeping it in the contrib 🙂