### PR TITLE
aur-srcver: Handle errors with running parallel

### DIFF
--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -38,10 +38,7 @@ if ((!$#)); then
     usage
 fi
 
-if ! type -P parallel >/dev/null; then
-    printf >&2 '%s: "parallel" is not found in $PATH\n' "$argv0"
-    exit 1
-fi
+command -V parallel >/dev/null || exit
 
 # XXX trickery for hyphen and absolute path arguments
 mapfile -t arg_path < <(readlink -e -- "$@")
@@ -56,14 +53,14 @@ exitcode=$?
 
 if ((exitcode > 101)); then
     printf >&2 '%s: error running "parallel", exit code %d\n' "$argv0" "$exitcode"
-    exit $exitcode
+    exit "$exitcode"
 fi
 
 if ((exitcode > 0 )); then
     printf >&2 '%s: failed to update %s packages\n' "$argv0" "$exitcode"
 
-    while IFS=$'\t' read -r seq _ _ _ _ _ exitcode _ command; do
-        if ((!exitcode)); then
+    while IFS=$'\t' read -r seq _ _ _ _ _ jobexitcode _ command; do
+        if ((!jobexitcode)); then
             continue
         else
             printf >&2 '8<----\n'

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -70,6 +70,8 @@ if ((exitcode > 0 )); then
             cat "${seq}_makepkg.err" >&2
         fi
     done < makepkg_log
+
+    exit "$exitcode"
 fi
 
 find_pkgbuild_path "${arg_path[@]}" | while IFS= read -d $'\0' -r; do

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -38,6 +38,11 @@ if ((!$#)); then
     usage
 fi
 
+if ! type -P parallel >/dev/null; then
+    printf >&2 '%s: "parallel" is not found in $PATH\n' "$argv0"
+    exit 1
+fi
+
 # XXX trickery for hyphen and absolute path arguments
 mapfile -t arg_path < <(readlink -e -- "$@")
 
@@ -47,10 +52,15 @@ trap 'trap_exit' EXIT
 cd "$tmp" || exit
 parallel --will-cite --nice 10 -j +2 --joblog makepkg_log --results '{#}_makepkg' \
   'cd {}; makepkg --skipinteg --noprepare -od' >/dev/null 2>&1 ::: "${arg_path[@]}"
-num_failed=$?
+exitcode=$?
 
-if ((num_failed > 0 )); then
-    printf >&2 '%s: failed to update %s packages\n' "$argv0" "$num_failed"
+if ((exitcode > 101)); then
+    printf >&2 '%s: error running "parallel", exit code %d\n' "$argv0" "$exitcode"
+    exit $exitcode
+fi
+
+if ((exitcode > 0 )); then
+    printf >&2 '%s: failed to update %s packages\n' "$argv0" "$exitcode"
 
     while IFS=$'\t' read -r seq _ _ _ _ _ exitcode _ command; do
         if ((!exitcode)); then


### PR DESCRIPTION
Simple way to fix #380: print a message and exit if parallel exit code is >101.

Also adds a special check if `parallel` is not available, because it is a required tool and we want to be as clear about this as possible.

```
❯ lib/aur-srcver ~/.cache/aurutils/sync/*-git
srcver: "parallel" is not found in $PATH
```
