### PR TITLE
aur-depends: remove unrelated functionality

### DIFF
--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -1,27 +1,11 @@
 #!/bin/bash
 # aur-depends - retrieve package dependencies using AurJson
-set -o noclobber
 readonly argv0=depends
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-
-# default options
-mode=aur
+readonly max_request=30
 
 count() {
     jq -r '.resultcount' "$1" | awk '{s += $1} END {print s}'
-}
-
-sort_by() {
-    awk 'FNR == NR {
-        a[$1] = $0; next
-    } {
-        if($0 in a)
-            print a[$0]
-    }' "$@"
-}
-
-tr_ver() {
-    sed -r 's/[<>=].*$//g'
 }
 
 tabulate() {
@@ -29,9 +13,12 @@ tabulate() {
         | .Name         as $name
         | .PackageBase  as $base
         | .Version      as $ver
-        | .URLPath      as $url
         | ([$name] + .Depends + .MakeDepends + .CheckDepends)[]?
-        | [$name, ., $base, $ver, $url] | @tsv' "$1"
+        | [$name, ., $base, $ver] | @tsv' "$1"
+}
+
+tr_ver() {
+    sed -r 's/[<>=].*$//g'
 }
 
 chain() {
@@ -45,34 +32,33 @@ chain() {
         exit 1
     fi
 
-    for ((a = 1; a <= 30; ++a)); do
+    for ((a = 1; a <= max_request; ++a)); do
         sub=$((a-1))
-
         tabulate json/$sub | tee -a tsv/n > tsv/$sub
 
-        cut -f1 tsv/$sub >> pkgname
-        cut -f1 tsv/$sub >> seen
-
         # Avoid querying duplicates (#4)
-        cut -f2 tsv/$sub | tr_ver | grep -Fxvf seen | aur rpc -t info > json/$a || exit
+        cut -f1 tsv/$sub >> seen # pkgname
+        cut -f2 tsv/$sub | tr_ver | grep -Fxvf seen \
+            | aur rpc -t info > json/$a || exit # rpc error
 
         if [[ -s json/$a ]]; then
             num=$(count json/$a)
         else
-            break
+            cat tsv/n
+            return # no unique results
         fi
 
         if ((num >= 1)); then
-            cut -f2 tsv/$sub >> seen
+            cut -f2 tsv/$sub >> seen # depends
         else
-            break
+            cat tsv/n
+            return # no results, recursion complete
         fi
     done
 
-    if ((a > 30)); then
-        printf '%s: total requests: %d (out of range)\n' "$argv0" $((++a)) >&2
-        exit 34
-    fi
+    # recursion limit exceeded
+    printf >&2 '%s: total requests: %d (out of range)\n' "$argv0" "$a"
+    exit 34
 }
 
 trap_exit() {
@@ -82,41 +68,17 @@ trap_exit() {
 }
 
 usage() {
-    printf 'usage: %s [-at] pkgname...\n' "$argv0" >&2
+    printf 'usage: %s pkgname...\n' "$argv0" >&2
     exit 1
 }
-
-# XXX move modes, sort_by to aur-deps
-while getopts :at opt; do
-    case $opt in
-        a) mode=all ;;
-        t) mode=tab ;;
-        *) usage    ;;
-    esac
-done
-shift $((OPTIND - 1))
-OPTIND=1
 
 tmp=$(mktemp -dt "$argv0".XXXXXXXX) || exit
 trap 'trap_exit' EXIT
 
 if cd "$tmp" && mkdir json tsv; then
-    chain # tsv/n, pkgname
+    chain # tsv/n: pkgname\tdepends\tpkgbase\pkgver
 else
-    exit "$?"
+    exit
 fi
-
-if ! cut -f1,2 tsv/n | tr_ver | tsort > order; then
-    printf '%s: invalid argument\n' "$argv0" >&2
-    exit 22
-fi
-
-cut -f2 --complement tsv/n | sort -uk 1,1 > pkginfo
-
-case $mode in
-    aur) grep -Fxf pkgname order | tac ;;
-    all) tac order                     ;;
-    tab) tac order | sort_by pkginfo - ;;
-esac
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -10,7 +10,7 @@ readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 fetch_args=()
 
 # default options
-deps=0
+recurse=0
 mode=git
 
 usage() {
@@ -26,10 +26,10 @@ unset log_dir
 while getopts :rgtL: opt; do
     case $opt in
         L) log_dir=$OPTARG ;;
-        r) deps=1   ;;
-        g) mode=git ;;
-        t) mode=snapshot ;;
-        *) usage    ;;
+        r) recurse=1       ;;
+        g) mode=git        ;;
+        t) mode=snapshot   ;;
+        *) usage           ;;
     esac
 done
 shift $((OPTIND -1))
@@ -49,9 +49,10 @@ if [[ -v log_dir ]]; then
 fi
 
 # set filters (1)
-case $deps in
-    1) print_deps() { printf '%s\n' "$@" | aur depends; } ;;
-    0) print_deps() { printf '%s\n' "$@"; } ;;
+case $recurse in
+    # total order is not required, though output must be unique.
+    1) deps() { aur depends | cut -f3 | sort -u; } ;;
+    0) deps() { tee; } ;;
 esac
 
 # set filters (2)
@@ -61,6 +62,6 @@ case $mode in
 esac
 
 # pipeline
-print_deps "$@" | format | aur "fetch-$mode" "${fetch_args[@]}"
+printf '%s\n' "$@" | deps | format | aur "fetch-$mode" "${fetch_args[@]}"
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -1,6 +1,6 @@
 #!/bin/bash
 # aur-sync - download and build AUR packages automatically
-set -o errexit -o pipefail -o noclobber
+set -o errexit -o pipefail
 shopt -s nullglob
 readonly argv0=sync
 readonly XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
@@ -66,6 +66,7 @@ db_fill_empty() {
     }'
 }
 
+# fields: $1 pkgname, $2 pkgbase, $3 pkgver
 select_pkgbase() {
     awk 'NR == FNR {
             a[$0]; next
@@ -74,6 +75,11 @@ select_pkgbase() {
                 print $0; seen[$2]
             }
         }' "$@"
+}
+
+# fields: $1 pkgname, $2 depends[<>=]
+tr_ver() {
+    awk -F'[<>=]' '{print $1}'
 }
 
 complement() {
@@ -293,7 +299,7 @@ fi
 } >argv
 
 if [[ -s argv ]]; then
-    aur depends -t <argv >pkginfo
+    aur depends <argv | tee deps | cut -f2 --complement | sort -u >pkginfo
 else
     plain "there is nothing to do"
     exit
@@ -311,9 +317,9 @@ fi
   fi
 
   if ((chkver)); then
-      # packages with equal or newer versions are taken as complement for
-      # the queue. if chkver_deps_only is enabled, packages on the command-line
-      # are excluded from this complement.
+      # packages with equal or newer versions are taken as complement
+      # for the queue. if chkver_deps_only is enabled, packages on the
+      # command-line are excluded from this complement.
       cut -f1,3 pkginfo | aur vercmp -p db_info -c | chkver_argv
   fi
 
@@ -323,7 +329,7 @@ fi
   fi
 } >filter
 
-cut -f1 pkginfo | lib32 | complement filter >queue_0
+cut -f1,2 deps | tr_ver | tsort | tac | lib32 | complement filter >queue_0
 
 if [[ -s queue_0 ]]; then
     select_pkgbase queue_0 pkginfo | cut -f2 >queue

--- a/man1/aur-depends.1
+++ b/man1/aur-depends.1
@@ -1,34 +1,37 @@
-.TH AUR-DEPENDS 1 2018-02-01 AURUTILS
+.TH AUR-DEPENDS 1 2018-04-29 AURUTILS
 .SH NAME
-aur\-depends \- retrieve dependencies using the aur rpc
+aur\-depends \- retrieve dependencies using AurJson
 
 .SH SYNOPSIS
 .SY "aur depends"
-.OP \-at
 .YS
 
 .SH DESCRIPTION
 \fBaur-depends\fR takes package names from \fIstdin\fR, and solves
-and orders the dependencies for those packages using the AUR RPC
-interface.
+the dependencies for those packages using AurJson. The output is in
+the following format:
 
-.SH OPTIONS
-.TP
-.B \-a
-Print the full dependency tree instead of only AUR packages.
+\fIpkgname\\tdepends\\tpkgbase\\tpkgver\fR
 
-.TP
-.B \-t
-Copy retrieved JSON files to a specified directory.
+.SH EXAMPLES
+Retrieve the total dependency order for the \fIplasma-desktop-git\fR
+package:
+.EX
+
+  $ echo plasma-desktop-git | aur depends | cut -f1,2 | tsort | tac
+
+.EE
 
 .SH NOTES
 Version information is ignored for dependencies. See \fIFS#54096\fR.
 
+Unlike \fBaur-graph(1)\fR, dependencies are kept in \fBpkgname\fR
+form.
+
 .SH SEE ALSO
 .BR aur (1),
 .BR aur\-rpc (1),
-.BR jq (1),
-.BR tsort (1)
+.BR jq (1)
 
 .SH AUTHORS
 .MT https://github.com/AladW


### PR DESCRIPTION
To better reflect the name (and more generally, to reduce the scope of the tool), this
commit removes most processing of the retrieved dependency information from the AUR.
In particular, if a total order is required, this must be done manually through cut(1)
and tsort(1).

Usage in aur-fetch remains similar, apart that pkgbase must be used when retrieving
build files (this was an oversight when recursion was introduced with commit
3bd2fcbcacdb939cbc782a99702580db35cdc24b).

Adapting aur-sync(1) is a more challenging task, and is not fully covered by this
commit.