### PR TITLE
aur-graph: support versioned dependencies

### DIFF
--- a/lib/aur-graph
+++ b/lib/aur-graph
@@ -82,17 +82,18 @@ END {
         for (dep = 1; dep <= dep_counts[pkgbase]; dep++) {
             # warning: split: fourth argument is a gawk extension
             split(pkg_deps[pkgbase, dep], dep_split, "(<|<=|=|>|>=)", dep_op)
+            dep_pkgname = dep_split[1]
 
             # only print dependency if it was encountered before
-            if (!(dep_split[1] in pkg_map))
+            if (!(dep_pkgname in pkg_map))
                 continue
 
             # run vercmp with provider and versioned dependency
-            if (get_vercmp(ver_map[dep_split[1]], dep_split[2], dep_op[1])) {
-                printf("%s\t%s\n", pkgbase, pkg_map[dep_split[1]])
+            if (get_vercmp(ver_map[dep_pkgname], dep_split[2], dep_op[1])) {
+                printf("%s\t%s\n", pkgbase, pkg_map[dep_pkgname])
             } else {
                 printf("invalid node: %s %s (required: %s%s)\n",
-                       dep_split[1], ver_map[dep_split[1]], dep_op[1], dep_split[2]) > "/dev/stderr"
+                       dep_pkgname, ver_map[dep_pkgname], dep_op[1], dep_split[2]) > "/dev/stderr"
                 close("/dev/stderr")
 
                 # delay mismatches to loop end

--- a/lib/aur-graph
+++ b/lib/aur-graph
@@ -1,26 +1,57 @@
-#!/bin/awk -f
+#!/bin/gawk -f
 # aur-graph - print package/dependency pairs
 
-BEGIN {
-    FS="[<=>]"
+# < 0 : if ver1 < ver2
+# = 0 : if ver1 == ver2
+# > 0 : if ver1 > ver2
+function get_vercmp(ver1, ver2, op) {
+    command = ("vercmp " ver1 " " ver2)
+
+    if (op == "" || ver2 == "") {
+        return "true" # dependency is unversioned
+    } else if (op == "=") {
+        return (ver1 == ver2) # common case
+    } else if (op == "<") {
+        command | getline
+        close(command)
+        return ($1 < 0)
+    } else if (op == ">") {
+        command | getline
+        close(command)
+        return ($1 > 0)
+    } else if (op == "<=") {
+        command | getline
+        close(command)
+        return ($1 <= 0)
+    } else if (op == ">=") {
+        command | getline
+        close(command)
+        return ($1 >= 0)
+    } else {
+        printf("invalid operation\n") > "/dev/stderr"
+        exit 1
+    }
 }
 
 /pkgbase/ {
     in_split_pkg = 0
-    pkgbase = $2
+    pkgbase = $3
+    pkgver  = ""
 
     # track both the pkgbases themselves and their number of deps
-    dep_counts[pkgbase] = 0 
+    dep_counts[pkgbase] = 0
+}
+
+/^\tpkgver/ {
+    if (!in_split_pkg) {
+        pkgver = $3
+    }
 }
 
 /^\t(make|check)?depends/ {
-    if (!length(pkgbase)) {
-        print "pkgbase unavailable" > "/dev/stderr"
-        exit 1
-    }
     if (!in_split_pkg) {
         # POSIX array of arrays!
-        pkg_deps[pkgbase,++dep_counts[pkgbase]] = $2
+        pkg_deps[pkgbase, ++dep_counts[pkgbase]] = $3 # versioned
     }
 }
 
@@ -28,22 +59,48 @@ BEGIN {
     in_split_pkg = 1
 }
 
-/pkgname/ || /^\tprovides/ {
-    if (!length(pkgbase)) {
-        print "pkgbase unavailable" > "/dev/stderr"
-        exit 1
-    }
-    pkg_map[$2] = pkgbase
+/pkgname/ {
+    pkg_map[$3] = pkgbase # node
+    ver_map[$3] = pkgver  # weight
+}
+
+/^\tprovides/ {
+    split($3, prov, "=")
+
+    # if provider is unversioned, use pkgver
+    if ("2" in prov)
+        ver_map[prov[1]] = prov[2]
+    else
+        ver_map[prov[1]] = pkgver
+
+    # append node
+    pkg_map[prov[1]] = pkgbase
 }
 
 END {
     for (pkgbase in dep_counts) {
         for (dep = 1; dep <= dep_counts[pkgbase]; dep++) {
-            dep_pkgname = pkg_deps[pkgbase,dep]
+            # warning: split: fourth argument is a gawk extension
+            split(pkg_deps[pkgbase, dep], dep_split, "(<|<=|=|>|>=)", dep_op)
+
             # only print dependency if it was encountered before
-            if (dep_pkgname in pkg_map)
-                printf("%s\t%s\n", pkgbase, pkg_map[dep_pkgname])
+            if (!(dep_split[1] in pkg_map))
+                continue
+
+            # run vercmp with provider and versioned dependency
+            if (get_vercmp(ver_map[dep_split[1]], dep_split[2], dep_op[1])) {
+                printf("%s\t%s\n", pkgbase, pkg_map[dep_split[1]])
+            } else {
+                printf("invalid node: %s %s (required: %s%s)\n",
+                       dep_split[1], ver_map[dep_split[1]], dep_op[1], dep_split[2]) > "/dev/stderr"
+                close("/dev/stderr")
+
+                # delay mismatches to loop end
+                _vercmp_exit = 1
+            }
         }
     }
-}
 
+    if (_vercmp_exit)
+        exit _vercmp_exit
+}


### PR DESCRIPTION
Sparsity checks were removed for performance reasons. (`gawk --profile`)

Solves #10. After 2 years! :tada: