### PR TITLE
aur-sync: exclude $tmpview itself from `find` results

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -347,7 +347,7 @@ if ((view)); then
     elif type -P vifm >/dev/null; then
         find -L . -maxdepth 2 -mindepth 1 | vifm - '+view!'
     else
-        find -L . -maxdepth 2 -mindepth 1 | command -- ${PAGER:-less}
+        { printf '%s\n\n' "$tmp_view"; find -L . -maxdepth 2 -mindepth 1 -printf '%P\n'; } | command -- ${PAGER:-less}
     fi
 
     cd_safe -

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -345,9 +345,9 @@ if ((view)); then
     if [[ -v AUR_PAGER ]]; then
         command -- $AUR_PAGER
     elif type -P vifm >/dev/null; then
-        find -L -maxdepth 2 | vifm - '+view!'
+        find . -L -maxdepth 2 -mindepth 1 | vifm - '+view!'
     else
-        find -L -maxdepth 2 | command -- ${PAGER:-less}
+        find . -L -maxdepth 2 -mindepth 1 | command -- ${PAGER:-less}
     fi
 
     cd_safe -

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -347,7 +347,7 @@ if ((view)); then
     elif type -P vifm >/dev/null; then
         find -L . -maxdepth 2 -mindepth 1 | vifm - '+view!'
     else
-        find -L "$tmp_view" -maxdepth 2 -mindepth 1 | command -- ${PAGER:-less}
+        find -L "$tmp_view" -maxdepth 2 | command -- ${PAGER:-less}
     fi
 
     cd_safe -

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -345,9 +345,9 @@ if ((view)); then
     if [[ -v AUR_PAGER ]]; then
         command -- $AUR_PAGER
     elif type -P vifm >/dev/null; then
-        find . -L -maxdepth 2 -mindepth 1 | vifm - '+view!'
+        find -L . -maxdepth 2 -mindepth 1 | vifm - '+view!'
     else
-        find . -L -maxdepth 2 -mindepth 1 | command -- ${PAGER:-less}
+        find -L . -maxdepth 2 -mindepth 1 | command -- ${PAGER:-less}
     fi
 
     cd_safe -

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -347,7 +347,7 @@ if ((view)); then
     elif type -P vifm >/dev/null; then
         find -L . -maxdepth 2 -mindepth 1 | vifm - '+view!'
     else
-        { printf '%s\n\n' "$tmp_view"; find -L . -maxdepth 2 -mindepth 1 -printf '%P\n'; } | command -- ${PAGER:-less}
+        find -L "$tmp_view" -maxdepth 2 -mindepth 1 | command -- ${PAGER:-less}
     fi
 
     cd_safe -


### PR DESCRIPTION
- Exclude `.` from results of `find` (screenshots below)
- Specify `.` as the first argument for `find`, because shellcheck says not all implementations of `find` default to the current directory.

![aurutils-3](https://user-images.githubusercontent.com/1177900/39916177-11a058d4-550a-11e8-80c9-06248e1406c5.png)

--------------

`find -maxdepth 2 | vifm - '+view!'`

![aurutils-4](https://user-images.githubusercontent.com/1177900/39916288-4fbc3fde-550a-11e8-853c-c0f35de7e010.png)

`find -maxdepth 2 -mindepth 1 | vifm - '+view!'`

![aurutils-5](https://user-images.githubusercontent.com/1177900/39916294-54ca5bc8-550a-11e8-850c-4846f2444324.png)
