### PR TITLE
scripts: use util/parseopts.sh for option parsing

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -68,6 +68,7 @@ usage() {
 
 source /usr/share/makepkg/util/util.sh
 source /usr/share/makepkg/util/message.sh
+source /usr/share/makepkg/util/parseopts.sh
 
 if [[ -t 2 && ! -o xtrace ]]; then
     colorize
@@ -79,28 +80,35 @@ var_tmp=$(mktemp -d "${TMPDIR:-/var/tmp}/$argv0".XXXXXXXX)
 trap 'trap_exit' EXIT
 trap 'exit' INT
 
+opt_short='a:d:r:C:D:M:cfNRsv'
+opt_long=()
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
+
 unset database db_root queue
-while getopts a:d:r:C:D:M:cfNRsv opt; do
-    case $opt in
-        a) queue=$OPTARG    ;;
-        c) chroot=1         ;;
-        f) overwrite=1      ;;
-        N) no_sync=1        ;;
-        r) db_root=$OPTARG  ;;
-        d) database=$OPTARG
-           chroot_args+=(-d "$OPTARG") ;;
-        C) chroot_args+=(-C "$OPTARG") ;;
-        D) chroot_args+=(-D "$OPTARG") ;;
-        M) chroot_args+=(-M "$OPTARG") ;;
-        R) repo_add_args+=(-R) ;;
-        s) sign_pkg=1
-           repo_add_args+=(-s) ;;
-        v) repo_add_args+=(-v) ;;
-        *) usage ;;
+while true; do
+    case "$1" in
+        -a) shift; queue=$1 ;;
+        -c) chroot=1 ;;
+        -f) overwrite=1 ;;
+        -N) no_sync=1 ;;
+        -r) shift; db_root=$1 ;;
+        -d) shift; database=$1
+            chroot_args+=(-d "$1") ;;
+        -C) shift; chroot_args+=(-C "$1") ;;
+        -D) shift; chroot_args+=(-D "$1") ;;
+        -M) shift; chroot_args+=(-M "$1") ;;
+        -R) repo_add_args+=(-R) ;;
+        -s) sign_pkg=1
+            repo_add_args+=(-s) ;;
+        -v) repo_add_args+=(-v) ;;
+        --) shift; break ;;
     esac
+    shift
 done
-shift $((OPTIND - 1))
-OPTIND=1
+unset opt_short opt_long OPTRET
 
 if [[ ${database=$AUR_REPO} ]]; then
     server=$(pacconf --single --repo="$database" Server)

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -37,24 +37,33 @@ usage() {
     exit 1
 }
 
-tmp=$(mktemp -d)
-trap 'trap_exit' EXIT
+source /usr/share/makepkg/util/parseopts.sh
+
+opt_short='BPd:r:C:D:M:'
+opt_long=()
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
 
 # FIXME: add --sysroot to set pacconf host, see pacutils-sysroot(7)
 unset pacman_conf makepkg_conf host_repo server
-while getopts :BPd:r:C:D:M: opt; do
-    case $opt in
-        d) host_repo+=("$OPTARG") ;;
-        D) directory=$OPTARG    ;;
-        C) pacman_conf=$OPTARG  ;;
-        M) makepkg_conf=$OPTARG ;;
-        B) build=0   ;;
-        P) prepare=0 ;;
-        *) usage     ;;
+while true; do
+    case "$1" in
+        -d) shift; host_repo+=("$1") ;;
+        -D) shift; directory=$1 ;;
+        -C) shift; pacman_conf=$1 ;;
+        -M) shift; makepkg_conf=$1 ;;
+        -B) build=0 ;;
+        -P) prepare=0 ;;
+        --) shift; break ;;
     esac
+    shift
 done
-shift $((OPTIND - 1))
-OPTIND=1
+unset opt_short opt_long OPTRET
+
+tmp=$(mktemp -d)
+trap 'trap_exit' EXIT
 
 # reset default makechrootpkg arguments
 if (($#)); then

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -26,18 +26,27 @@ EOF
     exit 1
 }
 
+source /usr/share/makepkg/util/parseopts.sh
+
+opt_short='rgtL:'
+opt_long=()
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
+
 unset log_dir
-while getopts :rgtL: opt; do
-    case $opt in
-        L) log_dir=$OPTARG ;;
-        r) recurse=1       ;;
-        g) mode=git        ;;
-        t) mode=snapshot   ;;
-        *) usage           ;;
+while true; do
+    case "$1" in
+        -L) shift; log_dir=$1 ;;
+        -r) recurse=1 ;;
+        -g) mode=git ;;
+        -t) mode=snapshot ;;
+        --) shift; break ;;
     esac
+    shift
 done
-shift $((OPTIND -1))
-OPTIND=1
+unset opt_short opt_long OPTRET
 
 if ((!$#)); then
     usage

--- a/lib/aur-fetch-git
+++ b/lib/aur-fetch-git
@@ -36,15 +36,24 @@ usage() {
     exit 1
 }
 
-while getopts :L: opt; do
-    case $opt in
-        L) log_dir=$OPTARG
-           log=directory ;;
-        *) usage ;;
+source /usr/share/makepkg/util/parseopts.sh
+
+opt_short='L:'
+opt_long=()
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
+
+while true; do
+    case "$1" in
+        -L) shift; log_dir=$1
+            log=directory ;;
+        --) shift; break ;;
     esac
+    shift
 done
-shift $((OPTIND - 1))
-OPTIND=1
+unset opt_short opt_long OPTRET
 
 # set filters
 case $log in

--- a/lib/aur-fetch-snapshot
+++ b/lib/aur-fetch-snapshot
@@ -27,15 +27,24 @@ trap_exit() {
     fi
 }
 
-while getopts :L: opt; do
-    case $opt in
-        L) log_dir=$OPTARG
-           log=directory ;;
-        *) usage ;;
+source /usr/share/makepkg/util/parseopts.sh
+
+opt_short='L:'
+opt_long=()
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
+
+while true; do
+    case "$1" in
+        -L) shift; log_dir=$1
+            log=directory ;;
+        --) shift; break ;;
     esac
+    shift
 done
-shift $((OPTIND - 1))
-OPTIND=1
+unset opt_short opt_long OPTRET
 
 tmp=$(mktemp -dt "$argv0".XXXXXXXX)
 trap trap_exit EXIT

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -40,17 +40,26 @@ usage() {
 # default to any match
 pcre_opt=('.*')
 
-while getopts :btF:P: opt; do
-    case "$opt" in
-        b) pkglist=pkgbase                ;;
-        t) delay=$OPTARG                  ;;
-        F) pcre_opt=('-e' "$OPTARG" '-F') ;;
-        P) pcre_opt=('-e' "$OPTARG")      ;;
-        *) usage                          ;;
+source /usr/share/makepkg/util/parseopts.sh
+
+opt_short='btF:P:'
+opt_long=()
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
+
+while true; do
+    case "$1" in
+        -b) pkglist=pkgbase ;;
+        -t) shift; delay=$1 ;;
+        -F) shift; pcre_opt=('-e' "$1" '-F') ;;
+        -P) shift; pcre_opt=('-e' "$1") ;;
+        --) shift; break ;;
     esac
+    shift
 done
-shift $((OPTIND - 1))
-OPTIND=1
+unset opt_short opt_long OPTRET
 
 mkdir -p     "$cache"
 chmod -c 700 "$cache"

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -41,17 +41,25 @@ usage() {
 }
 
 source /usr/share/makepkg/util/message.sh
+source /usr/share/makepkg/util/parseopts.sh
+
+opt_short='od:'
+opt_long=()
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
 
 unset argv_repo reposet
-while getopts od: opt; do
-    case $opt in
-        d) argv_repo+=("$OPTARG") ;;
-        o) mode=arch ;;
-        *) usage     ;;
+while true; do
+    case "$1" in
+        -d) shift; argv_repo+=("$1") ;;
+        -o) mode=arch ;;
+        --) shift; break;;
     esac
+    shift
 done
-shift $((OPTIND - 1))
-OPTIND=1
+unset opt_short opt_long OPTRET
 
 if [[ -v argv_repo ]]; then
     for i in "${argv_repo[@]}"; do

--- a/lib/aur-rpc
+++ b/lib/aur-rpc
@@ -34,16 +34,25 @@ usage() {
     exit 1
 }
 
+source /usr/share/makepkg/util/parseopts.sh
+
+opt_short='b:t:'
+opt_long=()
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
+
 unset by type
-while getopts :b:t: opt; do
-    case $opt in
-        b) by=$OPTARG   ;;
-        t) type=$OPTARG ;;
-        *) usage        ;;
+while true; do
+    case "$1" in
+        -b) shift; by=$1 ;;
+        -t) shift; type=$1 ;;
+        --) shift; break ;;
     esac
+    shift
 done
-shift $((OPTIND - 1))
-OPTIND=1
+unset opt_short opt_long OPTRET
 
 tmp=$(mktemp -dt "$argv0".XXXXXXXX) || exit
 trap 'trap_exit' EXIT

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -104,23 +104,32 @@ if [[ -t 2 && ! -o xtrace ]]; then
     colorize
 fi
 
+source /usr/share/makepkg/util/parseopts.sh
+
+opt_short='aisdmnqvk:'
+opt_long=()
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
+
 unset format
-while getopts :aisdmnqvk: opt; do
-    case $opt in
-        a) multiple=union       ;;
-        i) query_type=info      ;;
-        s) query_type=search    ;;
-        d) search_by=name-desc  ;;
-        m) search_by=maintainer ;;
-        n) search_by=name       ;;
-        q) format=short         ;;
-        v) format=long          ;;
-        k) sort_key=$OPTARG     ;;
-        *) usage                ;;
+while true; do
+    case "$1" in
+        -a) multiple=union ;;
+        -i) query_type=info ;;
+        -s) query_type=search ;;
+        -d) search_by=name-desc ;;
+        -m) search_by=maintainer ;;
+        -n) search_by=name ;;
+        -q) format=short ;;
+        -v) format=long ;;
+        -k) shift; sort_key=$1 ;;
+        --) shift; break ;;
     esac
+    shift
 done
-shift $((OPTIND - 1))
-OPTIND=1
+unset opt_short opt_long OPTRET
 
 if ((!$#)); then
     usage

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -101,124 +101,70 @@ usage() {
 
 source /usr/share/makepkg/util/util.sh
 source /usr/share/makepkg/util/message.sh
+source /usr/share/makepkg/util/parseopts.sh
 
 if [[ -t 2 && ! -o xtrace ]]; then
     colorize
 fi
 
-if getopt -T || (($? != 4)); then
-    error "$argv0: util-linux getopt required"
-    exit 22
-fi
+opt_short='d:D:AcfglLnprstTu'
+opt_long=('allan' 'bind:' 'chroot' 'directory:' 'force' 'ignore:' 'ignorearch'
+          'ignore-arch' 'log' 'noconfirm' 'no-confirm' 'nover' 'no-ver' 'noview'
+          'no-view' 'print' 'rmdeps' 'rm-deps' 'sign' 'temp' 'tar' 'repo:'
+          'database:' 'root:' 'upgrades' 'nhehgvyf' 'continue' 'list' 'git'
+          'makepkg-conf:' 'pacman-conf:' 'provides' 'repo-list' 'nover-shallow'
+          'no-ver-shallow')
 
-longopts=allan,bind:,chroot,directory:,force,ignore:,ignorearch,ignore-arch,log
-longopts+=,noconfirm,no-confirm,nover,no-ver,noview,no-view,print,rmdeps,rm-deps
-longopts+=,sign,temp,tar,repo:,database:,root:,upgrades,nhehgvyf,continue,list,git
-longopts+=,makepkg-conf:,pacman-conf:,provides,repo-list,nover-shallow,no-ver-shallow
-shortopts=d:D:AcfglLnprstTu
-
-if optstring=$(getopt -o "$shortopts" -l "$longopts" -n "$argv0" -- "$@"); then
-    eval set -- "$optstring"
-else
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
     usage
 fi
-
-tmp=$(mktemp -dt "$argv0".XXXXXXXX)
-tmp_view=$(mktemp -dt view.XXXXXXXX)
-trap 'trap_exit' EXIT
+set -- "${OPTRET[@]}"
 
 unset pkg pkg_i root repo
 while true; do
     case "$1" in
-        -c|--chroot)
-            chroot=1
-            build_args+=(-c)
-            shift ;;
-        -f|--force)
-            build_args+=(-f)
-            shift ;;
-        -s|--sign)
-            build_args+=(-sv)
-            shift ;;
-        -D|--directory)
-            build_args+=(-D "$2")
-            shift 2 ;;
-        --makepkg-conf)
-            build_args+=(-M "$2")
-            shift 2 ;;
-        --pacman-conf)
-            build_args+=(-C "$2")
-            shift 2 ;;
-        --bind)
-            makechrootpkg_args+=(-D "$2")
-            shift 2 ;;
-        -T|--temp)
-            makechrootpkg_args+=(-T)
-            shift ;;
+        -c|--chroot)           chroot=1; build_args+=(-c) ;;
+        -f|--force)            build_args+=(-f) ;;
+        -s|--sign)             build_args+=(-sv) ;;
+        -D|--directory)        shift; build_args+=(-D "$1") ;;
+        --makepkg-conf)        shift; build_args+=(-M "$1") ;;
+        --pacman-conf)         shift; build_args+=(-C "$1") ;;
+        --bind)                shift; makechrootpkg_args+=(-D "$1") ;;
+        -T|--temp)             makechrootpkg_args+=(-T) ;;
         -A|--ignorearch|--ignore-arch)
-            makepkg_args+=(-A)
-            makechrootpkg_makepkg_args+=(-A)
-            shift ;;
-        -L|--log)
-            makepkg_args+=(-L)
-            shift ;;
+                               makepkg_args+=(-A);
+                               makechrootpkg_makepkg_args+=(-A) ;;
+        -L|--log)              makepkg_args+=(-L) ;;
         --noconfirm|--no-confirm)
-            makepkg_args+=(--noconfirm)
-            shift ;;
-        -l|--list)
-            list=1
-            shift ;;
-        --repo-list)
-            repo_list=1
-            shift ;;
-        -r|--rmdeps|--rm-deps)
-            makepkg_args+=(-r)
-            shift ;;
-        -p|--print)
-            build=0
-            shift ;;
-        -g|--git)
-            snapshot=0
-            shift ;;
-        -t|--tar)
-            snapshot=1
-            shift ;;
-        -u|--upgrades)
-            update=1
-            shift ;;
-        --allan|--nhehgvyf)
-            rotate=1
-            shift ;;
-        --continue)
-            download=0
-            shift ;;
-        --ignore)
-            IFS=, read -a pkg -r <<< "$2"
-            pkg_i+=("${pkg[@]}")
-            shift 2 ;;
-        --nover|--no-ver)
-            chkver=0
-            shift ;;
+                               makepkg_args+=(--noconfirm) ;;
+        -l|--list)             list=1 ;;
+        --repo-list)           repo_list=1 ;;
+        -r|--rmdeps|--rm-deps) makepkg_args+=(-r) ;;
+        -p|--print)            build=0 ;;
+        -g|--git)              snapshot=0 ;;
+        -t|--tar)              snapshot=1 ;;
+        -u|--upgrades)         update=1 ;;
+        --allan|--nhehgvyf)    rotate=1 ;;
+        --continue)            download=0 ;;
+        --ignore)              shift
+                               IFS=, read -a pkg -r <<< "$1"
+                               pkg_i+=("${pkg[@]}") ;;
+        --nover|--no-ver)      chkver=0 ;;
         --nover-shallow|--no-ver-shallow)
-            chkver_deps_only=1
-            shift ;;
-        --noview|--no-view)
-            view=0
-            shift ;;
-        --provides)
-            provides=1
-            shift ;;
-        -d|--database|--repo)
-            repo=$2
-            shift 2 ;;
-        --root)
-            root=$2
-            shift 2 ;;
-        *)
-            shift
-            break ;;
+                               chkver_deps_only=1 ;;
+        --noview|--no-view)    view=0 ;;
+        --provides)            provides=1 ;;
+        -d|--database|--repo)  shift; repo=$1 ;;
+        --root)                shift; root=$1 ;;
+        --)                    shift; break ;;
     esac
+    shift
 done
+unset opt_short opt_long OPTRET
+
+tmp=$(mktemp -dt "$argv0".XXXXXXXX)
+tmp_view=$(mktemp -dt view.XXXXXXXX)
+trap 'trap_exit' EXIT
 
 if ((rotate)); then
     if { hash rot13 && target=$(aur pkglist | shuf -n 1); } 2>/dev/null; then

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -84,26 +84,34 @@ usage() {
     exit 1
 }
 
-source /usr/share/makepkg/util/message.sh || exit
+source /usr/share/makepkg/util/message.sh
+source /usr/share/makepkg/util/parseopts.sh
 
 if [[ -t 2 && ! -o xtrace ]]; then
     colorize
 fi
 
+opt_short='acd:p:u:'
+opt_long=()
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
+
 unset all aux repo upair
-while getopts :acd:p:u: opt; do
-    case $opt in
-        a) all=1         ;;
-        c) format=equal  ;;
-        d) repo=$OPTARG  ;; # FIXME remove this? (#316)
-        p) target=file
-           aux=$OPTARG   ;;
-        u) upair=$OPTARG ;;
-        *) usage         ;;
+while true; do
+    case "$1" in
+        -a) all=1 ;;
+        -c) format=equal ;;
+        -d) shift; repo=$1 ;; # FIXME remove this? (#316)
+        -p) target=file
+            shift; aux=$1 ;;
+        -u) shift; upair=$1 ;;
+        --) shift; break ;;
     esac
+    shift
 done
-shift $((OPTIND - 1))
-OPTIND=1
+unset opt_short opt_long OPTRET
 
 tmp=$(mktemp) || exit
 trap 'trap_exit' EXIT


### PR DESCRIPTION
Pacman 5.1 provides a util script for option parsing that supports short
and long options.

In addition to provide easier to read options, this will also benefit
completion scripts that rely on parsing the output of `--help`.

--- 8< ---

I didn't have time to test this today, but wanted to put this out so we can have a dedicated place to discuss this.

134264b just converts existing use of `getopts` to `parseopts` without adding any extra functionality. Thus, `aur-{srcver,jobs,graph,depends}`<sup>1</sup> scripts remain without long option support.

I tried to follow the loop style used upstream where it uses a common `shift` for all options and the same line for the `pattern)` and `list ;;`. Saves a bunch of vertical space which makes it a bit nicer to read. But long `patterns)` kind mess up with the style<sup>2</sup>. (more evident on aur-sync for now)

Also kept just one space before the last command and `;;`. I always had mixed feelings about aligned `;;`, it looks prettier but adds noise to the history every time we need to adjust alignment.

Writing this I also noticed I have small inconsistencies on style. How strongly do you feel about this?

resolve before merging:
- [x] ~inconsistent quoting of `$1`~
- [x] ~add parseopts to scripts not covered by 134264b [1] (?)~
- [x] ~split long cases over multiple lines. [2] (?)~
  - ~split over multiple conditions and use cascading`;&`~
  - ~other or leave it as-is~