### PR TITLE
aur-search: Show popularity and tweak formatting

### DIFF
--- a/lib/aur-search
+++ b/lib/aur-search
@@ -72,9 +72,9 @@ parse_long() {
 }
 
 parse_short() {
-    local Name Version NumVotes Maintainer OutOfDate Description
+    local Name Version NumVotes Popularity Maintainer OutOfDate Description
 
-    while IFS=$'\t' read -r Name _ Version Description _ _ _ Maintainer NumVotes _ OutOfDate _; do
+    while IFS=$'\t' read -r Name _ Version Description _ _ _ Maintainer NumVotes Popularity OutOfDate _; do
         case $OutOfDate in
             -) unset OutOfDate ;;
             *) # FIXME move date command to jq (must only be run if OutOfDate is set)
@@ -86,8 +86,10 @@ parse_short() {
             *) unset Maintainer ;;
         esac
 
-        printf "${BLUE}aur/${ALL_OFF}${BOLD}%s ${GREEN}%s ${ALL_OFF}(%s) ${RED}%s%s${ALL_OFF}\\n    %s\\n" \
-               "$Name" "$Version" "$NumVotes" "$Maintainer" "$OutOfDate" "$Description"
+        printf -v Popularity "%.2f" "$Popularity"
+
+        printf "${BLUE}aur/${ALL_OFF}${BOLD}%s ${GREEN}%s ${ALL_OFF}(+%s %s%%) ${RED}%s%s${ALL_OFF}\\n    %s\\n" \
+               "$Name" "$Version" "$NumVotes" "$Popularity" "$Maintainer" "$OutOfDate" "$Description"
     done
 }
 


### PR DESCRIPTION
Votes are now prefixed with + and popularity is suffixed with %.
I tend to prefer this format as it clearly shows which number is which.

![image](https://user-images.githubusercontent.com/16593899/41208202-931f948a-6d18-11e8-8e8c-b86b023eabe3.png)
