### PR TITLE
aur-build: Update sudoers docs to not use localhost

### DIFF
--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -99,8 +99,8 @@ prompts, \fBsudoers\fR(5) can be used instead.
 For example:
 .EX
 
-  %build localhost = (root) NOPASSWD: SETENV: /usr/bin/makechrootpkg
-  %build localhost = (root) NOPASSWD: /usr/bin/mkarchroot, /usr/bin/arch-nspawn
+  %build ALL = (root) NOPASSWD: SETENV: /usr/bin/makechrootpkg
+  %build ALL = (root) NOPASSWD: /usr/bin/mkarchroot, /usr/bin/arch-nspawn
 
 .EE
 


### PR DESCRIPTION
I've been debugging an issue on some of my systems where `aursync` was still prompting for passwords when I was aiming for a hands-off build after reviewing AUR diffs. It turns out that specifying `localhost` in a `sudoers` config line _only_ applies in cases where the host's canonical hostname is actually "localhost". Here's a quote from `man sudoers`:

> Note that sudo only inspects actual network interfaces; this means that IP address 127.0.0.1 (localhost) will never match.  Also, the host name “localhost” will only match if that is the actual host name, which is usually only the case for non-networked systems.

In the absence of a more specific hostname value that could apply generally in the man pages, `ALL` seems like the next-best thing. It casts a wider net than (what we'd like to just be) `localhost`, but the case that the sudoers documentation mentions seems like it won't apply very often (a host literally named "localhost"). FWIW, making this change takes me from intermittent sudo prompts mid-build when running `aursync` to zero prompts, so the change appears to work from my perspective.

My guess is that this hasn't come up previously since perhaps folks are using the man page sudoers section as only general guidance; but at least for me, including the literal config lines that make it work as expected seems like a good way to go 👍 

Thank you for `aurutils`, it's by far the best-designed AUR helper I've had the pleasure to use!