### PR TITLE
Document -p for aur ver-cmp

### DIFF
--- a/man1/aur-vercmp.1
+++ b/man1/aur-vercmp.1
@@ -30,6 +30,12 @@ The name of a pacman repository. If \fInot\fR specified, packages and their
 versions are taken from stdin (tab-separated).
 
 .TP
+.B \-p
+Read package versions from a file instead of the AUR. The package list should
+be in the same format as stdin (\fIpkgname\fR as the first
+field, \fIpkgver\fR as the second, both separated by tabs).
+
+.TP
 .B \-q
 For all comparisons, show only package names.
 

--- a/man1/aur-vercmp.1
+++ b/man1/aur-vercmp.1
@@ -18,7 +18,7 @@ are not available in AUR are also shown.
 .TP
 .B \-c
 Takes packages and their versions from stdin (\fIpkgname\fR as the first
-field, \fIpkgver\fR as the second, both separated by tabs), printing
+field, \fIpkgver\fR as the second, space-separated), printing
 packages with equal or newer versions in a repository specified with
 \fB\-d\fR to stdout. If this argument or \fB\-d\fR is \fInot\fR
 specified, compare packages in the repository with their respective
@@ -27,13 +27,13 @@ versions in the AUR, and print updates to stdout.
 .TP
 .B \-d
 The name of a pacman repository. If \fInot\fR specified, packages and their
-versions are taken from stdin (tab-separated).
+versions are taken from stdin (space-separated).
 
 .TP
 .B \-p
 Read package versions from a file instead of the AUR. The package list should
 be in the same format as stdin (\fIpkgname\fR as the first
-field, \fIpkgver\fR as the second, both separated by tabs).
+field, \fIpkgver\fR as the second, space-separated).
 
 .TP
 .B \-q


### PR DESCRIPTION
I saw the `[-p path]` in the man page but it was never explained. Hopefully I got its usage right.