### PR TITLE
Preserve GNUPGHOME in aur-chroot

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -113,7 +113,7 @@ if ((prepare)); then
 fi
 
 if ((build)); then
-    sudo PKGDEST="${PKGDEST:-$PWD}" makechrootpkg -r "$directory" \
+    sudo --preserve-env=GNUPGHOME,PKGDEST makechrootpkg -r "$directory" \
          "${makechrootpkg_bindmounts_ro[@]}" "${makechrootpkg_args[@]}"
 else
     printf >&2 'container path: %q\n' "$directory"


### PR DESCRIPTION
Closes #426. I added `env` inside `sudo` because that's what makechrootpkg does, not sure if it’s necessary.