### PR TITLE
Follow proper man punctuation standards

### DIFF
--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -25,8 +25,8 @@ All arguments after \-\- are passed to \fBmakepkg\fR(8), or
 
 .TP
 .BI "\-a " queue
-A text file with directories containing a PKGBUILD. If none is
-specified, the current directory is assumed.
+A text file with directories containing a PKGBUILD.
+If none is specified, the current directory is assumed.
 
 .TP
 .B \-c
@@ -39,8 +39,8 @@ The name of the pacman database.
 .TP
 .B \-f
 Continue the build process if a package with the same name is found
-(ignoring the extension). Existing packages will be moved with a
-\fI~\fR suffix.
+(ignoring the extension).
+Existing packages will be moved with a \fI~\fR suffix.
 
 .TP
 .B \-N
@@ -48,15 +48,16 @@ Do not sync the local repository after building.
 
 .TP
 .BI "\-r " root
-The root for the repository. The \fIroot\fR is the location for the
-pacman database (\fIfoo.db\fR), built packages, and secondary files
-such as the files database (\fIfoo.files\fR). This defaults to the
-\fIServer\fR value of the configured repository.
+The root for the repository.
+The \fIroot\fR is the location for the pacman database (\fIfoo.db\fR),
+built packages, and secondary files such as the files database
+(\fIfoo.files\fR).
+This defaults to the \fIServer\fR value of the configured repository.
 
-.SY Note:
+.SY Note :
 The \fIServer\fR value configured in \fBpacman.conf\fR is used for
-\fBpacman\fR sync operations regardless of this setting. See also
-\fB\-N\fR.
+\fBpacman\fR sync operations regardless of this setting.
+See also \fB\-N\fR.
 
 .TP
 .B \-R
@@ -66,35 +67,37 @@ database (\fBrepo\-add \-R\fR).
 .TP
 .B \-s
 Sign built packages and the database (\fBrepo\-add \-s\fR) with
-\fBgpg\fR(1).  To use another key than the default, the \fBGPGKEY\fR
-environment variable can be set to the appopriate key identifier.
+\fBgpg\fR(1).
+To use another key than the default, the \fBGPGKEY\fR environment
+variable can be set to the appopriate key identifier.
 
 .TP
 .B \-v
-Verify the PGP signature of the database before
-updating. (\fBrepo\-add \-v\fR).
+Verify the PGP signature of the database before updating.
+(\fBrepo\-add \-v\fR).
 
 .SH NOTES
 When building locally (outside a container), \fBpacman \-Syu\fR is run
-while restricted to a local repository. This is comparable to
-\fBmakepkg \-i\fR, but without subsequent package installation (if a
-package was installed before, it is updated to the latest available
-version). An interesting side-effect is that pacman considers packages
-inside the official repositories "local", and warns if they are newer
-than any custom counterpart. Packages which define a \fIreplaces\fR
-field are ignored if the target package is installed on the local
-system.
+while restricted to a local repository.
+This is comparable to \fBmakepkg \-i\fR, but without subsequent
+package installation (if a package was installed before, it is updated
+to the latest available version).
+An interesting side-effect is that pacman considers packages inside
+the official repositories "local", and warns if they are newer than
+any custom counterpart.
+Packages which define a \fIreplaces\fR field are ignored if the target
+package is installed on the local system.
 
 Databases are built with \fBLANG=C\fR to avoid libalpm from skipping
-entries if the locale is not set (FS#49342). Packages are signed
-manually with \fBgpg \-\-batch \-\-detach\-sign \-\-no\-armor\fR
-(FS#49946).
+entries if the locale is not set (FS#49342).
+Packages are signed manually with \fBgpg \-\-batch \-\-detach\-sign
+\-\-no\-armor\fR (FS#49946).
 
 .SS Avoiding password prompts
 \fBmakepkg\fR(8) must be run as a regular user as of version 4.2, with
-privileged operations done via \fBsudo\fR(8). As such,
-\fBaur\-build\fR(1) can not be run directly as root. To avoid password
-prompts, \fBsudoers\fR(5) can be used instead.
+privileged operations done via \fBsudo\fR(8).
+As such, \fBaur\-build\fR(1) can not be run directly as root.
+To avoid password prompts, \fBsudoers\fR(5) can be used instead.
 
 For example:
 .EX
@@ -104,19 +107,19 @@ For example:
 
 .EE
 
-.SY Note:
-If the rule should only apply to certain hosts, replace \fBALL\fR with 
+.SY Note :
+If the rule should only apply to certain hosts, replace \fBALL\fR with
 the respective \fIhostname\fR.
 
 .SH SEE ALSO
-.BR aur (1),
-.BR aur\-chroot (1),
-.BR pacconf (1),
-.BR pacman (1),
-.BR makepkg.conf (5),
-.BR pacman.conf (5),
-.BR makepkg (8),
-.BR repo-add (8),
+.BR aur (1) ,
+.BR aur\-chroot (1) ,
+.BR pacconf (1) ,
+.BR pacman (1) ,
+.BR makepkg.conf (5) ,
+.BR pacman.conf (5) ,
+.BR makepkg (8) ,
+.BR repo-add (8) ,
 .BR setarch (8)
 
 .SH AUTHORS

--- a/man1/aur-chroot.1
+++ b/man1/aur-chroot.1
@@ -23,26 +23,28 @@ All arguments after \-\- are passed to \fBmakechrootpkg\fR.
 
 .TP
 .BI "\-D " directory
-The base directory for containers. This directory usually contains a
-\fB/root\fR subdirectory that serves as template for user containers
-(named after \fI$SUDO_USER\fR, or \fB/copy\fR if unset).
+The base directory for containers.
+This directory usually contains a \fB/root\fR subdirectory that serves
+as template for user containers (named after \fI$SUDO_USER\fR, or
+\fB/copy\fR if unset).
 
-.SY Note:
+.SY Note :
 If the \fB\-T\fR parameter is specified to \fBmakechrootpkg\fR, the
 user container has a random name and is removed on build completion.
 
 .TP
 .BI "\-C " pacman_conf
-The \fIpacman.conf\fR file to be used in the container. Defaults to
-\fIpacman-extra.conf\fR from devtools. This file is processed with
-\fBpacconf\fR(1) to include necessary information from the host, such
-as mirrors. If a local repository name is specified with \fB\-d\fR,
-its configuration is appended to this file.
+The \fIpacman.conf\fR file to be used in the container.
+Defaults to \fIpacman-extra.conf\fR from devtools.
+This file is processed with \fBpacconf\fR(1) to include necessary
+information from the host, such as mirrors.
+If a local repository name is specified with \fB\-d\fR, its
+configuration is appended to this file.
 
 .TP
 .BI "\-M " makepkg_conf
-The makepkg.conf file to be used in the container. Defaults to
-\fImakepkg\-<machine>.conf\fR from devtools.
+The makepkg.conf file to be used in the container.
+Defaults to \fImakepkg\-<machine>.conf\fR from devtools.
 
 .TP
 .B \-B
@@ -55,14 +57,14 @@ Build a package, to not update the container.
 
 .TP
 .B \-d
-The used local repository in the container, see \fB\-C\fR. The first
-\fBServer\fR directive starting in \fBfile://\fR is bind mounted
-(read-only) in the container.
+The used local repository in the container, see \fB\-C\fR.
+The first \fBServer\fR directive starting in \fBfile://\fR is bind
+mounted (read-only) in the container.
 
 .SH ENVIRONMENT
-Packages are placed in the directory specified in \fBPKGDEST\fR. If
-not set, the current directory (\fI$PWD\fR) is used. See also
-\fBmakepkg.conf\fR(5).
+Packages are placed in the directory specified in \fBPKGDEST\fR.
+If not set, the current directory (\fI$PWD\fR) is used.
+See also \fBmakepkg.conf\fR(5).
 
 .B AUR_REPO
 .RS
@@ -72,8 +74,9 @@ The default local repository, see \fB\-\fR.
 .SH NOTES
 .SS Building with \fBmakechrootpkg\fR
 Changes to the pacman database are \fInot\fR propagated from the
-container to the local system. Packages must be installed and updated
-separately, typically through \fBpacman \-Syu \fIpackage_name\fR.
+container to the local system.
+Packages must be installed and updated separately, typically through
+\fBpacman \-Syu \fIpackage_name\fR.
 
 Package conflicts inside the container must be solved manually, as
 \fBmakechrootpkg\fR uses \fBmakepkg \-\-confirm \-s\fR internally.
@@ -83,25 +86,26 @@ root.
 
 .SS Building for a different architecture
 To build packages for a different architecture, prepend \fBsetarch
-\fIarch\fR to the aurbuild command line. The target architecture must
-both be supported by the current system (run \fBsetarch \-\-list\fR
-for an approximation) and have a respective \fImakepkg.conf\fR file
-available in \fI/usr/share/devtools\fR (such as
+\fIarch\fR to the aurbuild command line.
+The target architecture must both be supported by the current system
+(run \fBsetarch \-\-list\fR for an approximation) and have a respective
+\fImakepkg.conf\fR file available in \fI/usr/share/devtools\fR (such as
 \fI/usr/share/devtools/makepkg\-i686.conf\fR for \fIi686\fR).
 
 .SS Accessing the local repository
 To install packages from the local repository (for example, on
 dependency resolution with \fImakepkg \-s\fR), the container requires
 at least read-only access to the host directory where it is
-located. This is ensured through a \fIbind mount\fR.
+located.
+This is ensured through a \fIbind mount\fR.
 
 .SH SEE ALSO
-.BR aur (1),
-.BR aur\-build (1),
-.BR pacconf (1),
-.BR pacman (1),
-.BR makepkg.conf (5),
-.BR pacman.conf (5),
+.BR aur (1) ,
+.BR aur\-build (1) ,
+.BR pacconf (1) ,
+.BR pacman (1) ,
+.BR makepkg.conf (5) ,
+.BR pacman.conf (5) ,
 .BR setarch (8)
 
 .SH AUTHORS

--- a/man1/aur-depends.1
+++ b/man1/aur-depends.1
@@ -8,8 +8,8 @@ aur\-depends \- retrieve dependencies using AurJson
 
 .SH DESCRIPTION
 \fBaur-depends\fR takes package names from \fIstdin\fR, and solves
-the dependencies for those packages using AurJson. The output is in
-the following format:
+the dependencies for those packages using AurJson.
+The output is in the following format:
 
 \fIpkgname\\tdepends\\tpkgbase\\tpkgver\fR
 
@@ -23,14 +23,14 @@ package:
 .EE
 
 .SH NOTES
-Version information is ignored for dependencies. See \fIFS#54096\fR.
+Version information is ignored for dependencies.
+See \fIFS#54096\fR.
 
-Unlike \fBaur-graph(1)\fR, dependencies are kept in \fBpkgname\fR
-form.
+Unlike \fBaur-graph(1)\fR, dependencies are kept in \fBpkgname\fR form.
 
 .SH SEE ALSO
-.BR aur (1),
-.BR aur\-rpc (1),
+.BR aur (1) ,
+.BR aur\-rpc (1) ,
 .BR jq (1)
 
 .SH AUTHORS

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -12,8 +12,8 @@ aur\-fetch \- fetches packages from a location
 
 .SH DESCRIPTION
 \fBaur\-fetch\fR accepts URIs to packages from stdin, and attempts to
-download them. It's capable of handling \fItar\fR archives and \fIgit\fR
-repositories.
+download them.
+It's capable of handling \fItar\fR archives and \fIgit\fR repositories.
 
 .SH OPTIONS
 .TP
@@ -34,8 +34,8 @@ Downloads the package as a \fIgit\fR repository with \fBaur\-fetch\-git\fR.
 Download both packages and their dependencies with \fBaur-deps-rpc\fR(1).
 
 .SH SEE ALSO
-.BR git (1),
-.BR tar (1),
+.BR git (1) ,
+.BR tar (1) ,
 .BR aur (1)
 
 .SH AUTHORS

--- a/man1/aur-graph.1
+++ b/man1/aur-graph.1
@@ -8,13 +8,14 @@ aur\-graph \- package/dependency directed graph
 
 .SH DESCRIPTION
 \fBaur-graph\fR takes package information from \fB.SRCINFO\fR files
-and prints them as \fIpkgbase<TAB>dependency\fR pairs. Any
-dependencies are converted from \fBpkgname\fR to \fBpkgbase\fR or
+and prints them as \fIpkgbase<TAB>dependency\fR pairs.
+Any dependencies are converted from \fBpkgname\fR to \fBpkgbase\fR or
 skipped if absent from the input.
 
 .SH EXAMPLES
 The paired output is suitable as input for \fBtsort(1)\fR, provided no
-cycles are present. For example:
+cycles are present.
+For example:
 .EX
 
   cd ~/.cache/aurutils/sync
@@ -30,9 +31,9 @@ performance:
 
 .EE
 
-\fBprovides\fR and versioned dependencies are fully supported. This
-can be used to verify dependency chains from \fBaur-depends\fR(1). For
-example:
+\fBprovides\fR and versioned dependencies are fully supported.
+This can be used to verify dependency chains from \fBaur-depends\fR(1).
+For example:
 .EX
 
   aur sync --print <package> | xargs printf '%s/.SRCINFO\n' | xargs aur graph

--- a/man1/aur-pkglist.1
+++ b/man1/aur-pkglist.1
@@ -9,9 +9,10 @@ aur\-pkglist \- print the AUR packagelist
 .YS
 
 .SH DESCRIPTION
-\fBaur\-pkglist\fR prints the list of \fIpkgname\fRs that are available in the
-AUR to standard output. Optionally a pattern can be specified that is
-matched with \fBpcregrep\fR(1).
+\fBaur\-pkglist\fR prints the list of \fIpkgname\fRs that are available
+in the AUR to standard output.
+Optionally a pattern can be specified that is matched with
+\fBpcregrep\fR(1).
 
 This list is available at:
 .UR https://aur.archlinux.org/packages.gz
@@ -38,10 +39,11 @@ Interpret the given pattern as a Perl-compatible regular expression
 (PCRE).
 
 .SH NOTES
-To avoid retrieving the package list on every query, \fBaur\-pkglist\fR uses a
-caching logic which stores the list together with its timestamp in
-\fI$XDG_CACHE_HOME/aur\-pkglist\fR. New lists are generated every 5 minutes,
-thus setting a lower interval with \fB\-t\fR yields no benefit.
+To avoid retrieving the package list on every query, \fBaur\-pkglist\fR
+uses a caching logic which stores the list together with its timestamp
+in \fI$XDG_CACHE_HOME/aur\-pkglist\fR.
+New lists are generated every 5 minutes, thus setting a lower interval
+with \fB\-t\fR yields no benefit.
 
 See also:
 
@@ -50,9 +52,9 @@ See also:
 .UE
 
 .SH SEE ALSO
-.BR aur (1),
-.BR gzip (1),
-.BR pcregrep (1),
+.BR aur (1) ,
+.BR gzip (1) ,
+.BR pcregrep (1) ,
 .BR wget (1)
 
 .SH AUTHORS

--- a/man1/aur-repo-filter.1
+++ b/man1/aur-repo-filter.1
@@ -11,14 +11,14 @@ aur\-repo\-filter \- filter packages in the Arch Linux repositories
 .SH DESCRIPTION
 \fBaur\-repo\-filter\fR checks if \fIpkgname\fR (provided on
 \fIstdin\fR) is in the official Arch Linux repositories, and print it to
-\fIstdout\fR if not. Virtual packages, when found, are solved and
-printed to stderr.
+\fIstdout\fR if not.
+Virtual packages, when found, are solved and printed to stderr.
 
 .SH OPTIONS
 .TP
 .BI "\-d " database
-Check a given repository instead of those from Arch Linux. Multiple
-repositories can be specified by repeating \fB\-d\fR.
+Check a given repository instead of those from Arch Linux.
+Multiple repositories can be specified by repeating \fB\-d\fR.
 
 .TP
 .BI "\-o"
@@ -26,9 +26,9 @@ Use the JSON interface for the official repositories to query
 packages.
 
 .SH SEE ALSO
-.BR aur (1),
-.BR expac (1),
-.BR jq (1),
+.BR aur (1) ,
+.BR expac (1) ,
+.BR jq (1) ,
 .BR pacsift (1)
 
 .SH AUTHORS

--- a/man1/aur-rpc.1
+++ b/man1/aur-rpc.1
@@ -17,7 +17,7 @@ As the AUR RPC is limited to GET requests, queries are split by 150
 arguments to avoid HTTP 414 errors (\fIFS#49089\fR).
 
 .SH SEE ALSO
-.BR aria2c (1),
+.BR aria2c (1) ,
 .BR wget (1)
 
 .SH AUTHORS

--- a/man1/aur-search.1
+++ b/man1/aur-search.1
@@ -10,10 +10,10 @@ aur\-search \- search for AUR package
 .YS
 
 .SH DESCRIPTION
-\fBaur\-search\fR searches the AUR by multiple strings of packages. The
-union of all results is returned. By default, searches are performed
-by name and description using the \fIsearchby\fR interface, and
-displayed in a brief format.
+\fBaur\-search\fR searches the AUR by multiple strings of packages.
+The union of all results is returned.
+By default, searches are performed by name and description using the
+\fIsearchby\fR interface, and displayed in a brief format.
 
 .SH OPTIONS
 
@@ -52,8 +52,8 @@ Possible choices are \fIName\fR, \fIVersion\fR, \fINumVotes\fR,
 \fIFirstSubmitted\fR, \fILastModified\fR (for \fB-v\fR verbose output).
 
 .SH SEE ALSO
-.BR aur (1),
-.BR aur\-rpc (1),
+.BR aur (1) ,
+.BR aur\-rpc (1) ,
 .BR jq (1)
 
 .SH AUTHORS

--- a/man1/aur-srcver.1
+++ b/man1/aur-srcver.1
@@ -9,14 +9,16 @@ aur\-srcver \- lists version of VCS packages
 
 .SH DESCRIPTION
 \fBaur\-srcver\fR takes the names of packages and lists the current
-\fIpkgver\fR of VCS packages. This is achieved by running \fBmakepkg
-\-\-skipinteg \-\-noprepare \-od\fR and parsing the output.
+\fIpkgver\fR of VCS packages.
+This is achieved by running \fBmakepkg \-\-skipinteg \-\-noprepare
+\-od\fR and parsing the output.
 
 It is assumed that source directories are already available, and that
-\fBaur\-srcver\fR is used in the same directory as those source directories.
+\fBaur\-srcver\fR is used in the same directory as those source
+directories.
 
 .SH SEE ALSO
-.BR makepkg (1),
+.BR makepkg (1) ,
 .BR aur (1)
 
 .SH AUTHORS

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -19,23 +19,27 @@ aur\-sync \- download and build aur packages automatically
 
 .SH DESCRIPTION
 \fBaur\-sync\fR downloads and builds packages automatically to a local
-repository. Package names serve as arguments.
+repository.
+Package names serve as arguments.
 
 If \fBvifm\fR(1) is installed, the downloaded files are shown using vifm
-and can be edited. If not, the files are shown in \fBless\fR(1), or
-\fI$PAGER\fR if configured.
+and can be edited.
+If not, the files are shown in \fBless\fR(1), or \fI$PAGER\fR if
+configured.
 
 .SH OPTIONS
 .SS Build options
 .TP
 .BR \-f ", " \-\-force
 Continue the build process if a package with the same name exists
-already. (\fBaur build \-f\fR)
+already.
+(\fBaur build \-f\fR)
 
 .TP
 .B \-\-ignore=\fIPACKAGE\fR
-Ignore a package upgrade. Multiple packages can be specified by
-separating them with a comma, or by repeating the \fB\-\-ignore\fR option.
+Ignore a package upgrade.
+Multiple packages can be specified by separating them with a comma, or
+by repeating the \fB\-\-ignore\fR option.
 
 .TP
 .BR \-\-nover ", " \-\-no\-ver
@@ -44,8 +48,8 @@ Disable version checking for packages in the queue.
 .TP
 .BR \-\-nover\-shallow ", " \-\-no\-ver\-shallow
 Disable version checking for packages specified on the command line or
-upgrade candidates from \-\-upgrades. Version checks for dependencies
-remain enabled.
+upgrade candidates from \-\-upgrades.
+Version checks for dependencies remain enabled.
 
 .TP
 .BR \-p ", " \-\-print
@@ -53,27 +57,30 @@ Print target packages and their paths instead of building them.
 
 .TP
 .BR \-s ", " \-\-sign
-Sign built packages and verify the database with gpg. (\fBaur build \-sv\fR)
+Sign built packages and verify the database with gpg.
+(\fBaur build \-sv\fR)
 
 .SS Container options
 .TP
 .BR \-c ", " \-\-chroot
-Build packages with makechrootpkg. (\fBaur build \-c\fR)
+Build packages with makechrootpkg.
+(\fBaur build \-c\fR)
 
 .TP
 .BR \-\-pacman\-conf=\fIFILE\fR
-Set the \fIpacman.conf\fR file to be used in the container. (\fBaur
-build \-C\fR)
+Set the \fIpacman.conf\fR file to be used in the container.
+(\fBaur build \-C\fR)
 .RE
 
 .TP
 .BR \-\-makepkg\-conf=\fIFILE\fR
-Set the \fImakepkg.conf\fR file to be used in the container. (\fBaur
-build \-M\fR)
+Set the \fImakepkg.conf\fR file to be used in the container.
+(\fBaur build \-M\fR)
 
 .TP
 .BR "\-D \fIDIR\fR" ", " \-\-directory=\fIDIR\fR
-Set the container path to \fIDIR\fR. (\fBaur build \-D\fR)
+Set the container path to \fIDIR\fR.
+(\fBaur build \-D\fR)
 
 .SS Download options
 .TP
@@ -110,22 +117,24 @@ file paths.
 .TP
 .B \-\-provides
 Take virtual dependencies (\fBprovides\fR) in the local repository into
-account. Packages specified on the command line or available upgrades
-are considered regardless of this setting.
+account.
+Packages specified on the command line or available upgrades are
+considered regardless of this setting.
 
 Note: Ensure the local repository is propagated to \fBpacman\fR(8)
 before using this option, for example with \fBpacsync\fR(1).
 
 .TP
 .B \-d \fINAME\fR ", " \-\-database=\fINAME\fR ", " \-\-repo=\fINAME\fR
-Use the \fINAME\fR repository. If this option is not specified,
-\fBaur\-sync\fR defaults to the first \fIfile://\fR repository in
-\fBpacman.conf\fR(5), or aborts if multiple are available.
+Use the \fINAME\fR repository.
+If this option is not specified, \fBaur\-sync\fR defaults to the first
+\fIfile://\fR repository in \fBpacman.conf\fR(5), or aborts if multiple
+are available.
 
 .TP
 .B \-\-root=\fIDIR\fR
-The location of the repository root. Defaults to the \fIServer\fR
-value of the configured repository.
+The location of the repository root.
+Defaults to the \fIServer\fR value of the configured repository.
 
 .TP
 .BR \-u ", " \-\-upgrades
@@ -141,37 +150,44 @@ Ignore a missing or incomplete \fIarch\fR field in the build script.
 
 .TP
 .BR \-L ", " \-\-log
-Enable logging to a text file in the build directory. (\fBmakepkg
-\-L\fR)
+Enable logging to a text file in the build directory.
+(\fBmakepkg \-L\fR)
 
 .TP
 .BR \-\-noconfirm ", " \-\-no\-confirm
-Do not wait for user input. (\fBmakepkg \-\-noconfirm\fR)
+Do not wait for user input.
+(\fBmakepkg \-\-noconfirm\fR)
 
 .TP
 .BR \-r ", " \-\-rmdeps
-Remove dependencies installed by makepkg. (\fBmakepkg \-r\fR)
+Remove dependencies installed by makepkg.
+(\fBmakepkg \-r\fR)
 
 .SS makechrootpkg
-The default set of options is \fBmakechrootpkg \-cu\fR. For more information 
+The default set of options is \fBmakechrootpkg \-cu\fR.
+For more information 
 about building in containers, see \fBaur\-chroot\fR(1).
 
 .TP
 .B \-\-bind=\fIDIR\fR
-Bind a directory read-only. (\fBmakechrootpkg \-D\fR)
+Bind a directory read-only.
+(\fBmakechrootpkg \-D\fR)
 
 .TP
 .B \-\-bind-rw=\fIDIR\fR
-Bind a directory read-write. (\fBmakechrootpkg \-d\fR)
+Bind a directory read-write.
+(\fBmakechrootpkg \-d\fR)
 
 .TP
 .BR \-T ", " \-\-temp
-Build in a temporary container. (\fBmakechrootpkg \-T\fR)
+Build in a temporary container.
+(\fBmakechrootpkg \-T\fR)
 
 .SH ENVIRONMENT
 .B AURDEST
 .RS
-Determines where build files will be cloned. This must be an absolute path.
+Determines where build files will be cloned.
+This must be an absolute path.
 
 Default: \fI$XDG_CACHE_HOME/aurutils/sync\fR
 .RE
@@ -179,49 +195,54 @@ Default: \fI$XDG_CACHE_HOME/aurutils/sync\fR
 .B AURDEST_SNAPSHOT
 .RS
 Determines where build files will be copied when using snapshots
-(\fBaur sync \-t\fR). This must be an absolute path.
+(\fBaur sync \-t\fR).
+This must be an absolute path.
 
 Default: \fI$XDG_CACHE_HOME/aurutils/snapshot\fR
 .RE
 
 .B AUR_PAGER
 .RS
-The file manager used to view and edit build files. This variable is
+The file manager used to view and edit build files.
+This variable is
 split on white space, allowing \fIAUR_PAGER="program -option"\fR.
 .RE
 
 .B AUR_REPO
 .RS
-The repository used for building packages. The entry must be a valid
-\fBfile://\fR repository configured in \fBpacman.conf\fR(5).
+The repository used for building packages.
+The entry must be a valid \fBfile://\fR repository configured in
+\fBpacman.conf\fR(5).
 .RE
 
 .SH NOTES
 When version checks are enabled (\fB\-\-no\-ver\fR is not specified),
 build files are only retrieved if the remote (RPC) version is newer
-than a version in the pacman database. Checks assume there are no
-mismatches between \fB.SRCINFO\fR and \fBPKGBUILD\fR files.
+than a version in the pacman database.
+Checks assume there are no mismatches between \fB.SRCINFO\fR and
+\fBPKGBUILD\fR files.
 
 Architecture-specific depends (as introduced with pacman 4.2) are
-merged with regular depends in RPC queries. \fBaur\-sync\fR works around
-this by stripping the \fIlib32\-\fR prefix from packages and removing
-\fIgcc\-multilib\fR if the i686 architecture is detected.
+merged with regular depends in RPC queries.
+\fBaur\-sync\fR works around this by stripping the \fIlib32\-\fR prefix
+from packages and removing \fIgcc\-multilib\fR if the i686 architecture
+is detected.
 
 \fItar\fR snapshots are extracted to the \fI$AURDEST_SNAPSHOT\fR
 directory, in order to avoid conflicts with \fBgit\fR(1).
 
 .SH SEE ALSO
-.BR aur (1),
-.BR aur\-build (1),
-.BR aur\-fetch (1),
-.BR aur\-rpc (1),
-.BR aur\-repo\-filter (1),
-.BR aur\-deps\-rpc (1),
-.BR aur\-updates (1),
-.BR jq (1),
-.BR less (1),
-.BR pacconf (1),
-.BR vifm (1),
+.BR aur (1) ,
+.BR aur\-build (1) ,
+.BR aur\-fetch (1) ,
+.BR aur\-rpc (1) ,
+.BR aur\-repo\-filter (1) ,
+.BR aur\-deps\-rpc (1) ,
+.BR aur\-updates (1) ,
+.BR jq (1) ,
+.BR less (1) ,
+.BR pacconf (1) ,
+.BR vifm (1) ,
 .BR pacman.conf (5)
 
 .SH AUTHORS

--- a/man1/aur-vercmp.1
+++ b/man1/aur-vercmp.1
@@ -12,38 +12,41 @@ aur\-vercmp \- check packages for AUR updates
 .TP
 .B \-a
 If \fB-c\fR is \fInot\fR specified, this option also shows packages with
-older or the same version in the AUR. If specified twice, packages that
-are not available in AUR are also shown.
+older or the same version in the AUR.
+If specified twice, packages that are not available in AUR are also
+shown.
 
 .TP
 .B \-c
 Takes packages and their versions from stdin (\fIpkgname\fR as the first
 field, \fIpkgver\fR as the second, space-separated), printing
 packages with equal or newer versions in a repository specified with
-\fB\-d\fR to stdout. If this argument or \fB\-d\fR is \fInot\fR
-specified, compare packages in the repository with their respective
-versions in the AUR, and print updates to stdout.
+\fB\-d\fR to stdout.
+If this argument or \fB\-d\fR is \fInot\fR specified, compare packages
+in the repository with their respective versions in the AUR, and print
+updates to stdout.
 
 .TP
 .B \-d
-The name of a pacman repository. If \fInot\fR specified, packages and their
-versions are taken from stdin (space-separated).
+The name of a pacman repository.
+If \fInot\fR specified, packages and their versions are taken from stdin
+(space-separated).
 
 .TP
 .B \-p
-Read package versions from a file instead of the AUR. The package list should
-be in the same format as stdin (\fIpkgname\fR as the first
-field, \fIpkgver\fR as the second, space-separated).
+Read package versions from a file instead of the AUR.
+The package list should be in the same format as stdin (\fIpkgname\fR as
+the first field, \fIpkgver\fR as the second, space-separated).
 
 .TP
 .B \-q
 For all comparisons, show only package names.
 
 .SH SEE ALSO
-.BR aur (1),
-.BR aur\-rpc (1),
-.BR jq (1),
-.BR pacman (1),
+.BR aur (1) ,
+.BR aur\-rpc (1) ,
+.BR jq (1) ,
+.BR pacman (1) ,
 .BR vercmp (1)
 
 .SH AUTHORS

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -126,13 +126,14 @@ Synchronize pacman:
   $ sudo pacman -Syu
 
 .EE
-.SY Note:
+.SY Note :
 It is recommended to use a pacman cache directory (\fBCacheDir\fR) as
-the package pool. This avoids checksum mismatches between built
-packages and any cached versions.
+the package pool.
+This avoids checksum mismatches between built packages and any cached
+versions.
 .YS
 
-.SY Tip:
+.SY Tip :
 Consider separate repositories for different purposes, such as
 version control packages.
 .YS
@@ -142,16 +143,17 @@ If built packages are available, follow the instructions in
 \fBCreating a local repository\fR and move the packages to the new
 location.
 
-Missing packages may be recreated from system files. Before doing so,
-it is recommended to check for mismatches between the pacman database
-and the local filesystem:
+Missing packages may be recreated from system files.
+Before doing so, it is recommended to check for mismatches between the
+pacman database and the local filesystem:
 .EX
 
   $ pacman -Qqm | paccheck --md5sum --quiet
 
 .EE
 If mismatches occur, consider rebuilding the respective
-packages. Otherwise, recreate the packages with \fBbacman\fR:
+packages.
+Otherwise, recreate the packages with \fBbacman\fR:
 .EX
 
   $ pacman -Qqm | xargs -L1 bacman
@@ -250,8 +252,9 @@ Check foreign packages for AUR updates:
 
 .EE
 Repository packages can be "made foreign" by temporarily removing the
-repository from the pacman configuration. This can be used with programs
-that only check foreign packages for AUR updates.
+repository from the pacman configuration.
+This can be used with programs that only check foreign packages for AUR
+updates.
 
 For example, create the following script in
 \fI/usr/local/bin/mypacman\fR:

--- a/man7/aurhosting.7
+++ b/man7/aurhosting.7
@@ -6,12 +6,12 @@ aurhosting \- host pacman repositories using git
 .SH ADVANTAGES
 .SS Atomic changesets
 
-Each revision can be viewed as a single set of packages. This provides
-a way for every commit to be an atomic operation allowing for mirrors
-to synchronise consistently. Each mirror can then make a shallow
-clone of the repository while still only recovering changed packages
-reducing bandwidth while maintaining atomicity without additional
-scripting or tooling.
+Each revision can be viewed as a single set of packages.
+This provides a way for every commit to be an atomic operation allowing
+for mirrors to synchronise consistently.
+Each mirror can then make a shallow clone of the repository while still
+only recovering changed packages reducing bandwidth while maintaining
+atomicity without additional scripting or tooling.
 
 .SS Changeset based roll back
 


### PR DESCRIPTION
Reformat man page sources to follow end of sentence, end of line and spaces between punctuation and words on macro lines. Lines have also been reflowed to be at or under 72 characters per line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aladw/aurutils/430)
<!-- Reviewable:end -->
