### PR TITLE
aur-chroot: auto distcc/ccache

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -92,6 +92,15 @@ makepkg_conf=${makepkg_conf-/usr/share/devtools/makepkg-$machine.conf}
 
 # CacheDir will be replaced by devtools (#416)
 pacman-conf | host_with_cache "${host_repo[@]}" >"$tmp"/custom.conf
+# parse the makepkg.conf for buildenv dependencies
+readonly makepkg_conf_buildenv_deps=$(
+    deps_array=()
+    source ${makepkg_conf}
+    source /usr/share/makepkg/util/option.sh;
+    check_buildenv "ccache" "y" && deps_array+=("ccache")
+    check_buildenv "distcc" "y" && deps_array+=("distcc")
+    echo ${deps_array[@]}
+)
 
 # bind mount all file:// paths to container (#461)
 while read -r key _ value; do
@@ -118,7 +127,7 @@ if ((prepare)); then
         fi
 
         sudo mkarchroot -C "$tmp"/pacman.conf -M "$makepkg_conf" \
-             "$directory"/root base-devel
+             "$directory"/root base-devel ${makepkg_conf_buildenv_deps[@]}
     fi
 fi
 

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -119,7 +119,8 @@ if ((prepare)); then
     if [[ -f $directory/root/.arch-chroot ]]; then
         # locking is done by systemd-nspawn
         sudo arch-nspawn -C "$tmp"/pacman.conf -M "$makepkg_conf" \
-             "$directory"/root "${bindmounts_ro[@]}" pacman -Syu --noconfirm
+             "$directory"/root "${bindmounts_ro[@]}" \
+              pacman -Syu --noconfirm ${makepkg_conf_buildenv_deps[@]}
     else
         # parent path is not created by mkarchroot (#371)
         if [[ ! -d $directory ]]; then


### PR DESCRIPTION
### Autodetect ccache/distcc in aur-chroot
Slick an simple, using `check_buildenv` function from option.sh@pacman. 
- enter subshell
- - source `makepkg.conf`
- - source `option.sh@mapkepkg`
- - call `check_buildenv` for ccache and distcc
- store package names in `makepkg_conf_buildenv_deps` variable
- append `makepkg_conf_buildenv_deps` to `pacman` invocation in `prepare` section.
resolves #369 #334