### PR TITLE
aur-repo-filter: pass --repo=... to pacsift

### DIFF
--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -52,9 +52,9 @@ tmp=$(mktemp) || exit
 if ((sync_repo)); then
     reposet=(--sync)
 elif [[ -v argv_repo ]]; then
-    reposet=("${argv_repo[@]}")
+    reposet=("${argv_repo[@]/#/--repo=}")
 else
-    reposet=("${arch_repo[@]}")
+    reposet=("${arch_repo[@]/#/--repo=}")
 fi
 
 declare -A pkgset


### PR DESCRIPTION
If --repo=reponame is not passed to pacsift, then it won't filter to match
$reposet and will output 'local/pkgname' which then yields an expac
'package not found' error.