### PR TITLE
aur-build: fix a bug in find_pkg_dupes()

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -36,7 +36,7 @@ find_pkg_dupes() {
     # This function uses the extended --packagelist introduced with
     # pacman 5.1. It assumes that PKGEXT does not change between
     # invoking --packagelist and makepkg in the later build process.
-    makepkg --packagelist | xargs basename -a | xargs -I{} find "$1" -maxdepth 1 -name '{}'
+    makepkg --packagelist | xargs -I{} basename -a '{}' | xargs -I{} find "$1" -maxdepth 1 -name '{}'
 }
 
 print_quoted() {

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -36,7 +36,7 @@ find_pkg_dupes() {
     # This function uses the extended --packagelist introduced with
     # pacman 5.1. It assumes that PKGEXT does not change between
     # invoking --packagelist and makepkg in the later build process.
-    makepkg --packagelist | xargs -I{} find "$1" -maxdepth 1 -name '{}'
+    makepkg --packagelist | xargs basename -a | xargs -I{} find "$1" -maxdepth 1 -name '{}'
 }
 
 print_quoted() {


### PR DESCRIPTION
Indeed `makepkg --packagelist` returns the absolute name of the package,
so the find afterwards won't find it even if it exists. Add a
`| xargs basename -a` missing between the `makepakage
--packagelist` and the `find`.