### PR TITLE
aur-chroot: A local repo without a file:// entry is not an error

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -80,7 +80,8 @@ done > "$tmp"/custom.conf
 
 for repo in "${host_repo[@]}"; do
     # FIXME: custom.conf may contain multiple file:// entries per local repo
-    server=$(get_file_server "$repo" "$tmp"/custom.conf | grep -Em1 '^file://')
+    # the '|| true' is to not exit when no file servers are available
+    server=$(get_file_server "$repo" "$tmp"/custom.conf | grep -Em1 '^file://' || true)
     server=${server#file://}
 
     # arch-nspawn only supports specifying a single CacheDir via -c


### PR DESCRIPTION
`aur sync -c -d foo -r foo_db_path` will call `aur chroot -d foo`, and
if the repo 'foo' does not have a corresponding 'file://' entry in
pacman.conf, then the grep -Em1 fails which exit the script.

But this is not an error, it just means that the corresponding directory
won't be bind_mounted. So desactivate 'errexit' for this case.