### PR TITLE
aur-sync: --list should not clear AUR_VIEWDIR

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -224,14 +224,6 @@ if ! [[ -w $root/$repo.db && -r $root/$repo.db ]]; then
     exit 13
 fi
 
-# reset state of view directory
-if [[ -d $AUR_VIEWDIR ]]; then
-    find "$AUR_VIEWDIR" \( -type l \
-         -or -name '*.patch' -or -name '*.diff' \) -delete
-else
-    mkdir -p "$AUR_VIEWDIR"
-fi
-
 if ((snapshot)); then
     aur_workdir=$AURDEST_SNAPSHOT
     fetch_args=(-L "$AUR_VIEWDIR" -t)
@@ -254,6 +246,14 @@ if ((list)); then
     done <db_info
 
     exit
+fi
+
+# reset state of view directory
+if [[ -d $AUR_VIEWDIR ]]; then
+    find "$AUR_VIEWDIR" \( -type l \
+         -or -name '*.patch' -or -name '*.diff' \) -delete
+else
+    mkdir -p "$AUR_VIEWDIR"
 fi
 
 { if (($#)); then
@@ -314,7 +314,7 @@ fi
 
 if ((download)); then
     msg "Retrieving package files"
-    
+
     aur jobs -Xj +3 --nice 10 --halt soon,fail=1 \
         aur fetch "${fetch_args[@]}" :::: "$tmp"/queue
 fi


### PR DESCRIPTION
I'm still not 100% sure that having a global state was a good idea (e.g. what if you run `aur sync somepkg` in parallel in two terminals?), but at least `aur sync --list` should not clear this shared folder. 

I use `aur sync --list` in a script that runs periodically to be notified of new updates, and I was very surprised when out of the blue vifm got cleared while I was reviewing PKGBUILD 😄 