### PR TITLE
[wip] factorise db handling and add `aur repolist`

### DIFF
--- a/aur.in
+++ b/aur.in
@@ -23,6 +23,7 @@ if [[ -z $1 ]]; then
 fi
 
 readonly PATH=$lib_dir:$PATH
+export AURUTILS_LIB=$lib_dir
 
 if type -P "aur-$1" >/dev/null; then
     exec "aur-$1" "${@:2}"

--- a/contrib/vercmp-devel
+++ b/contrib/vercmp-devel
@@ -21,7 +21,7 @@ trap 'rm -rf "$tmp"' EXIT
 cd_safe "$tmp"
 
 # get repo contents
-aur sync --list "$@" | cut -f2,3 >db_info
+aur repolist "$@" >db_info
 
 # checkout latest revision for existing pkgbuilds
 # this sources the pkgbuilds assuming they have been viewed priorly

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -46,8 +46,8 @@ usage() {
 }
 
 source /usr/share/makepkg/util/util.sh
-source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
+source $AURUTILS_LIB/db_helper.sh
 
 if [[ -t 2 && ! -o xtrace ]]; then
     colorize
@@ -66,15 +66,15 @@ if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset database db_root queue
+unset queue
 while true; do
     case "$1" in
         -a) shift; queue=$1 ;;
         -c) chroot=1 ;;
         -f) overwrite=1 ;;
         -N) no_sync=1 ;;
-        -r) shift; db_root=$1 ;;
-        -d) shift; database=$1
+        -r) shift; AUR_DBROOT=$1 ;;
+        -d) shift; AUR_REPO=$1
             chroot_args+=(-d "$1") ;;
         -C) shift; chroot_args+=(-C "$1") ;;
         -D) shift; chroot_args+=(-D "$1") ;;
@@ -89,16 +89,9 @@ while true; do
 done
 unset opt_short opt_long OPTRET
 
-if [[ ${database=$AUR_REPO} ]]; then
-    server=$(pacconf --single --repo="$database" Server)
-    server=${server#*//}
-else
-    error "$argv0: database: missing argument"
-    usage
-fi
-
-db_root=$(realpath -e -- "${db_root-${AUR_DBROOT-$server}}")
-db_path=$(realpath -e -- "${db_root}/$database.db") # .db symbolic link to archive
+get_db
+db_root=$(realpath -e -- "${AUR_DBROOT}")
+db_path=$(realpath -e -- "${AUR_DBROOT}/$AUR_REPO.db") # .db symbolic link to archive
 
 if ! [[ -r $db_path && -w $db_path ]]; then
     error "$argv0: $db_path: permission denied"
@@ -130,7 +123,7 @@ if ((sign_pkg)); then
         gpg_args+=(-u "$GPGKEY")
     fi
 else
-    db_sigs=("$db_root/$database"{,.files}.sig)
+    db_sigs=("$db_root/$AUR_REPO"{,.files}.sig)
 
     if [[ -f ${db_sigs[0]} ]]; then
         # avoid errors from stale db.sig files
@@ -144,7 +137,7 @@ fi
 if ((chroot)); then
     aur chroot --nobuild "${chroot_args[@]}"
 else
-    conf_repo "$database" >"$tmp"/custom.conf
+    conf_repo "$AUR_REPO" >"$tmp"/custom.conf
 fi
 
 while IFS= read -ru "$fd" path; do

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -90,8 +90,8 @@ done
 unset opt_short opt_long OPTRET
 
 get_db
-db_root=$(realpath -e -- "${AUR_DBROOT}")
-db_path=$(realpath -e -- "${AUR_DBROOT}/$AUR_REPO.db") # .db symbolic link to archive
+db_root=$(realpath -e -- "$AUR_DBROOT")
+db_path=$(realpath -e -- "$AUR_DBROOT/$AUR_REPO.db") # .db symbolic link to archive
 
 if ! [[ -r $db_path && -w $db_path ]]; then
     error "$argv0: $db_path: permission denied"

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -80,7 +80,8 @@ done > "$tmp"/custom.conf
 
 for repo in "${host_repo[@]}"; do
     # FIXME: custom.conf may contain multiple file:// entries per local repo
-    server=$(get_file_server "$repo" "$tmp"/custom.conf | grep -Em1 '^file://')
+    # the '|| true' is to not exit when no file servers are available
+    server=$(get_file_server "$repo" "$tmp"/custom.conf | grep -Em1 '^file://' || true)
     server=${server#file://}
 
     # arch-nspawn only supports specifying a single CacheDir via -c

--- a/lib/aur-repolist
+++ b/lib/aur-repolist
@@ -1,0 +1,65 @@
+#!/bin/bash
+# aur-repolist - list packages from a repo
+set -o errexit -o pipefail
+shopt -s nullglob
+shopt -s extglob
+readonly argv0=sync
+
+db_namever() {
+    awk '/%NAME%/ {
+        getline
+        printf("%s\t", $1)
+    }
+    /%VERSION%/ {
+        getline
+        printf("%s\n", $1)
+    }'
+}
+
+db_fill_empty() {
+    awk '{print} END {
+        if (!NR)
+            printf("%s\t%s\n", "(none)", "(none)")
+    }'
+}
+
+parse_sync() {
+    # https://git.archlinux.org/pacman.git/commit/?id=ab3d8478
+    pacsift --exact --null --repo "$1" <&- \
+        | xargs -0r pacman -Sddp --print-format '%n %v'
+}
+
+usage() {
+    plain "usage: $argv0 -d database"
+    exit 1
+}
+
+source /usr/share/makepkg/util/parseopts.sh
+source $AURUTILS_LIB/db_helper.sh
+
+if [[ -t 2 && ! -o xtrace ]]; then
+    colorize
+fi
+
+opt_short='d:l:'
+opt_long=('database:' 'local:' 'repo:' 'root:')
+
+if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
+
+while true; do
+    case "$1" in
+        -d|--repo|--database) shift; AUR_REPO=$1 ;;
+        -l|--local)           shift; local_repo=$1 ;;
+        --root)               shift; AUR_DBROOT=$1 ;;
+        --)                   shift; break ;;
+    esac
+    shift
+done
+unset opt_short opt_long OPTRET
+
+get_db
+db_path=$(realpath -e -- "${AUR_DBROOT}/$AUR_REPO.db") # .db symbolic link to archive
+bsdcat "$db_path" | db_namever | db_fill_empty

--- a/lib/aur-repolist
+++ b/lib/aur-repolist
@@ -53,6 +53,12 @@ if [[ -v local_repo ]]; then
     exit $?
 fi
 
-get_db
-db_path=$(realpath -e -- "$AUR_DBROOT/$AUR_REPO.db") # .db symbolic link to archive
-cat_db "$db_path"
+if (($#)); then
+    for file in "$@"; do
+        cat_db $file
+    done
+else
+    get_db
+    db_path=$(realpath -e -- "$AUR_DBROOT/$AUR_REPO.db") # .db symbolic link to archive
+    cat_db "$db_path"
+fi

--- a/lib/aur-repolist
+++ b/lib/aur-repolist
@@ -5,6 +5,7 @@ shopt -s nullglob
 shopt -s extglob
 readonly argv0=sync
 
+<<<<<<< HEAD
 db_namever() {
     awk '/%NAME%/ {
         getline
@@ -29,6 +30,8 @@ parse_sync() {
         | xargs -0r pacman -Sddp --print-format '%n %v'
 }
 
+=======
+>>>>>>> f72452c... aur-sync + aur-repolist: factorise cat_db
 usage() {
     plain "usage: $argv0 -d database"
     exit 1
@@ -60,6 +63,5 @@ while true; do
 done
 unset opt_short opt_long OPTRET
 
-get_db
-db_path=$(realpath -e -- "${AUR_DBROOT}/$AUR_REPO.db") # .db symbolic link to archive
-bsdcat "$db_path" | db_namever | db_fill_empty
+db_path=$(realpath -e -- "$AUR_DBROOT/$AUR_REPO.db") # .db symbolic link to archive
+cat_db "$db_path"

--- a/lib/aur-repolist
+++ b/lib/aur-repolist
@@ -5,23 +5,9 @@ shopt -s nullglob
 shopt -s extglob
 readonly argv0=sync
 
-<<<<<<< HEAD
-db_namever() {
-    awk '/%NAME%/ {
-        getline
-        printf("%s\t", $1)
-    }
-    /%VERSION%/ {
-        getline
-        printf("%s\n", $1)
-    }'
-}
-
-db_fill_empty() {
-    awk '{print} END {
-        if (!NR)
-            printf("%s\t%s\n", "(none)", "(none)")
-    }'
+check_sync() {
+    # https://github.com/andrewgregory/pacutils/issues/22
+    pacconf --repo="$1" >/dev/null || exit 1
 }
 
 parse_sync() {
@@ -30,8 +16,6 @@ parse_sync() {
         | xargs -0r pacman -Sddp --print-format '%n %v'
 }
 
-=======
->>>>>>> f72452c... aur-sync + aur-repolist: factorise cat_db
 usage() {
     plain "usage: $argv0 -d database"
     exit 1
@@ -63,5 +47,12 @@ while true; do
 done
 unset opt_short opt_long OPTRET
 
+if [[ -v local_repo ]]; then
+    check_sync "$repo"
+    parse_sync "$local_repo"
+    exit $?
+fi
+
+get_db
 db_path=$(realpath -e -- "$AUR_DBROOT/$AUR_REPO.db") # .db symbolic link to archive
 cat_db "$db_path"

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -41,24 +41,6 @@ conf_file_repo() {
         }'
 }
 
-db_namever() {
-    awk '/%NAME%/ {
-        getline
-        printf("%s\t", $1)
-    }
-    /%VERSION%/ {
-        getline
-        printf("%s\n", $1)
-    }'
-}
-
-db_fill_empty() {
-    awk '{print} END {
-        if (!NR)
-            printf("%s\t%s\n", "(none)", "(none)")
-    }'
-}
-
 # files: $1 pkgname\tpkgbase $2 pkgname (order by $2)
 select_pkgbase() {
     awk 'NR == FNR {

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -184,13 +184,7 @@ if ! (($# + update + list)); then
 fi
 
 msg "Using [$AUR_REPO] repository"
-db_root=$(realpath -e -- "${AUR_DBROOT}")
-db_path=$(realpath -e -- "${AUR_DBROOT}/$AUR_REPO.db") # .db symbolic link to archive
-
-if ! [[ -w $db_path && -r $db_path ]]; then
-    error "$argv0: $AUR_REPO: permission denied (read-write)"
-    exit 13
-fi
+db_path=$(realpath -e -- "$AUR_DBROOT/$AUR_REPO.db") # .db symbolic link to archive
 
 if ((snapshot)); then
     aur_workdir=$AURDEST_SNAPSHOT
@@ -206,7 +200,7 @@ chmod -c 700 "$aur_workdir"
 cd_safe "$tmp"
 
 # parse repo contents
-bsdcat "$db_path" | db_namever | db_fill_empty >db_info
+cat_db "$db_path" > db_info
 
 if ((list)); then
     while read -r pkgname pkgver; do

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -109,8 +109,8 @@ usage() {
 }
 
 source /usr/share/makepkg/util/util.sh
-source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
+source $AURUTILS_LIB/db_helper.sh
 
 if [[ -t 2 && ! -o xtrace ]]; then
     colorize
@@ -130,10 +130,10 @@ if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset pkg pkg_i root repo
+unset pkg pkg_i
 while true; do
     case "$1" in
-        -d|--repo|--database) shift; repo=$1 ;;
+        -d|--repo|--database) shift; AUR_REPO=$1 ;;
         -D|--directory)       shift; build_args+=(-D "$1") ;;
         --bind)               shift; makechrootpkg_args+=(-D "$1") ;;
         --bind-rw)            shift; makechrootpkg_args+=(-d "$1") ;;
@@ -141,7 +141,7 @@ while true; do
                               pkg_i+=("${pkg[@]}") ;;
         --makepkg-conf)       shift; build_args+=(-M "$1") ;;
         --pacman-conf)        shift; build_args+=(-C "$1") ;;
-        --root)               shift; root=$1 ;;
+        --root)               shift; AUR_DBROOT=$1 ;;
         -A|--ignore?(-)arch)  makepkg_args+=(-A)
                               makechrootpkg_makepkg_args+=(-A) ;;
         -c|--chroot)          chroot=1; build_args+=(-c) ;;
@@ -194,33 +194,19 @@ if ((!keep_deps)); then
     makepkg_args+=(-r)
 fi
 
-if [[ ${repo=$AUR_REPO} ]]; then
-    server=$(pacconf --single --repo="$repo" Server)
-    server=${server#*://}
-else
-    mapfile -t conf < <(pacconf | conf_file_repo)
-
-    case ${#conf[@]} in
-        2) repo=${conf[0]}
-           root=${conf[1]#*://} ;;
-        0) error "$argv0: no file:// repository found"
-           exit 2 ;;
-        *) error "$argv0: repository choice is ambiguous (use --repo to specify)"
-           printf '%s\n' "${conf[@]}" | paste - - | column -t >&2
-           exit 2 ;;
-    esac
-fi
+get_db
 
 if ! (($# + update + list)); then
     error "$argv0: no targets specified"
     exit 1
 fi
 
-msg "Using [$repo] repository"
-root=$(realpath -- "${root-${AUR_DBROOT-$server}}")
+msg "Using [$AUR_REPO] repository"
+db_root=$(realpath -e -- "${AUR_DBROOT}")
+db_path=$(realpath -e -- "${AUR_DBROOT}/$AUR_REPO.db") # .db symbolic link to archive
 
-if ! [[ -w $root/$repo.db && -r $root/$repo.db ]]; then
-    error "$argv0: $repo: permission denied (read-write)"
+if ! [[ -w $db_path && -r $db_path ]]; then
+    error "$argv0: $AUR_REPO: permission denied (read-write)"
     exit 13
 fi
 
@@ -238,11 +224,11 @@ chmod -c 700 "$aur_workdir"
 cd_safe "$tmp"
 
 # parse repo contents
-bsdcat "$root/$repo".db | db_namever | db_fill_empty >db_info
+bsdcat "$db_path" | db_namever | db_fill_empty >db_info
 
 if ((list)); then
     while read -r pkgname pkgver; do
-        printf '%q\t%s\t%s\n' "$repo" "$pkgname" "$pkgver"
+        printf '%q\t%s\t%s\n' "$AUR_REPO" "$pkgname" "$pkgver"
     done <db_info
 
     exit
@@ -287,7 +273,7 @@ cut -f2 --complement depends | sort -u >pkginfo
 
   if ((provides)); then
       # note: this uses pacman's copy of the repo (as used by makepkg -s)
-      cut -f1 pkginfo | complement argv | aur repo-filter -d "$repo"
+      cut -f1 pkginfo | complement argv | aur repo-filter -d "$AUR_REPO"
   fi
 } >filter
 
@@ -327,7 +313,7 @@ if ((view)); then
 fi
 
 if ((build)); then
-    build_args+=(-d "$repo" -r "$root" -a "$tmp"/queue)
+    build_args+=(-a "$tmp"/queue)
 
     # check if dependency graph is valid
     aur graph "$tmp_view"/*/.SRCINFO >/dev/null

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -61,17 +61,6 @@ parse_aur() {
     aur rpc -t info | jq -r '.results[] | [.Name, .Version] | @tsv'
 }
 
-check_sync() {
-    # https://github.com/andrewgregory/pacutils/issues/22
-    pacconf --repo="$1" >/dev/null || exit 1
-}
-
-parse_sync() {
-    # https://git.archlinux.org/pacman.git/commit/?id=ab3d8478
-    pacsift --exact --null --repo "$1" <&- \
-        | xargs -0r pacman -Sddp --print-format '%n %v'
-}
-
 trap_exit() {
     if [[ ! -o xtrace ]]; then
         rm -rf "$tmp"
@@ -79,7 +68,7 @@ trap_exit() {
 }
 
 usage() {
-    plain "usage: $argv0 [-d repo] [-p file] [-ac]"
+    plain "usage: $argv0 [-p file] [-ac]"
     exit 1
 }
 
@@ -90,7 +79,7 @@ if [[ -t 2 && ! -o xtrace ]]; then
     colorize
 fi
 
-opt_short='acd:p:u:'
+opt_short='acp:u:'
 opt_long=()
 if ! parseopts "$opt_short" "${opt_long[@]}" -- "$@"; then
     usage
@@ -102,7 +91,6 @@ while true; do
     case "$1" in
         -a) all=1 ;;
         -c) format='equal' ;;
-        -d) shift; repo=$1 ;; # FIXME remove this? (#316)
         -p) target='file'
             shift; aux=$1 ;;
         -u) shift; upair=$1 ;;
@@ -116,15 +104,7 @@ tmp=$(mktemp) || exit
 trap 'trap_exit' EXIT
 
 # set input file
-if [[ -v repo ]]; then
-    check_sync "$repo"
-    parse_sync "$repo" | sort -k 1b,1 >"$tmp"
-else
-    if [[ -t 0 ]]; then
-        plain 'repository not specified, assuming stdin'
-    fi
-    sort -k 1b,1 >"$tmp"
-fi
+sort -k 1b,1 >"$tmp"
 
 # set filters (1)
 case $target in

--- a/lib/db_helper.sh
+++ b/lib/db_helper.sh
@@ -1,5 +1,24 @@
 source /usr/share/makepkg/util/message.sh
 
+db_namever() {
+    awk '/%NAME%/ {
+        getline
+        printf("%s\t", $1)
+    }
+    /%VERSION%/ {
+        getline
+        printf("%s\n", $1)
+    }'
+}
+
+db_fill_empty() {
+    awk '{print} END {
+        if (!NR)
+            printf("%s\t%s\n", "(none)", "(none)")
+    }'
+}
+
+
 conf_file_repo() {
     awk -F'= ' '
         $1 ~ /^\[.+\]$/ {

--- a/lib/db_helper.sh
+++ b/lib/db_helper.sh
@@ -1,0 +1,43 @@
+source /usr/share/makepkg/util/message.sh
+
+conf_file_repo() {
+    awk -F'= ' '
+        $1 ~ /^\[.+\]$/ {
+            repo = substr($1, 2, length($1)-2)
+        }
+        $1 ~ /^Server/ && $2 ~ /^file:/ {
+            printf("%s\n%s\n", repo, $2)
+        }'
+}
+
+autodetect_db() {
+    local conf
+    mapfile -t conf < <(pacconf | conf_file_repo)
+
+    case ${#conf[@]} in
+        2) export AUR_REPO=${conf[0]}
+           export AUR_DBROOT=${conf[1]#*://} ;;
+        0) error "$argv0: no file:// repository found"
+           exit 2 ;;
+        *) error "$argv0: repository choice is ambiguous (use --repo to specify)"
+           printf '%s\n' "${conf[@]}" | paste - - | column -t >&2
+           exit 2 ;;
+    esac
+}
+
+get_db() {
+    if [[ -n "$AUR_REPO" && -z "$AUR_DBROOT" ]]; then
+        AUR_DBROOT=$(pacconf --repo="$repo" Server | grep -Em1 '^file://' || true)
+        AUR_DBROOT=${AUR_DBROOT#file://}
+        if [[ -z "$AUR_DBROOT" ]]; then
+            error "$argv0: could not autodetect the root of repo $AUR_REPO"
+            exit 2
+        fi
+    elif [[ -z "$AUR_REPO" && -z "$AUR_DBROOT" ]]; then
+        autodetect_db
+    elif [[ -z "$AUR_REPO" && -n "$AUR_DBROOT" ]]; then
+        error "$argv0: cannot set the repo root without setting the repo name"
+        exit 2
+    fi
+    export AUR_REPO AUR_DBROOT
+}

--- a/lib/db_helper.sh
+++ b/lib/db_helper.sh
@@ -60,3 +60,25 @@ get_db() {
     fi
     export AUR_REPO AUR_DBROOT
 }
+
+db_namever() {
+    awk '/%NAME%/ {
+        getline
+        printf("%s\t", $1)
+    }
+    /%VERSION%/ {
+        getline
+        printf("%s\n", $1)
+    }'
+}
+
+db_fill_empty() {
+    awk '{print} END {
+        if (!NR)
+            printf("%s\t%s\n", "(none)", "(none)")
+    }'
+}
+
+cat_db() {
+    bsdcat "$1" | db_namever | db_fill_empty
+}


### PR DESCRIPTION
I am opening this new pr to continue the discussion of
    https://github.com/AladW/aurutils/pull/441
(which is out of scope of that pr).

So this pr add a library helper to handle the detection of the database file in a uniform manner, and add 'aur repolist'.

You don't have "having lib files that are not executables", and I can agree
with that, but personally I hate even more code duplication, which get too easily unsynchronised :)

In particular I agree that lib helpers should not be used for 'plumbing'
commands, but I think they are ok for 'porcelain' commands. However I was
operating under the assumption that 'aur sync' was a porcelain command, but
since you talk about removing '-u' maybe you consider it as a 'plumbing'
command?

If you prefer the 'plumbing' route, then we could do the following things:

- remove '-u' from `aur sync` (eventually make a 'aur checkupdate' for
this), and --list, --repo-list (which could go to aur repolist).

- In `aur build` remove all autodetection of the repository path from the
repository name, and request to be given the direct path to the db file
(something like $AUR_DB=$AUR_DBROOT/$AUR_REPO.db). This has the advantage of
only having to pass one variable rather than two, and $AUR_DBROOT and
$AUR_REPO are easily recovered from $AUR_dB). Eventually add 'aur config'
for db autodetection.

- `aur vercmp` has two purposes: compare packages between stdin and the aur
or compare packages between stdin and a file (+ the -c option which is
essentially reversing the comparison order with a different output format).
Change it to only compare the versions of two files, and move the aur
comparison to 'aur checkupdate'.

So `aur sync -u` would be replaced by `xargs -a <(aur repolist $AUR_DB |
aur checkupdate | cut -f 1) aur sync`.

Would you prefer such an approach?

Also what about `aur repolist`? Since you talk about replacing `repoctl` do you have in mind something more like `aur repo update ..., aur repo list ...`?