### PR TITLE
Allow to override default scripts

### DIFF
--- a/aur.in
+++ b/aur.in
@@ -22,7 +22,7 @@ if [[ -z $1 ]]; then
     exit 1
 fi
 
-readonly PATH=$lib_dir:$PATH
+readonly PATH=$PATH:$lib_dir
 
 if type -P "aur-$1" >/dev/null; then
     exec "aur-$1" "${@:2}"


### PR DESCRIPTION
Make it possible to override one of the built-in command (like aur-sync) by creating a script with the same name in a folder of the PATH (like ~/bin).

Example of `~/.local/bin/aur-sync` (with ~/.local/bin in $PATH):
```bash
#!/bin/bash
packages=${XDG_CONFIG_HOME:-$HOME/.config}/aurutils/sync/ignore
packages=$(sed '/^#/d' "$packages" | fmt -1 | paste -sd,)
exec /usr/lib/aurutils/aur-sync --ignore="$packages" "$@"
```