### PR TITLE
Add aur-comments

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -56,3 +56,25 @@ aur sync --list | cut -f2 | grep -E "$AURVCS" | xargs aur sync --no-ver --print
 [//]: # (The last pipeline will also show any non-VCS dependencies.)
 [//]: # (Since the respective PKGBUILDs are not run by aur-srcver,)
 [//]: # (they are not of relevance. Use aur-fetch manually?)
+
+
+## comments
+
+This script fetches and displays the comments of an AUR page
+
+Dependencies:
+- hq
+
+```
+$ aur comments aurutils-git 3
+Alad commented on 2018-10-15 12:17:
+Done. Much appreciated.
+PS. Daily shouldn't be required. There's however a new PKGBUILD in the devel branch, which has not yet been pulled to master.
+
+sudoforge commented on 2018-10-13 19:26:
+Hey Alad, would you mind adding me as a maintainer for this package? I'd be happy to push updated PKGBUILDs daily, to keep this in sync with its upstream.
+
+Alad commented on 2018-06-11 16:43:
+Note that technically speaking `ed` is an optional dependency (for aur-chroot) but as a convenient/short way to edit files, I may use it in other scripts later.
+If someone gets it working with `ex` (I didn't) feel free to tell me.
+```

--- a/contrib/comments
+++ b/contrib/comments
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# depends: hq
+# usage: aur comments <package name> <number of comments>
+# example: aur comments aurutils-git 3
+
+if ! [ -n "$1" ] || ! [ -n "$2" ] || ! [ "$2" -eq "$2" ] 2>/dev/null; then
+  echo "invalid arguments" >&2
+  exit 1
+fi
+
+out="$(curl -sSL "https://aur.archlinux.org/packages/$1/?O=0&PP=$2")"
+comid=0
+commax=$2
+
+IFS=$'\0' readarray -d $'\0' authors < <(<<< "$out" hq -0 '.package-comments > .comment-header[id*="comment"]' text)
+IFS=$'\0' readarray -d $'\0' contents < <(<<< "$out" hq -0 '.package-comments > .article-content[id*="comment"]' text md)
+
+while true; do
+  if [ $((commax-comid)) -lt 1 ] || ! [[ -n "${authors[comid]}" ]]; then
+    break
+  elif [ $comid -gt 0 ]; then
+    printf -- "\n"
+  fi
+
+  printf -- "\e[1m%s\e[0m:\n\e[2m%s\e[0m\n" "${authors[comid]}" "${contents[comid]}"
+  comid=$((comid+1))
+done

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -16,7 +16,8 @@ optdepends=('devtools: aur-chroot'
             'diffstat: aur-fetch-snapshot'
             'expac: aur-repo-filter'
             'vifm: build file interaction'
-            'xdelta3: generate delta files')
+            'xdelta3: generate delta files'
+            'hq: aur-comments (contrib)')
 
 pkgver() {
     cd aurutils


### PR DESCRIPTION
aur-comments is a bash script for fetching comments from an AUR page.

It is intended as a replacement for https://github.com/AladW/aurutils/pull/454;
It only depends on community/hq

Example output:
```
Alad commented on 2018-10-15 12:17:
Done. Much appreciated.
PS. Daily shouldn't be required. There's however a new PKGBUILD in the devel branch, which has not yet been pulled to master.

sudoforge commented on 2018-10-13 19:26:
Hey Alad, would you mind adding me as a maintainer for this package? I'd be happy to push updated PKGBUILDs daily, to keep this in sync with its upstream.

Alad commented on 2018-06-11 16:43:
Note that technically speaking `ed` is an optional dependency (for aur-chroot) but as a convenient/short way to edit files, I may use it in other scripts later.
If someone gets it working with `ex` (I didn't) feel free to tell me.
```