### PR TITLE
aur-build: Fix documentation inconsistencies

### DIFF
--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -23,7 +23,7 @@ prefix in
 All arguments after \-\- are passed to
 .BR makepkg (8),
 or
-.BR aur\-chroot (1)
+.BR makechrootpkg
 when
 .B \-c
 is specified.


### PR DESCRIPTION
`aur build`'s man page is inconsistent with its actual behaviour; options are passed to `makechrootpkg` and not `aur chroot` itself.

I also added a short note about `-C`, `-D` and `-M` options, as these aren't mentioned anywhere else in `aur-build(1)`.