### PR TITLE
aur-repo: fix sync_format

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -41,7 +41,7 @@ sync_pkgspec() {
 
 sync_format() {
     # https://git.archlinux.org/pacman.git/commit/?id=ab3d8478
-    xargs -0r pacman -Sddp --print-format "$2"
+    xargs -0r pacman -Sddp --print-format "$1"
 }
 
 usage() {


### PR DESCRIPTION
Fix a copy&paste error introduced in d6881cb3e3ce0152c1f7f788ca79ba64efc1cae6. This is necessary for `aur repo -u` and `aur repo -S` to work correctly.