### PR TITLE
 Install bash completion by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,15 @@ SHRDIR ?= $(PREFIX)/share
 BINDIR ?= $(PREFIX)/bin
 LIBDIR ?= $(PREFIX)/lib
 
-.PHONY: shellcheck install
+.PHONY: shellcheck install build completion
+
+build: aur completion
 
 aur: aur.in
 	m4 -DAUR_LIB_DIR=$(LIBDIR)/$(PROGNM) $< >$@
+
+completion:
+	@$(MAKE) -C completions bash
 
 shellcheck: aur
 	@shellcheck -f gcc -e 2035,2086,2094,2016,1117,1083,1071,1091 aur lib/*
@@ -18,3 +23,4 @@ install:
 	@install -Dm644 man1/*    -t $(DESTDIR)$(SHRDIR)/man/man1
 	@install -Dm644 man7/*    -t $(DESTDIR)$(SHRDIR)/man/man7
 	@install -Dm644 LICENSE   -t $(DESTDIR)$(SHRDIR)/licenses/$(PROGNM)
+	@$(MAKE) -C completions DESTDIR=$(DESTDIR) install-bash

--- a/completions/Makefile
+++ b/completions/Makefile
@@ -1,8 +1,11 @@
 PREFIX ?= /usr
 SHRDIR ?= $(PREFIX)/share
+.PHONY = bash install-bash
 
-bash/aur: command_opts.m4 bash/aurutils.in
-	m4 $^ >$@
+bash: bash/aur
 
-install: bash/aur
-	@install -Dm644 bash/aur $(DESTDIR)$(SHRDIR)/bash-completion/completions
+bash/aur: command_opts.m4 bash/aurutils.in ../lib/*
+	m4 $(wordlist 1,2,$^) >$@
+
+install-bash: bash/aur
+	@install -Dm644 bash/aur -t $(DESTDIR)$(SHRDIR)/bash-completion/completions

--- a/completions/command_opts.m4
+++ b/completions/command_opts.m4
@@ -4,7 +4,7 @@ dnl
 define(`CORECOMMANDS',
 HAVE_OPTDUMP(build,fetch-snapshot,search,fetch,repo-filter,
              repo,chroot,pkglist,fetch-git,vercmp,sync,rpc)dnl
-NO_OPTDUMP(depends,jobs,graph,srcver))
+NO_OPTDUMP(depends,jobs,graph,srcver,vercmp-devel))
 
 dnl recursively print all elements
 dnl How the element is ultimately printed depends on the

--- a/completions/command_opts.m4
+++ b/completions/command_opts.m4
@@ -36,6 +36,6 @@ define(DEFAULT_OPTS,
 
 dnl Helper macro to retrieves options from subcommand --dump-options
 dnl
-define(GET_OPTS,'`translit(esyscmd(aur $1 --dump-options),`
+define(GET_OPTS,'`translit(esyscmd(../lib/aur-$1 --dump-options),`
 ',` ')'')
 divert(0)dnl


### PR DESCRIPTION
* fix multiple issues related to completion generation. Some caused by issues on the completions/Makefile and another caused by the m4 macro itself. Both could result in installation of stale completion scripts.
* Add vercmp-devel to completion macro
* Install bash completion by default