### PR TITLE
aur-chroot: fix local repo path for bind mounts

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -77,7 +77,7 @@ makepkg_conf=${makepkg_conf-/usr/share/devtools/makepkg-$machine.conf}
 
 # FIXME: local repos may contain multiple file:// entries
 for repo in "${host_repo[@]}"; do
-    server=$(get_conf_repo "$repo" | tee "$tmp"/custom.conf | grep -Em1 '^file://' || true)
+    server=$(get_conf_repo "$repo" | tee "$tmp"/custom.conf | grep -Eom1 'file://.*$' || true)
     server=${server#file://}
 
     if [[ $server ]]; then


### PR DESCRIPTION
The line from get_conf_repo is in format `Server = file:///path/to/repo`. Without successful bind mount, `pacman -Syu` fails in prepare stage, stopping the build.