### PR TITLE
aur-search: colorize if stdout is a tty

### DIFF
--- a/lib/aur-search
+++ b/lib/aur-search
@@ -106,7 +106,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ -t 1 && ! -o xtrace ]]; then
     colorize
 fi
 


### PR DESCRIPTION
`aur-search` only prints colors on stdout.