### PR TITLE
Fix outputs of usage()

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -24,7 +24,7 @@ trap_exit() {
 }
 
 usage() {
-    printf >&2 "usage: %s [-CDM <path>] [-d <repo>] -- <makechrootpkg args>" "$argv0"
+    printf >&2 'usage: %s [-CDM <path>] [-d <repo>] -- <makechrootpkg args>\n' "$argv0"
     exit 1
 }
 

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -68,7 +68,7 @@ trap_exit() {
 }
 
 usage() {
-    printf 'usage: %s pkgname...\n' "$argv0" >&2
+    printf >&2 'usage: %s\n' "$argv0"
     exit 1
 }
 

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -22,7 +22,7 @@ usage() {
 ICAgICAgICAgICAgIC4tLX5+LF9fCjotLi4uLiwtLS0tLS0tYH5+Jy5fLicKIGAtLCwsICAsXyAg
 ICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
 EOF
-    printf >&2 'usage: %s [-grt] [-L log_dir] pkgname [pkgname...]\n' "$argv0"
+    printf >&2 'usage: %s [-grt] [-L log_dir] pkgname...\n' "$argv0"
     exit 1
 }
 

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -99,7 +99,7 @@ parse_short() {
 }
 
 usage() {
-    printf >&2 'usage: %s: [-aisdmnqv] [-k key] package [package...]\n' "$argv0"
+    printf >&2 'usage: %s: [-aisdmnqv] [-k key] pkgname...\n' "$argv0"
     exit 1
 }
 

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -23,7 +23,7 @@ find_pkgbuild_path() {
 }
 
 usage() {
-    printf 'usage: %s path [path...]\n' "$argv0" >&2
+    printf >&2 'usage: %s path...\n' "$argv0"
     exit 1
 }
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -68,7 +68,7 @@ trap_exit() {
 }
 
 usage() {
-    plain "usage: $argv0 [-ABcDfglLnrstTu] [--] pkgname... [-]" >&2
+    plain "usage: $argv0 [-ABcDfglLnrstTu] [--] pkgname..." >&2
     exit 1
 }
 


### PR DESCRIPTION
* Made argument specs more consistent
  - `pkgname...` instead of `pkgname [pkgname...]`
* Added missing newline when using `printf`
* Removed unused arguments
  - `aur sync -` is no longer possible (use `xargs`)
  - `aur depends <pkgname>` is no longer possible (reads from stdin)