### PR TITLE
Change aur-repo --repo-list to print to stdout

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -116,7 +116,7 @@ case $mode in
     #requires (none)
     repo_list)
         if [[ ${conf_repo[*]} ]]; then
-            printf '%s\n' "${conf_repo[@]}" | paste - - | column -t >&2
+            printf '%s\n' "${conf_repo[@]}" | paste - - | column -t
         else
             plain "no file:// repository configured"
         fi


### PR DESCRIPTION
`aur repo --repo-list` prints non-error output to stderr instead of stdout