### PR TITLE
aur-repo: simplify pacman query, add -S

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -4,38 +4,27 @@ readonly argv0=repo
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
+modifier=local
 vercmp_args=()
 
 db_namever() {
     awk '/%NAME%/ {
-        getline; printf("%s\t", $1)
+        getline
+        printf("%s\t", $1)
     } /%VERSION%/ {
-        getline; printf("%s\n", $1)
-    } END {
-        if (!NR) {
-            printf("warning: empty database\n") > "/dev/stderr"
-            close("/dev/stderr")
-        }
+        getline
+        printf("%s\n", $1)
     }'
 }
 
-sync_exists() {
-    # https://github.com/andrewgregory/pacutils/issues/22
-    pacman-conf -r "$1" >/dev/null
-}
-
-sync_pkgspec() {
-    # https://github.com/andrewgregory/pacutils/issues/3
-    pacsift --exact --null --repo "$1" <&-
-}
-
-sync_format() {
-    # https://git.archlinux.org/pacman.git/commit/?id=ab3d8478
-    xargs -0r pacman -Sddp --print-format "$1"
+ex_namever() {
+    awk -F"/" -v rname="^$1/" '{
+        $0 ~ rname { print $NF }
+    }'
 }
 
 usage() {
-    plain "usage: $argv0 [-d repo] [-r path] [-alu]" >&2
+    plain "usage: $argv0 [-d repo] [-r path] [-alSu]" >&2
     exit 1
 }
 
@@ -47,9 +36,9 @@ if [[ -t 2 && ! -o xtrace ]]; then
 fi
 
 ## option parsing
-opt_short='d:r:alu'
+opt_short='d:r:alSu'
 opt_long=('all' 'database:' 'list' 'root:' 'upgrades' 'repo-list'
-          'status-file:')
+          'status-file:' 'sync')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -65,6 +54,7 @@ while true; do
         -r|--root)     shift; db_root=$1 ;;
         -l|--list)     mode=list_packages ;;
         -u|--upgrades) mode=list_upgrades ;;
+        -S|--sync)     modifier=sync ;;
         --repo-list)   mode=repo_list ;;
         --status-file) shift; status_file=$1 ;;
         --dump-options) printf -- '--%s\n' "${opt_long[@]}" ;
@@ -111,11 +101,12 @@ while read -r key _ value; do
     esac
 done < <(pacman-conf)
 
+# exclusive modes
 case $mode in
     #requires (none)
     repo_list)
         if [[ ${conf_repo[*]} ]]; then
-            printf '%s\n' "${conf_repo[@]}" | paste - - | column -t
+            printf '%s\n' "${conf_repo[@]}" | paste - -
         else
             plain "no file:// repository configured"
         fi
@@ -141,33 +132,36 @@ if [[ -v status_file ]]; then
     printf '%s\n%s\n' "$db_name" "$db_root" >"$status_file"
 fi
 
-case $mode in
+case $modifier in
     #requires
-    # - $db_root/$db_name (path) OR
-    # - [$db_name], Server=file:// (pacman.conf)
-    list_packages)
+    # - $db_root/$db_name (path)
+    local)
         if ! [[ $db_root ]]; then
             error "$argv0: $db_name: repository path not found"
             exit 2
         elif [[ $db_root == *://* ]]; then
-            error "$argv0: $db_root: object is remote"
+            error "$argv0: $db_root: object is remote (use -S to query)"
             exit 66
         elif ! [[ -d $db_root ]]; then
             error "argv0: $db_root: not a directory"
             exit 20
+        else
+            contents() { bsdcat "$db_root/$db_name".db | db_namever; }
         fi
-
-        bsdcat "$db_root/$db_name".db | db_namever
         ;;
     #requires
     # - [$db_name] (pacman.conf)
-    list_upgrades)
-        if sync_exists "$db_name"; then
-            sync_pkgspec "$db_name" | \
-                sync_format '%n %v' | aur vercmp "${vercmp_args[@]}"
-        else
-            exit 1
-        fi
+    sync)
+        contents() { expac -Sv '%r/%n\t%v' | ex_namever "$db_name"; }
+        ;;
+esac
+
+case $mode in
+    list_updates)
+        contents | aur vercmp "${vercmp_args[@]}"
+        ;;
+    list_packages)
+        contents
         ;;
     *)
         printf '%s\n' "$db_root/$db_name".db

--- a/man1/aur-repo.1
+++ b/man1/aur-repo.1
@@ -1,4 +1,4 @@
-.TH AUR-REPO 1 2018-12-10 AURUTILS
+.TH AUR-REPO 1 2018-12-13 AURUTILS
 .SH NAME
 aur\-repo \- manage local repositories
 
@@ -6,12 +6,10 @@ aur\-repo \- manage local repositories
 .SY "aur repo"
 .OP \-d database
 .OP \-r root
-.OP \-lu
+.OP \-lSu
 .OP \-\-repo\-list
 .OP \-\-status\-file
 .YS
-
-.SH DESCRIPTION
 
 .SH OPTIONS
 .TP
@@ -25,6 +23,9 @@ aur\-repo \- manage local repositories
 
 .TP
 .BR \-u ", " \-\-updates
+
+.TP
+.BR \-S ", " \-\-sync
 
 .TP
 .BI \-\-status\-file= PATH
@@ -44,12 +45,8 @@ repository configured in
 .BR pacman.conf (5).
 .RE
 
-.B AUR_DBROOT
-.RS
-.RE
-
 .SH SEE ALSO
 .BR aur (1),
+.BR expac (1),
 .BR pacman (1),
-.BR pacsift (1),
 .BR pacman.conf (5)


### PR DESCRIPTION
Because repository names cannot contain newlines, pacsift --null is not
required and the output can be parsed line-by-line. For a simple command
line, expac is used instead of pacman --print.

Add a sync "modifier" that applies to both package listing and package
upgrades. It is disabled by default; in particular, aur repo -u is now
equivalent to "aur repo -l | aur vercmp". If the repository path is
remote, hint to -S which enables it.

-Sl and -l have the same output: pkgname and pkgver separated by tabs.