### PR TITLE
aur-build: Allow passing multiple local repos to aur-chroot

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -66,7 +66,7 @@ unset queue db_name db_path db_root
 while true; do
     case "$1" in
         -a|--arg-file)  shift; queue=$1 ;;
-        -d|--database)  shift; db_name=$1 ;;
+        -d|--database)  shift; db_name=$1; chroot_args+=(-d "$1") ;;
         -r|--root)      shift; db_root=$1 ;;
         -c|--chroot)    chroot=1 ;;
         -f|--force)     overwrite=1 ;;
@@ -132,9 +132,6 @@ esac
 
 # resolve symbolic link
 db_path=$(readlink -f -- "$db_path")
-
-# local repository access for aur-chroot (#485)
-chroot_args+=(-d "$db_name")
 
 if ! [[ -w $db_path ]]; then
     error "$argv0: $db_path: permission denied"


### PR DESCRIPTION
This used to work in the past, but was lost at some point during the refactoring.

Personally, I use one local repo `aur` for packages built directly from the AUR without modifications, and one repo `custom` which holds modified and self-created packages. As most of the dependencies will land in the `aur` repo, it is almost always required during `aur build`.