### PR TITLE
aur-repo: fix --sync and --upgrades

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -18,9 +18,7 @@ db_namever() {
 }
 
 ex_namever() {
-    awk -F"/" -v rname="^$1/" '{
-        $0 ~ rname { print $NF }
-    }'
+    awk -F"/" -v rname="^$1/" '$0 ~ rname { print $NF }'
 }
 
 usage() {
@@ -157,7 +155,7 @@ case $modifier in
 esac
 
 case $mode in
-    list_updates)
+    list_upgrades)
         contents | aur vercmp "${vercmp_args[@]}"
         ;;
     list_packages)

--- a/man1/aur-repo.1
+++ b/man1/aur-repo.1
@@ -22,7 +22,7 @@ aur\-repo \- manage local repositories
 .BR \-l ", " \-\-list
 
 .TP
-.BR \-u ", " \-\-updates
+.BR \-u ", " \-\-upgrades
 
 .TP
 .BR \-S ", " \-\-sync


### PR DESCRIPTION
Fix two bugs introduced in #491:
- `aur repo -Sl` fails with the error
    
    ```
    awk: cmd. line:2:         $0 ~ rname { print $NF }
    awk: cmd. line:2:                    ^ syntax error
    ```
    due to a spurious pair of braces in the AWK program used by `ex_namever`.
- `aur repo -u` only returns the path to the database file due to a typo (`list_updates` instead of `list_upgrades`). Additionally correct the name of the long option name in the man page from `--updates` to the actually used `--upgrades`.