### PR TITLE
aur-sync: implement agrep

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -282,6 +282,38 @@ if ((build)); then
         aur build "${build_args[@]}" -- "${makechrootpkg_args[@]}" \
             -- "${makechrootpkg_makepkg_args[@]}"
     else
+        # check repo dependencies (FIXME: --sysroot for containers)
+        cut -f2 "$tmp"/depends | aur repo-filter --all 2>/dev/null >"$tmp"/found_repo
+
+        cut -f1 "$tmp"/depends | cat "$tmp"/found_repo - \
+            | complement - <(cut -f2 "$tmp"/depends) >"$tmp"/foreign
+
+        # guess candidates for unknown packages and present them to the user
+        mapfile -t undeps < <(sort -u "$tmp"/foreign | pacman -T -)
+
+        # avoid nested while loops in formatting text
+        if [[ ${undeps[*]} ]]; then
+            error "$argv0: virtual or missing packages"
+
+            for i in "${undeps[@]}"; do
+                origin=$(grep -w -m1 "$i" "$tmp"/depends | cut -f1)
+                msg2 "$i ($origin)" >&2
+            done
+
+            msg "Possible providers:"
+            aur pkglist >"$tmp"/pkglist
+
+            # agrep does not support -f, has differing results with OR
+            for i in "${undeps[@]}"; do
+                agrep --show-cost --best-match "^$i" "$tmp"/pkglist | while
+                    IFS=: read -r cost pkg
+                do
+                    msg2 "$pkg [$RED$cost$ALL_OFF$BOLD errors]" >&2
+                done
+            done
+            exit 2
+        fi
+
         aur build "${build_args[@]}" -- "${makepkg_args[@]}"
     fi
 else


### PR DESCRIPTION
This is similar to git's "did you mean", for purely virtual packages in
the AUR. A package search alone does not suffice, since package
names may differ in minute ways. (For example, foo-pkg vs foo_pkg.)

Implementation is done using agrep from the tre package. Potential
candidates are presented to the user.

----
This does not work with chroot builds, as the pacman (sys)root cannot be specified to `expac`.