### PR TITLE
Add zsh run-help assistant

### DIFF
--- a/completions/Makefile
+++ b/completions/Makefile
@@ -16,3 +16,4 @@ install-bash: bash/aur
 
 install-zsh: zsh/_aur
 	@install -Dm644 zsh/_aur -t $(DESTDIR)$(SHRDIR)/zsh/site-functions
+	@install -Dm755 zsh/run-help-aur -t $(DESTDIR)$(SHRDIR)/zsh/functions/Misc

--- a/completions/zsh/run-help-aur
+++ b/completions/zsh/run-help-aur
@@ -1,0 +1,5 @@
+if [ $# -eq 0 ]; then
+	man aur
+else
+	man aur-$1
+fi


### PR DESCRIPTION
This allows for zsh run-help to open the correct man page for the aur commands, instead of opening aur(1).
To use it, it must be autoloaded:

autoload -Uz run-help-aur