### PR TITLE
Add zsh run-help assistant

### DIFF
--- a/completions/Makefile
+++ b/completions/Makefile
@@ -16,3 +16,4 @@ install-bash: bash/aur
 
 install-zsh: zsh/_aur
 	@install -Dm644 zsh/_aur -t $(DESTDIR)$(SHRDIR)/zsh/site-functions
+	@install -Dm755 zsh/run-help-aur -t $(DESTDIR)$(SHRDIR)/zsh/functions/Misc

--- a/completions/zsh/README.run-help-aur
+++ b/completions/zsh/README.run-help-aur
@@ -1,0 +1,7 @@
+run-help-aur is a Zsh run-help assistant. It allows run-help to open the correct man page for the aur commands, instead of opening aur(1).
+To use it, first setup run-help following zshcontrib(1), then place run-help-aur in fpath and autoload it.
+For example, after installing run-help-aur to /usr/share/zsh/functions/Misc/run-help-aur and autoloading run-help, run:
+
+autoload -Uz run-help-aur
+
+Refer to zshcontrib(1) for more details on run-help and its assistant functions.

--- a/completions/zsh/run-help-aur
+++ b/completions/zsh/run-help-aur
@@ -1,0 +1,5 @@
+if [ $# -eq 0 ]; then
+	man aur
+else
+	man aur-$1
+fi


### PR DESCRIPTION
run-help-aur is a Zsh run-help assistant. It allows `run-help` to open the correct man page for `aur *` commands, instead of opening `aur(1)`.
To use it, first setup `run-help`, then place `run-help-aur` in `fpath` and autoload it. For example, with `run-help-aur` in `/usr/share/zsh/functions/Misc/run-help-aur`:
```
unalias run-help
autoload -Uz run-help
autoload -Uz run-help-aur
```
After that invoke `run-help` on a `aur *` command and it will open the correct man page. E.g.: `run-help aur sync` will open `aur-sync(1)` and `run-help aur build` will open `aur-build(1)`.

`run-help` and its assistant functions are documented in `zshcontrib(1)`.