### PR TITLE
lib/aur-sync: cd before invoking $PAGER again

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -256,7 +256,7 @@ if type -P >/dev/null vifm; then
     # avoid directory prefix in printed paths (#452)
     viewer() ( cd "$1"; vifm -c 'view!' -c '0' - )
 else
-    viewer() { command -- ${PAGER:-less -K}; }
+    viewer() ( cd "$1"; command -- ${PAGER:-less -K}; )
 fi
 
 # check if dependency graph is valid


### PR DESCRIPTION
Previous versions of aur-sync used to set the current directory to the per-sync temporary directory before invoking the `$PAGER` command. Recent changes (65517a01fdcad12e4cb75ce05d636d8571dc0e21) broke this assumption. (This was broken for both `$PAGER` and vifm, but was later fixed, only for vifm, in 854c85ee0612ff5ca0ab982e41dd5126b07a8df6).