### PR TITLE
completions: group options by type

### DIFF
--- a/completions/bash/aurutils.in
+++ b/completions/bash/aurutils.in
@@ -28,4 +28,4 @@ _aur_completion()
 }
 
 
-complete -o bashdefault -o default -F _aur_completion aur
+complete -o bashdefault -o default -o nosort -F _aur_completion aur

--- a/completions/command_opts.m4
+++ b/completions/command_opts.m4
@@ -27,6 +27,6 @@ CORECOMMANDS')
 
 dnl Helper macro to retrieves options from subcommand --dump-options
 dnl
-define(GET_OPTS,'`translit(esyscmd(../lib/aur-$1 --dump-options),`
+define(GET_OPTS,'`translit(esyscmd(bash -c "../lib/aur-$1 --dump-options | LC_ALL=C sort"),`
 ',` ')'')
 divert(0)dnl

--- a/completions/zsh/aurutils.in
+++ b/completions/zsh/aurutils.in
@@ -1,5 +1,7 @@
 #compdef aur
 
+zstyle ':completion::complete:aur:argument-rest:' sort false
+
 _aur() {
     local context state state_descr line
     typeset -A opt_args


### PR DESCRIPTION
Completions options are being shown in lexicographical order. The result
is that long and short options are shown mixed up.

This makes the completions hard to read as they're not well aligned due
to prefix length differences between short and long options (--/-).

To minimize these misalignments lets show them grouped together, showing
long options first followed by short options.

In response to #514 