### PR TITLE
srcver: re-add --noprepare

### DIFF
--- a/completions/command_opts.m4
+++ b/completions/command_opts.m4
@@ -3,8 +3,9 @@ dnl List of commands to be completed
 dnl
 define(`CORECOMMANDS',
 HAVE_OPTDUMP(build,search,fetch,repo-filter,
-             repo,chroot,pkglist,vercmp,sync,rpc)dnl
-NO_OPTDUMP(depends,jobs,graph,srcver,vercmp-devel))
+             repo,chroot,pkglist,vercmp,sync,rpc,
+             srcver)dnl
+NO_OPTDUMP(depends,jobs,graph,vercmp-devel))
 
 dnl recursively print all elements
 dnl How the element is ultimately printed depends on the

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -3,6 +3,29 @@
 readonly argv0=srcver
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 readonly startdir=$PWD
+makepkg_args=('--nobuild' '--nodeps' '--skipinteg')
+
+source /usr/share/makepkg/util/parseopts.sh
+opt_short=
+opt_long=('noprepare')
+opt_hidden=('dump-options')
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
+    echo "usage: $argv0 [--noprepare] <pkgbase> [<pkgbase> ...]" >&2
+    exit 1
+fi
+set -- "${OPTRET[@]}"
+unset opt_short opt_long opt_hidden OPTRET
+
+while true; do
+    case "$1" in
+        --noprepare)    makepkg_args+=("$1") ;;
+        --dump-options) printf -- '--%s\n' "${opt_long[@]}"
+                        printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
+                        exit ;;
+        --) shift; break ;;
+    esac
+    shift
+done
 
 srcver_pkgbuild_info() {
     env -C "$1" -i bash -c '
@@ -20,7 +43,7 @@ srcver_pkgbuild_info() {
 export -f srcver_pkgbuild_info
 
 srcver_pkgbuild_path() {
-    if env -C "$1" makepkg --skipinteg -od; then
+    if env -C "$1" makepkg "${@:3}" ; then
         srcver_pkgbuild_info "$1" >> "$2"
     else
         return
@@ -43,7 +66,7 @@ tmp=$(mktemp -dt "$argv0".XXXXXXXX) || exit
 trap 'trap_exit' EXIT
 
 aur jobs --nice 10 -j +2 --joblog "$tmp"/makepkg_log --results "$tmp/{#}_makepkg" \
-    srcver_pkgbuild_path '{}' "$tmp"/results ::: "$@" >/dev/null 2>&1
+    srcver_pkgbuild_path '{}' "$tmp"/results "${makepkg_args[@]}" ::: "$@" >/dev/null 2>&1
 jobs_exit=$?
 
 if ((jobs_exit > 101)); then

--- a/man1/aur-srcver.1
+++ b/man1/aur-srcver.1
@@ -4,6 +4,7 @@ aur\-srcver \- list version of VCS packages
 
 .SH SYNOPSIS
 .SY "aur srcver"
+.OP \-\-noprepare
 .IR pkgbase ...
 .YS
 
@@ -12,12 +13,17 @@ aur\-srcver \- list version of VCS packages
 takes the names of packages and lists the current
 .I pkgver
 of VCS packages. This is achieved by running
-.B "makepkg \-\-skipinteg \-\-noprepare \-od"
+.B "makepkg \-\-skipinteg \-od"
 and parsing the output.
 
 It is assumed that source directories are already available, and that
 .B aur\-srcver
 is used in the same directory as those source directories.
+
+.SH OPTIONS
+.TP
+.B \-\-noprepare
+Do not run the prepare() function in the PKGBUILD.
 
 .SH SEE ALSO
 .BR makepkg (1),


### PR DESCRIPTION
d2c26cc removed the `--noprepare` flag from `makepkg` calls in `aur srcver`. 

This made calls to `aur-srcver-devel` slow because in my particular case a go package's `prepare()` was running `dep ensure` which took some time to finish.

If `pkgver()` is allowed to depend on the result of `prepare()` maybe this is wrong and is something we'll need to live with?