### PR TITLE
completion: generate completion for aur-depends

### DIFF
--- a/completions/command_opts.m4
+++ b/completions/command_opts.m4
@@ -2,10 +2,9 @@ divert(-1)dnl
 dnl List of commands to be completed
 dnl
 define(`CORECOMMANDS',
-HAVE_OPTDUMP(build,search,fetch,repo-filter,
-             repo,chroot,pkglist,vercmp,sync,rpc,
-             srcver)dnl
-NO_OPTDUMP(depends,jobs,graph,vercmp-devel))
+HAVE_OPTDUMP(build,chroot,depends,fetch,pkglist,repo,
+             repo-filter,rpc,search,srcver,sync,vercmp)dnl
+NO_OPTDUMP(graph,jobs,vercmp-devel))
 
 dnl recursively print all elements
 dnl How the element is ultimately printed depends on the


### PR DESCRIPTION
In cadf3f7 (aur-depends: implement --pkgbase, --pkgname, --table,
2019-01-14) aur depends gained option handling but completion for it is
not being generated.

I noticed that there was a mismatch in number of scripts using parseopts
and the number of scripts with autocomplete, but because the macro
arguments were not lexicographically sorted spotting the missing one
took more seconds than it should.

So lets sort the arguments and move depends to HAVE_OPTDUMP so
completions are generated for it.