### PR TITLE
stop unsetting parseopt helper variables

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -90,7 +90,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long OPTRET
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/$argv0".XXXXXXXX)
 var_tmp=$(mktemp -d "${TMPDIR:-/var/tmp}/$argv0".XXXXXXXX)

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -72,7 +72,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long OPTRET
 
 tmp=$(mktemp -d)
 trap 'trap_exit' EXIT

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -105,7 +105,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long OPTRET
 
 tmp=$(mktemp -dt "$argv0".XXXXXXXX) || exit
 trap 'trap_exit' EXIT

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -141,7 +141,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long OPTRET
 
 tmp=$(mktemp -dt "$argv0".XXXXXXXX)
 trap trap_exit EXIT

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -62,7 +62,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long OPTRET
 
 # default to regex if >0 arguments specified
 case $# in

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -62,7 +62,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long OPTRET
 
 # assign environment variables
 : "${db_name=$AUR_REPO}"

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -54,7 +54,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long OPTRET
 
 if ((sync_repo)); then
     sift_args+=(--sync)

--- a/lib/aur-rpc
+++ b/lib/aur-rpc
@@ -59,7 +59,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long OPTRET
 
 # set filters
 case $type in

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -151,7 +151,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long OPTRET
 
 if ! (($#)); then
     usage

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -66,7 +66,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long opt_hidden OPTRET
 
 if ! (($#)); then
     usage

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -144,7 +144,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long OPTRET
 
 tmp=$(mktemp -dt "$argv0".XXXXXXXX)
 tmp_view=$(mktemp -dt view.XXXXXXXX)

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -104,7 +104,6 @@ while true; do
     esac
     shift
 done
-unset opt_short opt_long OPTRET
 
 tmp=$(mktemp) || exit
 trap 'trap_exit' EXIT


### PR DESCRIPTION
opt_hidden is not being unset after option handling in all but one
script. As this seems like an unnecessary step, instead of also
unsetting opt_hidden everywhere let's just stop unsetting those helper
variables.

This was brought up in #aurutils. Is there any real benefits from unsetting those variables here? If not, let's just remove all those lines. If yes, this can be converted into a PR that fixes all the missing `unset opt_hidden`.