### PR TITLE
aur-build: make repo-add -d optional

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -107,7 +107,7 @@ if (($#)); then
     fi
 fi
 
-if type -P xdelta3 >/dev/null && ((delta)); then
+if ((delta)); then
     repo_add_args+=(-d)
 fi
 

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -15,7 +15,7 @@ makepkg_args=(--clean --syncdeps)
 repo_add_args=()
 
 # default options
-chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0
+chroot=0 delta=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0
 
 conf_single() {
     awk -v "repo=[$1]" '
@@ -39,7 +39,7 @@ trap_exit() {
 }
 
 usage() {
-    plain "usage: $argv0 [-d repo] [-aCDMr path] [-cfNRsv] [--] <makepkg args>" >&2
+    plain "usage: $argv0 [-d repo] [-aCDMr path] [-cfNRXsv] [--] <makepkg args>" >&2
     exit 1
 }
 
@@ -52,8 +52,8 @@ if [[ -t 2 && ! -o xtrace ]]; then
 fi
 
 ## option parsing
-opt_short='a:B:C:d:D:M:r:cfNRsv'
-opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign'
+opt_short='a:B:C:d:D:M:r:cfNRXsv'
+opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'delta' 'sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:'
           'makepkg-conf:' 'remove' 'build-command:' 'pkgver')
 opt_hidden=('dump-options')
@@ -72,6 +72,7 @@ while true; do
         -r|--root)          shift; db_root=$1 ;;
         -c|--chroot)        chroot=1 ;;
         -f|--force)         overwrite=1 ;;
+        -X|--delta)         delta=1 ;;
         -s|--sign)          sign_pkg=1
                             repo_add_args+=(-s) ;;
         -v|--verify)        repo_add_args+=(-v) ;;
@@ -106,7 +107,7 @@ if (($#)); then
     fi
 fi
 
-if type -P xdelta3 >/dev/null; then
+if type -P xdelta3 >/dev/null && ((delta)); then
     repo_add_args+=(-d)
 fi
 

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -114,6 +114,13 @@ database
 .RB ( "repo\-add \-R" ).
 
 .TP
+.B \-X ", " \-\-delta
+Automatically generate and add a delta file between the old entry and the new one
+if the old package file is found next to the new one.
+.RB ( "repo\-add \-d" ).
+
+
+.TP
 .BR \-s ", " \-\-sign
 Sign built packages and the database
 .RB ( "repo\-add \-s" )

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -115,10 +115,11 @@ database
 
 .TP
 .B \-X ", " \-\-delta
-Automatically generate and add a delta file between the old entry and the new one
-if the old package file is found next to the new one.
-.RB ( "repo\-add \-d" ).
-
+Automatically generate and add a delta file between the old entry 
+and the new one, if the old package file is found next to the new one.
+.RB ( "repo\-add \-d" )
+requires:
+.BR xdelta3 (1).
 
 .TP
 .BR \-s ", " \-\-sign


### PR DESCRIPTION
Building deltas is a _time hog_, and deltas are pretty much never used in a small network environment.
It would be nice to have this feature turned off by default, and only activated with a flag. 

_can't reopen  #528, after force push :disappointed:_