### PR TITLE
sync: ask for confirmation when using PAGER

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -264,7 +264,7 @@ if type -P >/dev/null vifm; then
     viewer() ( cd "$1"; vifm -c 'view!' -c '0' - )
 else
     # shellcheck disable=SC2086
-    viewer() ( cd "$1"; command -- ${PAGER:-less -K} )
+    viewer() ( cd "$1"; command -- ${PAGER:-less -K -+F} )
 fi
 
 # check if dependency graph is valid
@@ -283,6 +283,11 @@ if ((view)); then
           # print build directories in dependency order
           xargs -I{} -a "$tmp"/queue find -L "$tmp_view"/{} -maxdepth 1
         } | viewer "$tmp_view"
+
+        # Fix for #530
+        if [[ -v PAGER ]]; then
+            read -p $'Press any key to continue or ctrl+d to abort\n'
+        fi
     fi
 fi
 


### PR DESCRIPTION
`aur sync` will use $PAGER if `vifm` is not avaiable, falling back to
`less -K` if $PAGER is unset. `aur sync` uses the exit code from this
invocation to decide if the build process should continue or should be
aborted. This is a important part of the process as continuing implies
the user reviewed and agreed to run the PKGBUILD.

While vifm and the current default (less -K) allows exiting with error
by using :cq or ^C respectively, if the user has $PAGER set to something
that doesn't wait for user input and provide a way to exit with error,
or has LESS=F which causes `less` to exit successfully if the output
fits in one page, aur sync will proceed without explicitly consent from
the user.

Let's override the -F option on our default fallback making sure it
always paginate, and prompt for confirmation whenever a custom $PAGER is
set in order to always have explicit consent from the user and a way to
abort if desired.

Fixes #530