### PR TITLE
Makefile: quote variables to prevent wordsplit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LIBDIR ?= $(PREFIX)/lib
 build: aur completion
 
 aur: aur.in
-	m4 -DAUR_LIB_DIR=$(LIBDIR)/$(PROGNM) $< >$@
+	m4 -DAUR_LIB_DIR="$(LIBDIR)/$(PROGNM)" $< >$@
 
 completion:
 	@$(MAKE) -C completions bash zsh
@@ -18,9 +18,9 @@ shellcheck: aur
 	@shellcheck -x -f gcc -e 2094,2035,2086,2016,1071 aur lib/*
 
 install:
-	@install -Dm755 aur       -t $(DESTDIR)$(BINDIR)
-	@install -Dm755 lib/aur-* -t $(DESTDIR)$(LIBDIR)/$(PROGNM)
-	@install -Dm644 man1/*    -t $(DESTDIR)$(SHRDIR)/man/man1
-	@install -Dm644 man7/*    -t $(DESTDIR)$(SHRDIR)/man/man7
-	@install -Dm644 LICENSE   -t $(DESTDIR)$(SHRDIR)/licenses/$(PROGNM)
-	@$(MAKE) -C completions DESTDIR=$(DESTDIR) install-bash install-zsh
+	@install -Dm755 aur       -t "$(DESTDIR)$(BINDIR)"
+	@install -Dm755 lib/aur-* -t "$(DESTDIR)$(LIBDIR)/$(PROGNM)"
+	@install -Dm644 man1/*    -t "$(DESTDIR)$(SHRDIR)/man/man1"
+	@install -Dm644 man7/*    -t "$(DESTDIR)$(SHRDIR)/man/man7"
+	@install -Dm644 LICENSE   -t "$(DESTDIR)$(SHRDIR)/licenses/$(PROGNM)"
+	@$(MAKE) -C completions DESTDIR="$(DESTDIR)" install-bash install-zsh

--- a/completions/Makefile
+++ b/completions/Makefile
@@ -12,8 +12,8 @@ zsh/_aur: command_opts.m4 zsh/aurutils.in ../lib/*
 	m4 $(wordlist 1,2,$^) >$@
 
 install-bash: bash/aur
-	@install -Dm644 bash/aur -t $(DESTDIR)$(SHRDIR)/bash-completion/completions
+	@install -Dm644 bash/aur -t "$(DESTDIR)$(SHRDIR)/bash-completion/completions"
 
 install-zsh: zsh/_aur
-	@install -Dm644 zsh/_aur -t $(DESTDIR)$(SHRDIR)/zsh/site-functions
-	@install -Dm755 zsh/run-help-aur -t $(DESTDIR)$(SHRDIR)/zsh/functions/Misc
+	@install -Dm644 zsh/_aur -t "$(DESTDIR)$(SHRDIR)/zsh/site-functions"
+	@install -Dm755 zsh/run-help-aur -t "$(DESTDIR)$(SHRDIR)/zsh/functions/Misc"


### PR DESCRIPTION
I came across this while debugging and trying to install aurutils manually on a `DESTDIR` that happened to contain a space.
