### PR TITLE
aur: Don't add lib_dir to PATH if already there

### DIFF
--- a/aur.in
+++ b/aur.in
@@ -22,7 +22,9 @@ if [[ -z $1 ]]; then
     exit 1
 fi
 
-readonly PATH=$lib_dir:$PATH
+if [[ "$PATH" != "$lib_dir:"* ]]; then
+    readonly PATH=$lib_dir:$PATH
+fi
 
 if type -P "aur-$1" >/dev/null; then
     exec "aur-$1" "${@:2}"


### PR DESCRIPTION
The aur wrapper prepends $lib_dir to $PATH to ensure it is using its own
scripts. But due to the modular nature of aurutils the wrapper is called
multiple times throughout multiple pipelines causing multiple instances
of $lib_dir being added to $PATH.

Only prepend $lib_dir to $PATH if it isn't the first occurrence.