### PR TITLE
aur: allow overriding aur lib_dir at build time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@ PREFIX ?= /usr
 SHRDIR ?= $(PREFIX)/share
 BINDIR ?= $(PREFIX)/bin
 LIBDIR ?= $(PREFIX)/lib
+AUR_LIB_DIR ?= $(LIBDIR)/$(PROGNM)
 
-.PHONY: shellcheck install build completion
+.PHONY: shellcheck install build completion aur
 
 build: aur completion
 
 aur: aur.in
-	m4 -DAUR_LIB_DIR="$(LIBDIR)/$(PROGNM)" $< >$@
+	m4 -DAUR_LIB_DIR='$(AUR_LIB_DIR)' $< >$@
 
 completion:
 	@$(MAKE) -C completions bash zsh
@@ -17,8 +18,10 @@ completion:
 shellcheck: aur
 	@shellcheck -x -f gcc -e 2094,2035,2086,2016,1071 aur lib/*
 
-install:
+install-aur: aur
 	@install -Dm755 aur       -t '$(DESTDIR)$(BINDIR)'
+
+install: install-aur
 	@install -Dm755 lib/aur-* -t '$(DESTDIR)$(LIBDIR)/$(PROGNM)'
 	@install -Dm644 man1/*    -t '$(DESTDIR)$(SHRDIR)/man/man1'
 	@install -Dm644 man7/*    -t '$(DESTDIR)$(SHRDIR)/man/man7'


### PR DESCRIPTION
To facilitate the customization of the aur wrapper, allow overriding the
lib_dir that becomes hardcoded in `aur`.

This can be useful in situations where the user wants to have multiple
installs running from different lib_dir's. While you can, this should
not be used to bypass the limitation that you cannot override default
scripts using aur-scripts in your $PATH.

If you do it, do it at your own risk.