### PR TITLE
sync: make confirmation prompt actually allow for any key to be pressed to continue

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -286,7 +286,7 @@ if ((view)); then
 
         # ask for confirmation when using PAGER (#530)
         if [[ -v PAGER ]]; then
-            read -p $'Press any key to continue or ctrl+d to abort\n'
+            read -n 1 -s -r -p $'Press any key to continue or ctrl+d to abort\n'
         fi
     fi
 fi


### PR DESCRIPTION
Credits to https://unix.stackexchange.com/a/293941