### PR TITLE
aur-repo: --repo-list: use full paths instead of tsv output

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -76,7 +76,7 @@ while read -r key _ value; do
             ;;
         Server=file://*)
             server=${value#file://}
-            conf_repo+=("$section" "$server")
+            conf_repo+=("$server" "$section")
 
             case $section in
                 $db_name)
@@ -103,7 +103,7 @@ case $mode in
     #requires (none)
     repo_list)
         if [[ ${conf_repo[*]} ]]; then
-            printf '%s\n' "${conf_repo[@]}" | paste - -
+            printf '%q/%q.db\n' "${conf_repo[@]}"
         else
             plain "no file:// repository configured"
         fi
@@ -112,14 +112,14 @@ esac
 
 if ! [[ $db_name ]]; then
     case ${#conf_repo[@]} in
-        2) db_name=${conf_repo[0]}
-           db_root=${conf_repo[1]}
+        2) db_root=${conf_repo[0]}
+           db_name=${conf_repo[1]}
            ;;
         0) error "no file:// repository found"
            exit 2
            ;;
         *) error "repository choice is ambiguous (use -d to specify)"
-           printf '%s\n' "${conf_repo[@]}" | paste - - | column -t >&2
+           printf '%q\n' "${conf_repo[@]}" | paste - - | column -t >&2
            exit 1
            ;;
     esac


### PR DESCRIPTION
This has two benefits:
1. Consistent with `aur-repo` when invoked without arguments, which only lists a path.
2. Makes looping over the output easier, i.e. does not require `cut`.

The repository name is simply the database name without `.db` extension, and can be retrieved with `basename`:
```
aur repo --repo-list | while read -r; do
  name=$(basename "$REPLY" .db)
done
```