### PR TITLE
aur-fetch: remove --tar support

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -1,173 +1,95 @@
 #!/bin/bash
 # aur-fetch - retrieve build files from the AUR
 readonly argv0=fetch
-readonly AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
-readonly fmt_git_clone=$AUR_LOCATION/%s.git
-readonly fmt_snapshot=$AUR_LOCATION/cgit/aur.git/snapshot/%s.tar.gz
-readonly startdir=$PWD
-readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+readonly AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
+readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 
 # default options
-mode=git recurse=0
-
-git_stat_patch() {
-    git --no-pager log -O "$1" --patch --stat '..@{upstream}'
-}
-
-merge_upstream() {
-    # set destination of patch file
-    local pkg=$1 log_dir=$2 output
-
-    if [[ -d $log_dir ]]; then
-        output=$log_dir/$pkg.patch
-    else
-        output=/dev/stdout
-    fi
-
-    # default to showing PKGBUILD diffs first (#399)
-    local orderfile=${GIT_DIR:-$PWD/.git}/orderfile
-
-    if [[ ! -s $orderfile ]]; then
-        echo PKGBUILD >"$orderfile"
-    fi
-
-    git fetch -v >&2
-
-    # only print log on upstream changes
-    if [[ $(git rev-parse HEAD) != $(git rev-parse '@{upstream}') ]]; then
-        git_stat_patch "$orderfile" >> "$output"
-
-        # discard any local changes (#349)
-        git reset --hard "HEAD@{upstream}" >&2
-    fi
-}
-
-fetch_git() {
-    local log_dir=$1 pkg uri
-
-    while IFS= read -r uri; do
-        pkg=${uri##*/}   # strip path
-        pkg=${pkg%%.git} # strip .git suffix
-
-        if [[ -d $pkg/.git ]]; then
-            # avoid issues with filesystem boundaries (#274)
-            GIT_DIR="$PWD/$pkg"/.git GIT_WORK_TREE="$PWD/$pkg" merge_upstream "$pkg" "$log_dir"
-        else
-            # abort if directory is a snapshot
-            git clone "$uri" || return
-        fi
-    done
-}
-
-diff_log() {
-    local base=$1 log_dir=$2
-
-    if [[ -d $log_dir ]]; then
-        tee -a "$log_dir/$base".diff | diffstat -Ckq -f3
-    else
-        tee
-    fi
-}
-
-tar_no_mode_diff() {
-    local archive=$1 base=$2 dir=$3
-
-    if [[ -d $dir/$base ]]; then
-        LC_MESSAGES=C tar -df "$archive" -C "$dir" | grep -Evq '(Mode|Uid|Gid)'
-    else
-        return 1
-    fi
-}
-
-fetch_tar() {
-    #global tmp
-    local log_dir=$1 archive base
-
-    wget -i /dev/stdin --directory-prefix "$tmp" || return 1
-
-    for archive in "$tmp"/*.tar.gz; do
-        base=$(basename "$archive" .tar.gz)
-        tar -kxf "$archive" --directory "$tmp"
-
-        if tar_no_mode_diff "$archive" "$base" "$startdir"; then
-            diff -ur "$startdir/$base" "$tmp/$base" | diff_log "$base" "$log_dir"
-        fi
-
-        cp -af "$tmp/$base" "$startdir"
-    done
-}
-
-linef() {
-    awk -v "fmt=$1" '{ printf(fmt, $0) }'
-}
-
-trap_exit() {
-    if [[ ! -o xtrace ]]; then
-        rm -rf "$tmp"
-    fi
-}
+verbose=0 recurse=0
 
 usage() {
-    base64 -d <<EOF
-ICAgICAgICAgICAgIC4tLX5+LF9fCjotLi4uLiwtLS0tLS0tYH5+Jy5fLicKIGAtLCwsICAsXyAg
-ICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
-EOF
-    printf >&2 'usage: %s [-L path] [-grt] pkgname...\n' "$argv0"
-    exit 1
+    cat <<! | base64 -d
+ICAgICAgICAgICAgIC4tLX5+LF9fCjotLi4uLiwtLS0tLS0tYH5+Jy5fLicKIGAtLCwsICAs
+XyAgICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
+!
+    printf 'usage: fetch [-l directory] [-rv] pkgname...\n'
 }
 
-source /usr/share/makepkg/util/util.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-opt_short='L:grt'
-opt_long=('log-dir:' 'git' 'recurse' 'tar')
+opt_short='rvl:'
+opt_long=('recurse' 'verbose' 'write_log:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
-    usage
+    usage >&2; exit 1;
 fi
 set -- "${OPTRET[@]}"
 
 unset log_dir
 while true; do
-    case "$1" in
-        -L|--log-dir) shift; log_dir=$(canonicalize_path "$1") ;;
-        -r|--recurse) recurse=1 ;;
-        -g|--git) mode=git ;;
-        -t|--tar) mode=tar ;;
+    case $1 in
+        -r|--recurse)   recurse=1 ;;
+        -v|--verbose)   verbose=1 ;;
+        -l|--write_log) shift; log_dir=$1 ;;
         --dump-options) printf -- '--%s\n' "${opt_long[@]}" ;
                         printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
                         exit ;;
         --) shift; break ;;
     esac
-    shift
 done
 
-tmp=$(mktemp -dt "$argv0".XXXXXXXX)
-trap trap_exit EXIT
-
-if ! (($#)); then
-    usage
+if [[ -v $log_dir ]] && [[ ! -d $log_dir ]]; then
+    printf 'fetch: %s: Not a directory\n' "$log_dir" >&2
+    exit 1
 fi
 
-if [[ -v log_dir ]] && [[ ! -d $log_dir ]]; then
-    printf >&2 '%s: %q: not a directory' "$argv0" "$log_dir"
-    exit 21
+if [[ ! $* ]]; then
+    printf 'fetch: No pkgname given\n' >&2
+    exit 1
 fi
 
-# set filters (1)
-case $recurse in
-    1) deps() { aur depends --pkgbase "$@"; } ;;
-    0) deps() { printf '%s\n' "$@"; } ;;
-esac
+# Prepare configuration directory.
+mkdir -p "$XDG_CONFIG_HOME"/aurutils/$argv0
 
-# set filters (2)
-case $mode in
-    git) uri() { linef "$fmt_git_clone\\n"; } ;;
-    tar) uri() { linef "$fmt_snapshot\\n" ; } ;;
-esac
+# Default to showing PKGBUILD first in patch. (#399)
+orderfile=$XDG_CONFIG_HOME/aurutils/$argv0/orderfile
 
-# pipeline
-deps "$@" | uri | fetch_$mode "$log_dir"
+if [[ ! -s $orderfile ]]; then
+    printf 'PKGBUILD\n' > "$orderfile"
+fi
+
+if (( recurse )); then
+    aur depends --pkgbase "$@"
+else
+   printf '%s\n' "$@"
+fi | while read -r pkg; do
+    if [[ -d $pkg/.git ]]; then
+        # Avoid issues with filesystem boundaries. (#274)
+        export GIT_DIR=$pkg GIT_WORK_TREE=$pkg/.git
+        git fetch --verbose
+
+        if [[ $(git rev-parse HEAD) != $(git rev-parse '@{upstream}') ]]; then
+            # Only print log on upstream changes.
+            if (( verbose )); then
+                git --no-pager log --patch --stat '..@{upstream}'
+            fi
+
+            if [[ $log_dir ]]; then
+                git --no-pager log --patch --stat '..@{upstream}' > "$log_dir"/"$GIT_DIR".patch
+                printf '%s/%s.patch\n' "$log_dir" "$GIT_DIR"
+            fi
+
+            # Discard any local changes. (#349)
+            git reset --hard 'HEAD@{upstream}' >&2
+        fi
+    else
+        if ! git clone -c diff.orderFile="$orderfile" "$AUR_LOCATION"/"$pkg".git; then
+            printf 'fetch: %s: Failed to clone repository\n' "$pkg" >&2
+            exit 1
+        fi
+    fi
+done
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -45,7 +45,7 @@ if [[ -v $log_dir ]] && [[ ! -d $log_dir ]]; then
     exit 1
 fi
 
-if [[ ! $* ]]; then
+if ! (( $# )); then
     printf 'fetch: No pkgname given\n' >&2
     exit 1
 fi

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -6,12 +6,10 @@ readonly argv0=sync
 readonly XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 readonly AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
-readonly AURDEST_SNAPSHOT=${AURDEST_SNAPSHOT:-$XDG_CACHE_HOME/aurutils/snapshot}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
 build_args=()
-fetch_args=()
 makechrootpkg_args=(-cu)
 makechrootpkg_makepkg_args=()
 makepkg_args=(--clean --syncdeps)
@@ -21,7 +19,7 @@ repo_args=()
 build=1 chkver_depth=2 download=1 view=1 provides=0 graph=1
 
 # default options (disabled)
-chroot=0 rotate=0 snapshot=0 update=0
+chroot=0 rotate=0 update=0
 
 lib32() {
     awk -v arch="$(uname -m)" '{
@@ -73,7 +71,7 @@ trap_exit() {
 }
 
 usage() {
-    plain "usage: $argv0 [-d repo] [-CDM path] [-AcfgkLnpPstTu] [--] pkgname..." >&2
+    plain "usage: $argv0 [-d repo] [-CDM path] [-AcfkLnpPsTu] [--] pkgname..." >&2
     exit 1
 }
 
@@ -85,13 +83,13 @@ if [[ -t 2 && ! -o xtrace ]]; then
     colorize
 fi
 
-opt_short='B:C:d:D:M:AcfgkLnpPrRstTu'
+opt_short='B:C:d:D:M:AcfkLnpPrRsTu'
 opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:'
           'root:' 'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue'
           'force' 'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph'
           'no-ver-shallow' 'no-view' 'print' 'provides' 'rm-deps'
-          'sign' 'temp' 'tar' 'upgrades' 'git' 'pkgver' 'rebuild'
-          'rebuild-tree' 'build-command:' 'ignore-file:')
+          'sign' 'temp' 'upgrades' 'pkgver' 'rebuild' 'rebuild-tree'
+          'build-command:' 'ignore-file:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile'
             'noconfirm' 'nover' 'nograph' 'nover-shallow' 'noview'
             'rebuildtree' 'rmdeps')
@@ -119,7 +117,6 @@ while true; do
                               makechrootpkg_makepkg_args+=(-A) ;;
         -c|--chroot)          chroot=1; build_args+=(-c) ;;
         -f|--force)           build_args+=(-f) ;;
-        -g|--git)             snapshot=0 ;;
         -L|--log)             makepkg_args+=(--log) ;;
         -P|--provides)        provides=1 ;;
         -n|--no?(-)confirm)   makepkg_args+=(--noconfirm) ;;
@@ -127,7 +124,6 @@ while true; do
         -r|--rm?(-)deps)      makepkg_args+=(--rmdeps) ;;
         -R)                   build_args+=(-R) ;;
         -s|--sign)            build_args+=(-sv) ;;
-        -t|--tar)             snapshot=1 ;;
         -T|--temp)            makechrootpkg_args+=(-T) ;;
         -u|--upgrades)        update=1 ;;
         --allan)              rotate=1 ;;
@@ -169,15 +165,7 @@ if ! (($# + update)); then
     exit 1
 fi
 
-if ((snapshot)); then
-    aur_workdir=$AURDEST_SNAPSHOT
-    fetch_args=(-L "$tmp_view" -t)
-else
-    aur_workdir=$AURDEST
-    fetch_args=(-L "$tmp_view" -g)
-fi
-
-mkdir -p "$aur_workdir"
+mkdir -p "$AURDEST"
 cd_safe "$tmp"
 
 # retrieve path to local repo (#448)
@@ -252,7 +240,7 @@ fi
 cut -f1,2 pkginfo | select_pkgbase - queue_1 >queue
 
 if [[ -s queue ]]; then
-    cd_safe "$aur_workdir"
+    cd_safe "$AURDEST"
 else
     plain "there is nothing to do" >&2
     exit
@@ -261,7 +249,7 @@ fi
 if ((download)); then
     msg "Retrieving package files" >&2
     aur jobs -Xj +3 --nice 10 --halt now,fail=1 --keep-order \
-        aur fetch "${fetch_args[@]}" :::: "$tmp"/queue
+        aur fetch -L "$tmp_view" :::: "$tmp"/queue
 fi
 
 # link build files in the queue (absolute links)

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Alad Wenter <https://github.com/AladW>
 pkgname=aurutils-git
-pkgver=2.2.0.r16.gecdb75b
+pkgver=2.3.1.r32.g80a7b6d
 pkgrel=1
 pkgdesc='helper tools for the arch user repository'
 url='https://github.com/AladW/aurutils'
@@ -10,7 +10,7 @@ source=('git+https://github.com/AladW/aurutils')
 sha256sums=('SKIP')
 conflicts=('aurutils')
 provides=("aurutils=${pkgver%%.r*}")
-depends=('git' 'jq' 'expac' 'diffstat' 'pacutils' 'parallel' 'wget')
+depends=('git' 'jq' 'expac' 'pacutils' 'parallel' 'wget')
 makedepends=('git')
 optdepends=('bash-completion: bash completion'
             'devtools: aur-chroot'

--- a/man1/aur-repo.1
+++ b/man1/aur-repo.1
@@ -4,9 +4,10 @@ aur\-repo \- manage local repositories
 
 .SH SYNOPSIS
 .SY "aur repo"
+.OP \-c config
 .OP \-d database
 .OP \-r root
-.OP \-alSu
+.OP \-aluS
 .OP \-\-repo\-list
 .YS
 
@@ -33,6 +34,17 @@ through the
 environment variable.
 
 .TP
+.BR \-a ", " \-\-all
+Use
+.B "aur\-vercmp --all"
+when checking for updates. Implies
+.BR \-\-upgrades .
+
+.TP
+.BR \-c ", " \-\-pacman\-conf
+
+
+.TP
 .BR \-l ", " \-\-list
 List the contents of the repository in
 .BI pkgname\tpkgver
@@ -43,22 +55,15 @@ option is not enabled, the repository is queried directly through the
 file on-disk.
 
 .TP
+.BR \-S ", " \-\-sync
+Query repositories through
+.BR pacman (8).
+
+.TP
 .BR \-u ", " \-\-upgrades
 Use
 .BR aur\-vercmp (1)
 to check a pacman repository for updates.
-
-.TP
-.BR \-a ", " \-\-all
-Use
-.B "aur\-vercmp --all"
-when checking for updates. Implies
-.BR \-\-upgrades .
-
-.TP
-.BR \-S ", " \-\-sync
-Query repositories through
-.BR pacman (8).
 
 .TP
 .BR \-\-repo\-list
@@ -71,6 +76,5 @@ format.
 .SH SEE ALSO
 .BR aur (1),
 .BR aur\-vercmp (1),
-.BR expac (1),
 .BR pacman (8),
 .BR pacman.conf (5)

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -123,16 +123,6 @@ The path pointing to the container. (\fBaur build \-D\fR)
 Do not download package files.
 
 .TP
-.BR \-g ", " \-\-git
-Clone AUR repositories with
-.BR git-clone (1).
-
-.TP
-.BR \-t ", " \-\-tar
-Download AUR snapshots (\fIpkgbase.tar.gz\fR) and extract them with
-.BR tar (1).
-
-.TP
 .BR \-\-noview ", " \-\-no\-view
 Do not present build files for inspection.
 
@@ -302,13 +292,6 @@ works around this by stripping the
 prefix from packages and removing
 .I gcc\-multilib
 if the i686 architecture is detected.
-
-.I tar
-snapshots are extracted to the
-.I $AURDEST_SNAPSHOT
-directory in order to avoid conflicts with
-.BR git (1)
-repositories.
 
 .SH SEE ALSO
 .BR aur (1),


### PR DESCRIPTION
This is based on a `sh` rewrite by @Earnestly of #525, in particular https://github.com/AladW/aurutils/pull/525#issuecomment-471142788. The version in this PR mainly adds some boilerplate for completions. The changes to the current `aur-fetch` are:

* Remove tar support. It was originally added due to git pull being slow on high workloads, but since using `parallel` in `aur-sync` the difference is small.
* Add `--verbose` and `--write-log` to print diffs to stdout and to `.patch` files in a directory, respectively. Both options may be combined.
* Save the git orderfile for all cloned `git` repositories in `$XDG_CONFIG_HOME/aurutils/fetch`.

The man page is not yet complete and should include a description on how diffs are generated and resets are done.