### PR TITLE
Remove expac dependency

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -9,16 +9,10 @@ vercmp_args=()
 
 db_namever() {
     awk '/%NAME%/ {
-        getline
-        printf("%s\t", $1)
+        getline; pkgname=$1
     } /%VERSION%/ {
-        getline
-        printf("%s\n", $1)
+        getline; printf("%s\t%s\n", pkgname, $1)
     }'
-}
-
-ex_namever() {
-    awk -F"/" -v rname="^$1/" '$0 ~ rname { print $NF }'
 }
 
 usage() {
@@ -34,8 +28,9 @@ if [[ -t 2 && ! -o xtrace ]]; then
 fi
 
 ## option parsing
-opt_short='d:r:alSu'
-opt_long=('all' 'database:' 'list' 'root:' 'upgrades' 'repo-list' 'sync')
+opt_short='c:d:r:aluS'
+opt_long=('database:' 'pacman-conf:' 'root:'
+          'all' 'list' 'repo-list' 'sync' 'upgrades')
 opt_hidden=('dump-options' 'status-file:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -48,12 +43,11 @@ while true; do
     case $1 in
         -d|--database)      shift; db_name=$1 ;;
         -r|--root)          shift; db_root=$1 ;;
-        -a|--all)           mode=list_upgrades
-                            vercmp_args+=(-a) ;;
-        -C|--pacman-conf)   shift; pacman_conf=$1 ;;
+        -c|--pacman-conf)   shift; pacman_conf=$1 ;;
+        -a|--all)           mode=list_upgrades; vercmp_args+=(-a) ;;
         -l|--list)          mode=list_packages ;;
-        -u|--upgrades)      mode=list_upgrades ;;
         -S|--sync)          modifier=sync ;;
+        -u|--upgrades)      mode=list_upgrades ;;
         --repo-list)        mode=repo_list ;;
         --status-file)      shift; status_file=$1 ;;
         --dump-options)     printf -- '--%s\n' "${opt_long[@]}" ;
@@ -74,6 +68,9 @@ while read -r key _ value; do
     case $key=$value in
         \[*\]*)
             section=${key:1:-1}
+            ;;
+        DBPath=)
+            pacman_dbpath=$key
             ;;
         Server=file://*)
             server=${value#file://}
@@ -150,7 +147,7 @@ case $modifier in
     #requires
     # - [$db_name] (pacman.conf)
     sync)
-        contents() { expac -Sv '%r/%n\t%v' | ex_namever "$db_name"; }
+        contents() { bsdcat "$pacman_dbpath/sync/$db_name".db | db_namever; }
         ;;
 esac
 

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -53,11 +53,6 @@ while true; do
     shift
 done
 
-if ! [[ -e ${sysroot}/etc/pacman.conf ]]; then
-    error "$argv0: invalid sysroot (${sysroot}/etc/pacman.conf does not exist)"
-    exit 2
-fi
-
 if ((sync_repo)); then
     sift_args+=(--sync)
 elif [[ -v argv_repo ]]; then

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -6,19 +6,17 @@ readonly arch_repo=(core extra testing community{,-testing} multilib{,-testing})
 
 # The command line will hit ARG_MAX on approximately 70k packages;
 # spread arguments with xargs (and printf, as a shell built-in).
-print_args() {
-    printf -- '--satisfies=%s\n' "$@"
-}
-
 satisfies() {
     #global sift_args
-    xargs -a <(print_args "$@") pacsift --null "${sift_args[@]}" <&-
+    xargs -a <(printf -- '--satisfies=%s\n' "$@") pacsift "${sift_args[@]}" <&-
 }
 
-# Use null delimimitation as repository names may contain (apart from
-# newlines) arbitrary characters.
 provides() {
-    xargs -0r expac '%n %R %S' -Sv
+    pacinfo | awk -F'[:<=>]' '
+        /Name:/     { pkgname=$2; print $2, $2; }
+        /Provides:/ { print pkgname, $2; }
+        /Replaces:/ { print pkgname, $2; }
+    '
 }
 
 usage() {
@@ -54,6 +52,11 @@ while true; do
     esac
     shift
 done
+
+if ! [[ -e ${sysroot}/etc/pacman.conf ]]; then
+    error "$argv0: invalid sysroot (${sysroot}/etc/pacman.conf does not exist)"
+    exit 2
+fi
 
 if ((sync_repo)); then
     sift_args+=(--sync)
@@ -100,28 +103,23 @@ fi
 # checks for a package satisfying this condition. Results are printed
 # as "repository/package", and piped to expac to relate the names of
 # the original provides to its corresponding package(s).
-satisfies "${strset[@]}" | provides | while read -ra array; do
-    package=${array[0]}
-
+satisfies "${strset[@]}" | provides | while read -r package virtual; do
     if [[ ${pkgset[$package]} ]]; then
         printf '%s\n' "$package"
     fi
 
-    for ((i = 1; i < ${#array[@]}; i++)); do
-        virtual=${array[$i]}
+    if [[ $virtual != "$package" ]]; then
+        version=${pkgset[$virtual]}
+    else
+        continue
+    fi
 
-        case $virtual in
-            None) continue ;;
-               *) version=${pkgset[$virtual]} ;;
-        esac
-
-        case $version in
-            1) plain "dependency $virtual satisfied by $package" >&2
-               printf '%s\n' "$virtual" ;;
-            *) plain "dependency $virtual$version satisfied by $package" >&2
-               printf '%s\n' "$virtual" ;;
-        esac
-    done
+    case $version in
+        1) plain "dependency $virtual satisfied by $package" >&2
+           printf '%s\n' "$virtual" ;;
+        *) plain "dependency $virtual$version satisfied by $package" >&2
+           printf '%s\n' "$virtual" ;;
+    esac
 done
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -101,7 +101,7 @@ fi
 
 # Standard input is taken as "provides[<cmp><version>]", where pacsift
 # checks for a package satisfying this condition. Results are printed
-# as "repository/package", and piped to expac to relate the names of
+# as "repository/package", and piped to pacinfo to relate the names of
 # the original provides to its corresponding package(s).
 satisfies "${strset[@]}" | provides | while read -r package virtual; do
     if [[ ${pkgset[$package]} ]]; then

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -10,7 +10,7 @@ source=('git+https://github.com/AladW/aurutils')
 sha256sums=('SKIP')
 conflicts=('aurutils')
 provides=("aurutils=${pkgver%%.r*}")
-depends=('git' 'jq' 'expac' 'pacutils' 'parallel' 'wget')
+depends=('git' 'jq' 'pacutils' 'parallel' 'wget')
 makedepends=('git')
 optdepends=('bash-completion: bash completion'
             'devtools: aur-chroot'

--- a/man1/aur-repo-filter.1
+++ b/man1/aur-repo-filter.1
@@ -48,7 +48,7 @@ https://github.com/andrewgregory/pacutils/issues/26.
 
 .SH SEE ALSO
 .BR aur (1),
-.BR expac (1),
+.BR pacinfo (1),
 .BR pacsift (1)
 
 .SH AUTHORS

--- a/man1/aur-repo-filter.1
+++ b/man1/aur-repo-filter.1
@@ -6,6 +6,7 @@ aur\-repo\-filter \- filter packages in the Arch Linux repositories
 .SY "aur repo-filter"
 .OP \-a
 .OP \-d database
+.OP \-\-sysroot
 .YS
 
 .SH DESCRIPTION
@@ -38,13 +39,10 @@ Query all available pacman repositories.
 Query a given pacman repository.  Multiple repositories may be
 specified by repeating this argument.
 
-.SH NOTES
-Due to
-.BR expac (1)
-limitations,
-.BR aur\-repo\-filter (1)
-only works with the local pacman configuration in
-.BR /etc/pacman.conf .
+.TP
+.BI \-\-sysroot= NAME
+Set an alternate system root. See
+.BR pacutils\-sysroot (7).
 
 .SH SEE ALSO
 .BR aur (1),

--- a/man1/aur-repo-filter.1
+++ b/man1/aur-repo-filter.1
@@ -1,4 +1,4 @@
-.TH AUR-REPO-FILTER 1 2019-01-24 AURUTILS
+.TH AUR-REPO-FILTER 1 2019-03-17 AURUTILS
 .SH NAME
 aur\-repo\-filter \- filter packages in the Arch Linux repositories
 
@@ -6,26 +6,26 @@ aur\-repo\-filter \- filter packages in the Arch Linux repositories
 .SY "aur repo-filter"
 .OP \-a
 .OP \-d database
-.OP \-\-sysroot
 .YS
 
 .SH DESCRIPTION
 .B aur\-repo\-filter
 checks if
-.IR package[<cmp><version>]
-(taken from standard input) is satisfied by a package in the official
-Arch Linux repositories \- that is,
+.IR package[<cmp><version>] ,
+taken from standard input, is satisfied by a package in the official
+Arch Linux repositories. In particular, the
 .BR core ,
 .BR extra ,
 .BR testing ,
 .BR community ,
 .BR community\-testing ,
 .BR multilib ,
-or
-.BR multilib\-testing .
+and
+.BR multilib\-testing
+repositories are checked.
 
-If found, the package is printed to standard output.  If the package
-is provided by a package of a different name, the latter is printed to
+The package is printed to standard output if found.  If the package is
+provided by a package of a different name, the latter is printed to
 standard error.
 
 .SH OPTIONS
@@ -36,13 +36,15 @@ Query all available pacman repositories.
 
 .TP
 .BI \-d " NAME" "\fR,\fP \-\-database=" NAME "\fR,\fP \-\-repo=" NAME
-Query a given pacman repository.  Multiple repositories may be
-specified by repeating this argument.
+Restrict output to the pacman repository
+.IR NAME .
+Multiple repositories may be specified by repeating this argument.
 
-.TP
-.BI \-\-sysroot= NAME
-Set an alternate system root. See
-.BR pacutils\-sysroot (7).
+.SH NOTES
+.BR pacutils\-sysroot (7)
+is not implemented, see
+.UR
+https://github.com/andrewgregory/pacutils/issues/26.
 
 .SH SEE ALSO
 .BR aur (1),


### PR DESCRIPTION
* **aur-repo-filter**
  + Recent versions of `pacinfo` have an easy to parse, line-by-line format, removing the need for `expac`. Newline seperation should suffice, so remove `--null`.
* **aur-repo**
  + Using `DBPath` allows to run `db_namever` on the sync db for a given repository.

The man page of `aur-repo-filter` should likely be updated to mention why #542 could not be implemented.