### PR TITLE
 fetch: preserve committed modifications to package 

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -78,21 +78,25 @@ fi | while read -r pkg; do
         # Avoid issues with filesystem boundaries. (#274)
         export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
 
-        git fetch "${fetch_args[@]}" || exit 1
+        # Discard any local uncommited changes. (#552)
+        git reset --hard HEAD >&2
+        git pull --rebase "${fetch_args[@]}" || exit 1
 
-        if [[ $(git rev-parse HEAD) != $(git rev-parse '@{upstream}') ]]; then
+        if ! git diff-files --diff-filter=U --quiet; then
+            warning '%s: Local commits conflict with upstream. Fix the conflicts and commit them.' "$pkg"
+            exit 1
+        fi
+
+        if [[ $(git rev-parse ORIG_HEAD) != $(git rev-parse HEAD) ]]; then
             # Only print log on upstream changes.
             if (( verbose )); then
-                git --no-pager log --patch --stat '..@{upstream}'
+                git --no-pager log --patch --stat 'ORIG_HEAD..HEAD'
             fi
 
             if [[ $log_dir ]]; then
-                git --no-pager log --patch --stat '..@{upstream}' > "$log_dir/$pkg".patch
+                git --no-pager log --patch --stat 'ORIG_HEAD..HEAD' > "$log_dir/$pkg".patch
                 printf '%s/%s.patch\n' "$log_dir" "$GIT_DIR"
             fi
-
-            # Discard any local changes. (#349)
-            git reset --hard 'HEAD@{upstream}' >&2
         fi
     else
         if git clone "$AUR_LOCATION"/"$pkg".git; then

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -7,7 +7,7 @@ readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
-verbose=0 recurse=0 fetch_args=('--verbose')
+verbose=0 recurse=0 fetch_args=('--verbose') confirm_seen=0
 
 usage() {
     cat <<! | base64 -d
@@ -26,7 +26,7 @@ if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == alw
 fi
 
 opt_short='rvL:'
-opt_long=('recurse' 'verbose' 'write-log:' 'force')
+opt_long=('recurse' 'verbose' 'write-log:' 'force' 'confirm-seen')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -41,6 +41,7 @@ while true; do
         -r|--recurse)   recurse=1 ;;
         -v|--verbose)   verbose=1 ;;
         --force)        fetch_args+=('--force') ;;
+        --confirm-seen) confirm_seen=1 ;;
         --dump-options) printf -- '--%s\n' "${opt_long[@]}" ;
                         printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g' ;
                         exit ;;
@@ -69,6 +70,10 @@ if [[ ! -s $orderfile ]]; then
     printf 'PKGBUILD\n' > "$orderfile"
 fi
 
+if ((confirm_seen)); then
+    msg "Marking repositories as seen"
+fi
+
 if (( recurse )); then
     aur depends --pkgbase "$@"
 else
@@ -77,6 +82,12 @@ fi | while read -r pkg; do
     if [[ -d $pkg/.git ]]; then
         # Avoid issues with filesystem boundaries. (#274)
         export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
+
+        if (( confirm_seen )); then
+            git update-ref AURUTILS_SEEN HEAD
+            msg2 'Marked %s as seen' "$pkg"
+            continue
+        fi
 
         # Discard any local uncommited changes. (#552)
         git reset --hard HEAD >&2
@@ -87,19 +98,26 @@ fi | while read -r pkg; do
             exit 1
         fi
 
-        if [[ $(git rev-parse ORIG_HEAD) != $(git rev-parse HEAD) ]]; then
-            # Only print log on upstream changes.
+        seen=$(git rev-parse --quiet --verify AURUTILS_SEEN);
+
+        if [[ "$seen" != $(git rev-parse HEAD) ]]; then
+            log_range="${seen:+$seen..}HEAD"
+
             if (( verbose )); then
-                git --no-pager log --patch --stat 'ORIG_HEAD..HEAD'
+                git --no-pager log --patch --stat "${log_range}"
             fi
 
             if [[ $log_dir ]]; then
-                git --no-pager log --patch --stat 'ORIG_HEAD..HEAD' > "$log_dir/$pkg".patch
-                printf '%s/%s.patch\n' "$log_dir" "$GIT_DIR"
+                logfile="$log_dir/$pkg".patch
+                gen_patchfile "${log_range[@]}" >"$logfile"
+                plain '%s' "$logfile"
             fi
         fi
     else
         if git clone "$AUR_LOCATION"/"$pkg".git; then
+            if (( confirm_seen )); then
+                warning 'fetch: --confirm-seen for %s ignored on first clone' "$pkg"
+            fi
             # show PKGBUILDS first (#399)
             git -C "$pkg" config diff.orderFile "$orderfile"
             # only allow fast-forward fetches. (#)

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -294,6 +294,7 @@ if ((view)); then
             read -rp $'Press Return to continue or Ctrl+d to abort\n'
         fi
     fi
+    xargs -a "$tmp/queue" aur fetch --confirm-seen
 fi
 
 if ((build)); then

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -7,7 +7,11 @@ aur\-fetch \- download packages from the AUR
 .OP \-L log_dir
 .OP \-r
 .OP \-v
-.IR "package [package...]"
+.IR package " [" package... ]
+.YS
+.SY "aur fetch"
+.OP \-\-confirm\-seen
+.IR package " [" package... ]
 .YS
 
 .SH DESCRIPTION
@@ -36,6 +40,11 @@ Print logs to
 will refuse to fetch if history was rewritten. This option allows
 overriding that check. (see \fIHISTORY REWRITES\fR under \fINOTES\fR)
 
+.TP
+.B \-\-confirm\-seen
+Marks the pacakge's checked out commit as seen.
+
+
 .SH NOTES
 
 .SS HISTORY REWRITES
@@ -50,6 +59,29 @@ To raise awareness to these events,
 will refuse to fetch unless
 .B \-\-force
 is passed.
+
+
+.SS LOGS
+The logs shown by
+.B aur-fetch
+show changes that happened since the commit referenced by the
+special reference
+.B AURUTILS_SEEN
+stored inside the repository.
+
+This reference can be created with with:
+
+.EX
+    \fB$ aur fetch --confirm-seen \fI<package> \fR[\fP<pacakge>...\fR]\fR
+.EE
+
+which will mark the current commit as seen, signaling
+.B aur-fetch
+that current changes should not be shown in future logs.
+
+When this reference is missing,
+.B aur-fetch
+will consider the entire history as changes.
 
 
 .SS LOCAL MODIFICATIONS (EXPERIMENTAL)
@@ -74,6 +106,7 @@ markers for the user to resolve.
 .BR git\-log (1),
 .BR git\-rev\-parse (1),
 .BR git\-reset (1),
+.BR git\-update\-ref (1)
 
 .SH AUTHORS
 .MT https://github.com/AladW

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -51,6 +51,19 @@ will refuse to fetch unless
 .B \-\-force
 is passed.
 
+
+.SS LOCAL MODIFICATIONS (EXPERIMENTAL)
+While
+.B aur-fetch
+will try to preserve changes committed locally, by trying to reapply
+them on top of the incoming new changes, it will discard any uncommitted
+changes present in the repository.
+
+If the changes cannot be applied cleanly,
+.B aur-fetch
+will exit with error, leaving the repository files with conflict
+markers for the user to resolve.
+
 .SH SEE ALSO
 .BR aur (1),
 .BR aur\-depends (1),


### PR DESCRIPTION
On bc8d5c8 (fetch-git: discard local changes ... 2018-04-12)
aurutils took a holistic approach when it comes to allowing users
modifying files inside cached repos. Discarding any changes when a
package is to be updated.

This obviously isn't very practical, as some packages require
adjustments because they're either broken or the user wants to tune a
particular aspect of it.

Another concern was that automating non-fast-forward merges could end up
keeping commits that TU wrote out of history. But that being addressed
by ad8723d (fetch: refuse to fetch non-fast-forward refs, 2019-03-18),
allow us take a different approach:

Discard any uncommitted changes but reapply any local commits on top of
the incoming changes.

Only local user commits have the potential to generate conflicts when
applied, in which case aur fetch will fail with error.

This should allow us to have user persistent modifications and be in
sync with AUR with minimal chances for conflicts.

prerequisite: #551