### PR TITLE
scripts: respect environment variable AUR_COLOR

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -6,6 +6,7 @@ readonly argv0=build
 readonly startdir=$PWD
 readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default arguments
 chroot_args=()
@@ -47,7 +48,7 @@ source /usr/share/makepkg/util/util.sh
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -3,6 +3,7 @@
 readonly argv0=depends
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 readonly max_request=30
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 mode=pkgname
@@ -79,7 +80,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -4,6 +4,7 @@ readonly argv0=fetch
 readonly AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
 readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 verbose=0 recurse=0 fetch_args=('--verbose')
@@ -20,7 +21,7 @@ XyAgICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -2,6 +2,7 @@
 # aur-repo - manage local repositories
 readonly argv0=repo
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default arguments
 modifier=local
@@ -23,7 +24,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -3,6 +3,7 @@
 readonly argv0=repo-filter
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 readonly arch_repo=(core extra testing community{,-testing} multilib{,-testing})
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # The command line will hit ARG_MAX on approximately 70k packages;
 # spread arguments with xargs (and printf, as a shell built-in).
@@ -27,7 +28,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -3,6 +3,7 @@
 readonly argv0=search
 readonly AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 multiple=section
@@ -113,7 +114,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 1 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -4,6 +4,7 @@ readonly argv0=srcver
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 readonly startdir=$PWD
 makepkg_args=('--nobuild' '--nodeps' '--skipinteg')
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 srcver_pkgbuild_info() {
     env -C "$1" -i bash -c '
@@ -43,7 +44,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -7,6 +7,7 @@ readonly XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 readonly AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default arguments
 build_args=()
@@ -79,7 +80,7 @@ source /usr/share/makepkg/util/util.sh
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -3,6 +3,7 @@
 set -o pipefail
 readonly argv0=vercmp
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 format=check
@@ -75,7 +76,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -111,6 +111,20 @@ Check packages for AUR updates.
 Programs follow a subset of errno(3), or preserve command status where
 applicable.
 
+.SH ENVIRONMENT
+.TP
+.B AUR_COLOR
+Output colorization can be controlled by setting this environment variable
+to
+.B always
+to force colorization on,
+.B auto
+to colorize output only if both \fBstdout\fR and \fBstderr\fR are connected to
+a terminal, while
+.B never
+or any unrecognized value will disable colorization completely. The default value is
+.BR auto .
+
 .SH CREATING A LOCAL REPOSITORY
 A local repository may be configured directly in
 .BR /etc/pacman.conf ,


### PR DESCRIPTION
When color options are not specified, color ouput unless stdout or
stderr is not connected to a terminal.

With --color and --no-color, the colorization can be forced on or off.