### PR TITLE
Do not prompt after vifm review when PAGER is set

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -255,12 +255,19 @@ fi
 # link build files in the queue (absolute links)
 aur jobs -X ln -s "$(pwd -P)"/{} "$tmp_view" :::: "$tmp"/queue
 
+# Explicitly define if exit success is to be trusted (#561)
+trust_exit_success=0
 if type -P >/dev/null vifm; then
     # avoid directory prefix in printed paths (#452)
     viewer() ( cd "$1"; vifm -c 'view!' -c '0' - )
+    trust_exit_success=1
 else
     # shellcheck disable=SC2086
     viewer() ( cd "$1"; command -- ${PAGER:-less -K -+F} )
+    # Trust our fallback
+    if [[ -z $PAGER ]]; then
+        trust_exit_success=1
+    fi
 fi
 
 # check if dependency graph is valid
@@ -269,6 +276,7 @@ if ((graph)); then
 fi
 
 if ((view)); then
+    # AUR_PAGER exit codes are respected by definition.
     if [[ -v AUR_PAGER ]]; then
         # shellcheck disable=SC2086
         command -- $AUR_PAGER "$tmp_view"
@@ -280,8 +288,8 @@ if ((view)); then
           xargs -I{} -a "$tmp"/queue find -L "$tmp_view"/{} -maxdepth 1
         } | viewer "$tmp_view"
 
-        # ask for confirmation when using PAGER (#530)
-        if [[ -v PAGER ]]; then
+        # ask for confirmation when viewer() exit success is not trusted (#530) (#561)
+        if ! ((trust_exit_success)); then
             read -rp $'Press Return to continue or Ctrl+d to abort\n'
         fi
     fi


### PR DESCRIPTION
aurutils should trust `vifm` exit codes as a signal that build files
were reviewed. But (532), the fix for (530), does not properly handle
all use cases. In particular, it asks for confirmation after review in
`vifm` if PAGER is set, when PAGER wasn't used in the first place.
Fix that.