### PR TITLE
manpages fixes

### DIFF
--- a/man1/aur-depends.1
+++ b/man1/aur-depends.1
@@ -36,7 +36,7 @@ in total order. All dependencies are printed.
 .BR \-t ", " \-\-table
 Output dependency information in the following format:
 
-.B pkgname\\\\tdepends\\\\tpkgbase\\\\tpkgver
+.BI pkgname\etdepends\etpkgbase\etpkgver
 
 .SH NOTES
 Version information is ignored for dependencies. See

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -1,54 +1,45 @@
-.TH AUR-FETCH 1 2018-02-14 AURUTILS
+.TH AUR-FETCH 1 2018-03-17 AURUTILS
 .SH NAME
 aur\-fetch \- download packages from the AUR
 
 .SH SYNOPSIS
 .SY "aur fetch"
 .OP \-L log_dir
-.OP \-t
-.OP \-g
 .OP \-r
+.OP \-v
 .IR "package [package...]"
 .YS
 
 .SH DESCRIPTION
 .B aur\-fetch
-downloads packages, specified on the command-line, from the AUR. It is
-capable of handling
-.BR tar (1)
-archives and
-.BR git (1)
-repositories.
+downloads packages, specified on the command-line, from the AUR.
 
 .SH OPTIONS
 .TP
-.BI \-M " FILE" "\fR,\fP \-\-makepkg\-conf=" FILE
 .BI \-L " DIRECTORY" "\fR,\fP \-\-write\-log=" DIRECTORY
 The location of where to store the diffs of previously unpacked
 archives.
 
 .TP
-.B \-t
-Download packages as
-.I tar
-archives.
-
-.TP
-.B \-g
-Download packages as
-.I git
-repositories.
-
-.TP
-.B \-r
+.BR \-r ", " \-\-recurse
 Download packages and their dependencies with
 .BR aur-depends (1).
+
+.TP
+.BR \-v ", " \-\-verbose
+Print logs to
+.BR stdout .
 
 .SH SEE ALSO
 .BR aur (1),
 .BR aur\-depends (1),
 .BR git (1),
-.BR tar (1)
+.BR git\-clone (1),
+.BR git\-fetch (1),
+.BR git\-pull (1),
+.BR git\-log (1),
+.BR git\-rev\-parse (1),
+.BR git\-reset (1),
 
 .SH AUTHORS
 .MT https://github.com/AladW

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -30,6 +30,27 @@ Download packages and their dependencies with
 Print logs to
 .BR stdout .
 
+.TP
+.BR \-\-force
+.B aur\-fetch
+will refuse to fetch if history was rewritten. This option allows
+overriding that check. (see \fIHISTORY REWRITES\fR under \fINOTES\fR)
+
+.SH NOTES
+
+.SS HISTORY REWRITES
+.B aur-fetch
+will refuse to fetch rewritten history by default. This happens rarely,
+as only Trusted Users have permissions to force-push to the AUR.
+
+In those situations, something serious may have happened that may
+require the user to do manual intervention on the machine.
+To raise awareness to these events,
+.B aur-fetch
+will refuse to fetch unless
+.B \-\-force
+is passed.
+
 .SH SEE ALSO
 .BR aur (1),
 .BR aur\-depends (1),

--- a/man1/aur-repo.1
+++ b/man1/aur-repo.1
@@ -67,11 +67,7 @@ to check a pacman repository for updates.
 
 .TP
 .BR \-\-repo\-list
-List all local (with a
-.B file://
-prefix) pacman repositories, in
-.BI name\tServer
-format.
+List all local pacman repositories.
 
 .SH SEE ALSO
 .BR aur (1),

--- a/man1/aur-repo.1
+++ b/man1/aur-repo.1
@@ -78,3 +78,10 @@ format.
 .BR aur\-vercmp (1),
 .BR pacman (8),
 .BR pacman.conf (5)
+
+.SH AUTHORS
+.MT https://github.com/AladW
+Alad Wenter
+.ME
+
+.\" vim: set textwidth=72:

--- a/man1/aur-repo.1
+++ b/man1/aur-repo.1
@@ -47,7 +47,7 @@ when checking for updates. Implies
 .TP
 .BR \-l ", " \-\-list
 List the contents of the repository in
-.BI pkgname\tpkgver
+.BI pkgname \et pkgver
 format. If the
 .B \-S
 option is not enabled, the repository is queried directly through the

--- a/man1/aur-search.1
+++ b/man1/aur-search.1
@@ -20,38 +20,38 @@ interface, and displayed in a brief format.
 
 .SH OPTIONS
 .TP
-.B \-q ", " \-\-short
+.BR \-q ", " \-\-short
 Only display package name, version and description.
 
 .TP
-.B \-r ", " \-\-raw
+.BR \-r ", " \-\-raw
 Display the unprocessed JSON output.
 
 .TP
-.B \-v ", " \-\-verbose
+.BR \-v ", " \-\-verbose
 Display more package information.
 
 .TP
-.B \-i ", " \-\-info
+.BR \-i ", " \-\-info
 Use the
 .I info
 interface instead of
 .IR searchby .
 
 .TP
-.B \-d ", " \-\-desc
+.BR \-d ", " \-\-desc
 Search by package name and description.
 
 .TP
-.B \-m ", " \-\-maintainer
+.BR \-m ", " \-\-maintainer
 Search by maintainer.
 
 .TP
-.B \-n ", " \-\-name
+.BR \-n ", " \-\-name
 Search by package name.
 
 .TP
-.B \-\-depends
+.BR \-\-depends
 Search for packages with keywords in
 .BR depends .
 

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -222,15 +222,6 @@ Default:
 .I $XDG_CACHE_HOME/aurutils/sync
 .RE
 
-.B AURDEST_SNAPSHOT
-.RS
-Determines where build files will be copied when using snapshots
-(\fBaur sync \-t\fR). This must be an absolute path.
-
-Default:
-.I $XDG_CACHE_HOME/aurutils/snapshot
-.RE
-
 .B AUR_PAGER
 .RS
 The file manager used to view and edit build files. This variable is

--- a/man1/aur-vercmp-devel.1
+++ b/man1/aur-vercmp-devel.1
@@ -80,3 +80,10 @@ inspection.
 \" The last pipeline will also show any non-VCS dependencies.  Since
 \" the respective PKGBUILDs are not run by aur-srcver, they are not of
 \" relevance. Use aur-fetch manually?
+
+.SH AUTHORS
+.MT https://github.com/AladW
+Alad Wenter
+.ME
+
+.\" vim: set textwidth=72:

--- a/man1/aur-vercmp.1
+++ b/man1/aur-vercmp.1
@@ -27,7 +27,7 @@ applicable to
 .BR \-c .)
 
 .TP
-.B \-c ", " \-\-current
+.BR \-c ", " \-\-current
 Changes format to print packages with an equal or newer version to
 .BR stdout .\&
 A human\-readable version of the comparison will be printed to
@@ -44,7 +44,7 @@ and
 space-separated).
 
 .TP
-.B \-q ", " \-\-quiet
+.BR \-q ", " \-\-quiet
 Only print package names to standard output.
 
 .TP


### PR DESCRIPTION
A couple of documentation fixes. 

Quick summary:
- Removes references related to `aur fetch --tar`
- Adds missing documentation of `aur fetch --force`
- Updates the documentation of `aur repo --repo-list`
- Fixes to things that were missing or not being correctly rendered 