### PR TITLE
scripts: respect environment variable AUR_COLOR, part 2

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -4,6 +4,7 @@ set -o errexit
 readonly argv0=chroot
 readonly PATH=/bin:/usr/bin
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 machine=$(uname -m)
 readonly machine
@@ -40,7 +41,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -5,6 +5,7 @@ readonly argv0=pkglist
 readonly cache=${XDG_CACHE_HOME:-$HOME/.cache}/aurutils/$argv0
 readonly AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 delay=300
@@ -41,7 +42,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-rpc
+++ b/lib/aur-rpc
@@ -3,6 +3,7 @@
 readonly argv0=rpc
 readonly AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}):${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 declare -i rpc_ver=5
@@ -37,7 +38,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ -t 2 && ! -o xtrace ]]; then
+if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 


### PR DESCRIPTION
Some of the scripts failed to receive the #557 treatment,
9dba6dd (scripts: respect environment variable AUR_COLOR, 2019-04-15).

Correct that.