### PR TITLE
fetch: remove use of undefined function gen_patchfile

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -109,7 +109,7 @@ fi | while read -r pkg; do
 
             if [[ $log_dir ]]; then
                 logfile="$log_dir/$pkg".patch
-                gen_patchfile "${log_range[@]}" >"$logfile"
+                git --no-pager log --patch --stat "${log_range}" >"$logfile"
                 plain '%s' "$logfile"
             fi
         fi


### PR DESCRIPTION
`gen_patchfile` is defined in PR-565 and was used here by mistake.

Correct that by reverting to the explict git call.