### PR TITLE
aur-repo: fix --sync option

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -70,8 +70,8 @@ while read -r key _ value; do
         \[*\]*)
             section=${key:1:-1}
             ;;
-        DBPath=)
-            pacman_dbpath=$key
+        DBPath=*)
+            pacman_dbpath=$value
             ;;
         Server=file://*)
             server=${value#file://}


### PR DESCRIPTION
fc4fc06 (aur-repo: remove expac, 2019-03-14) breaks --sync by
incorrectly determining pacman_dbpath.

Fix that.