### PR TITLE
aur-fetch: Generate full patch on first clone

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -83,43 +83,8 @@ if (( recurse )); then
 else
    printf '%s\n' "$@"
 fi | while read -r pkg; do
-    if [[ -d $pkg/.git ]]; then
-        # Avoid issues with filesystem boundaries. (#274)
-        export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
-
-        if (( confirm_seen )); then
-            git update-ref AURUTILS_SEEN HEAD
-            msg2 'Marked %s as seen' "$pkg"
-            continue
-        fi
-
-        # Discard any local uncommited changes. (#552)
-        git reset --hard HEAD >&2
-        if ! git pull --rebase "${fetch_args[@]}"; then
-            error '%s: Failed to integrate changes.' "$pkg"
-            exit 1
-        fi
-
-        seen=$(git rev-parse --quiet --verify AURUTILS_SEEN)
-
-        if [[ "$seen" != $(git rev-parse HEAD) ]]; then
-            log_range=(HEAD ${seen:+^$seen})
-
-            if (( verbose )); then
-                gen_patchfile "${log_range[@]}"
-            fi
-
-            if [[ $log_dir ]]; then
-                logfile="$log_dir/$pkg".patch
-                gen_patchfile "${log_range[@]}" >"$logfile"
-                plain '%s' "$logfile"
-            fi
-        fi
-    else
+    if [[ ! -e $pkg ]]; then
         if git clone "$AUR_LOCATION"/"$pkg".git; then
-            if (( confirm_seen )); then
-                warning 'fetch: --confirm-seen for %s ignored on first clone' "$pkg"
-            fi
             # show PKGBUILDS first (#399)
             git -C "$pkg" config diff.orderFile "$orderfile"
             # only allow fast-forward fetches. (#)
@@ -127,6 +92,37 @@ fi | while read -r pkg; do
         else
             error '%s: %s: Failed to clone repository' "$argv0" "$pkg"
             exit 1
+        fi
+    fi
+    # Avoid issues with filesystem boundaries. (#274)
+    export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
+
+    if (( confirm_seen )); then
+        git update-ref AURUTILS_SEEN HEAD
+        msg2 'Marked %s as seen' "$pkg"
+        continue
+    fi
+
+    # Discard any local uncommited changes. (#552)
+    git reset --hard HEAD >&2
+    if ! git pull --rebase "${fetch_args[@]}"; then
+        error '%s: Failed to integrate changes.' "$pkg"
+        exit 1
+    fi
+
+    seen=$(git rev-parse --quiet --verify AURUTILS_SEEN)
+
+    if [[ "$seen" != $(git rev-parse HEAD) ]]; then
+        log_range=(HEAD ${seen:+^$seen})
+
+        if (( verbose )); then
+            gen_patchfile "${log_range[@]}"
+        fi
+
+        if [[ $log_dir ]]; then
+            logfile="$log_dir/$pkg".patch
+            gen_patchfile "${log_range[@]}" >"$logfile"
+            plain '%s' "$logfile"
         fi
     fi
 done

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -94,8 +94,10 @@ fi | while read -r pkg; do
             exit 1
         fi
     fi
-    # Avoid issues with filesystem boundaries. (#274)
-    export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
+    # Avoid issues with filesystem boundaries, (#274)
+    # and make sure we have a valid git repository.
+    GIT_DIR=$(git rev-parse --resolve-git-dir "$pkg"/.git) || exit
+    export GIT_DIR GIT_WORK_TREE=$pkg
 
     if (( confirm_seen )); then
         git update-ref AURUTILS_SEEN HEAD


### PR DESCRIPTION
Review patches are not being generated on first clone. Fix that.

If --confirm-seen is used on first clone cases, it is assumed the user
trusts the source and the patch generation is skipped.

Hint: Easier to review if whitespace changes are hidden
https://github.com/AladW/aurutils/pull/586/files?w=1