### PR TITLE
Fix aur color

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -48,7 +48,7 @@ source /usr/share/makepkg/util/util.sh
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ( -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -41,7 +41,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ( -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -80,7 +80,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ( -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -25,7 +25,7 @@ XyAgICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ( -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -42,7 +42,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ( -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -38,7 +38,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ( -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -24,7 +24,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ( -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -28,7 +28,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ( -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -44,7 +44,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ( -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -80,7 +80,7 @@ source /usr/share/makepkg/util/util.sh
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ( -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 
@@ -258,6 +258,7 @@ parallel -X ln -s "$(pwd -P)"/{} "$tmp_view" :::: "$tmp"/queue
 
 # Explicitly define if exit success is to be trusted (#561)
 trust_exit_success=0
+
 if type -P >/dev/null vifm; then
     # avoid directory prefix in printed paths (#452)
     viewer() ( cd "$1"; vifm -c 'view!' -c '0' - )
@@ -265,6 +266,7 @@ if type -P >/dev/null vifm; then
 else
     # shellcheck disable=SC2086
     viewer() ( cd "$1"; command -- ${PAGER:-less -K -+F} )
+
     # Trust our fallback
     if [[ -z $PAGER ]]; then
         trust_exit_success=1

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -76,7 +76,7 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ( -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
     colorize
 fi
 

--- a/man1/aur-search.1
+++ b/man1/aur-search.1
@@ -75,12 +75,42 @@ Search for packages with keywords in
 Sort results via a key, defaulting to
 .IR Name .
 
-Valid choices are \fIName\fR, \fIVersion\fR, \fINumVotes\fR,
-\fIDescription\fR (for brief output) or \fIName\fR, \fIPackageBase\fR,
-\fIVersion\fR, \fIDescription\fR, \fIURL\fR, \fINumVotes\fR,
-\fIPopularity\fR, \fIOutOfDate\fR, \fIMaintainer\fR,
-\fIFirstSubmitted\fR, \fILastModified\fR (for \fB\-v\fR verbose
-output).
+Valid choices are
+.IR Name ,
+.IR Version ,
+.IR NumVotes ,
+.IR Description
+(for brief output) or
+.IR Name ,
+.IR PackageBase ,
+.IR Version ,
+.IR Description ,
+.IR URL ,
+.IR NumVotes ,
+.IR Popularity ,
+.IR OutOfDate ,
+.IR Maintainer ,
+.IR FirstSubmitted ,
+.IR LastModified
+(for \fB\-v\fR verbose output).
+
+.SH ENVIRONMENT
+.TP
+.B AUR_COLOR
+Output colorization can be controlled by setting this environment
+variable to
+.B always
+for forcing colorization, or
+.B auto
+to colorize output only if both
+.B stdout
+and
+.B stderr
+are connected to a terminal.
+.B never
+or any unrecognized value will disable colorization completely. The
+default value is
+.BR auto .
 
 .SH EXIT STATUS
 The exit status is 0 on valid results, 1 if no results were found, or

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -108,22 +108,28 @@ Check packages for AUR updates.
 .RE
 
 .SH EXIT STATUS
-Programs follow a subset of errno(3), or preserve command status where
-applicable.
+Programs follow a subset of
+.BR errno (3),
+or preserve command status where applicable.
 
 .SH ENVIRONMENT
 .TP
 .B AUR_COLOR
-Output colorization can be controlled by setting this environment variable
-to
+Output colorization can be controlled by setting this environment
+variable to
 .B always
-to force colorization on,
+for forcing colorization, or
 .B auto
-to colorize output only if both \fBstdout\fR and \fBstderr\fR are connected to
-a terminal, while
+to colorize output only if
+.B stderr
+is connected to a terminal.
 .B never
-or any unrecognized value will disable colorization completely. The default value is
+or any unrecognized value will disable colorization completely. The
+default value is
 .BR auto .
+
+See also
+.BR aur\-search (1).
 
 .SH CREATING A LOCAL REPOSITORY
 A local repository may be configured directly in


### PR DESCRIPTION
All `aur` scripts currently check if both `stdout` and `stderr` are connected to a terminal when determining if color should be enabled (`AUR_COLOR=auto`). However, only `aur-search` prints colored messages to `stdout`.

Change this so that scripts apart from `aur-search` only check `stderr` for colorization.

Closes #585