### PR TITLE
aur.1: add AUR_SHELLOPTS

### DIFF
--- a/aur.in
+++ b/aur.in
@@ -26,8 +26,17 @@ if [[ "$PATH" != "$lib_dir:"* ]]; then
     readonly PATH=$lib_dir:$PATH
 fi
 
+unset shellopts
+while getopts eux opt "$AUR_SHELLOPTS"; do
+    case $opt in
+        e) shellopts+=('-e') ;;
+        u) shellopts+=('-u') ;;
+        x) shellopts+=('-x') ;;
+    esac
+done
+
 if type -P "aur-$1" >/dev/null; then
-    exec "aur-$1" "${@:2}"
+    bash "${shellopts[@]}" "aur-$1" "${@:2}"
 else
     printf >&2 '%s: %q is not an aur command\n' "$argv0" "$1"
     exit 1

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -236,11 +236,7 @@ while IFS= read -ru "$fd" path; do
         env PKGDEST="$var_tmp" aur chroot --no-prepare "${chroot_args[@]}" -- "${makechrootpkg_args[@]}"
     else
         printf '%s\n' >&2 "Running makepkg ${makepkg_args[*]}"
-
-        # unset SHELLOPTS due to odd behavior with fakeroot (a /bin/sh
-        # script) when it is set in the environment. see:
-        # https://lists.gnu.org/archive/html/bug-bash/2011-10/msg00052.html
-        env -u SHELLOPTS makepkg --config "$tmp"/makepkg.conf "${makepkg_args[@]}"
+        makepkg --config "$tmp"/makepkg.conf "${makepkg_args[@]}"
     fi
 
     cd_safe "$var_tmp"

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -125,6 +125,16 @@ a terminal, while
 or any unrecognized value will disable colorization completely. The default value is
 .BR auto .
 
+.TP
+.B AUR_SHELLOPTS
+Shell options passed to
+.B aur
+programs. Valid options are
+.BR x " (xtrace),"
+.BR e " (errexit),"
+and
+.BR u " (nounset)."
+
 .SH CREATING A LOCAL REPOSITORY
 A local repository may be configured directly in
 .BR /etc/pacman.conf ,


### PR DESCRIPTION
This allows to run aur programs with a few select bash options (-x, -u
and -e), in particular removing the need to export SHELLOPTS for all
child processes.

Closes #571