### PR TITLE
aur-sync: allow to add comments to ignore-file

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -150,7 +150,7 @@ trap 'trap_exit' EXIT
 
 # append contents of ignore file
 if [[ -f ${ignore_file=$XDG_CONFIG_HOME/aurutils/sync/ignore} ]]; then
-    while read -r i; do pkg_i+=("$i"); done < "$ignore_file"
+    while IFS="#" read -r i _; do pkg_i+=("$i"); done < "$ignore_file"
 fi
 
 if ((rotate)); then

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -52,7 +52,8 @@ separating them with a comma, or by repeating the \fB\-\-ignore\fR option.
 .BI \-\-ignore\-file= FILE
 Ignore package upgrades listed in
 .IR FILE .
-Each package name should be specified on a separate line. Defaults to
+Each package name should be specified on a separate line. Comments may
+be specified after a number sign. Defaults to
 .BR $XDG_CONFIG_HOME/aurutils/sync/ignore .
 
 .TP


### PR DESCRIPTION
This allows adding reason(s) why a specific package was put on ignore.