### PR TITLE
implement NO_COLOR

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -6,7 +6,6 @@ readonly argv0=build
 readonly startdir=$PWD
 readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default arguments
 chroot_args=()
@@ -48,8 +47,8 @@ source /usr/share/makepkg/util/util.sh
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
-    colorize
+if [[ ! -v NO_COLOR ]] && [[ ! -o xtrace ]]; then
+    [[ -t 2 ]] && colorize
 fi
 
 ## option parsing
@@ -119,7 +118,7 @@ case $db_name in
                 db_name=$(basename "$db_path" .db)
                 db_root=$(dirname "$db_path")
                 ;;
-             *) error "$argv0: root specified without database name"
+             *) error '%s: root specified without database name' "$argv0"
                 exit 1 ;;
         esac ;;
     *)
@@ -135,12 +134,12 @@ esac
 
 # resolve symbolic link
 if ! db_path=$(readlink -e -- "$db_path"); then
-    error "$argv0: $db_path: no such file or directory"
+    error '%s: %s: no such file or directory' "$argv0" "$db_path"
     exit 2
 fi
 
 if ! [[ -w $db_path ]]; then
-    error "$argv0: $db_path: permission denied"
+    error '%s: %s: permission denied' "$argv0" "$db_path"
     exit 13
 fi
 
@@ -155,7 +154,7 @@ if [[ -v results_file ]]; then
     if [[ -w $results_file ]]; then
         results=1
     else
-        error "$argv0: $results_file: permission denied"
+        error '%s: %s: permission denied' "$argv0" "$results_file"
         exit 13
     fi
 fi
@@ -169,8 +168,7 @@ else
     db_sigs=("$db_root/$db_name".sig "$db_root/$db_name".files.sig)
 
     if [[ -f ${db_sigs[0]} ]]; then
-        # avoid errors from stale db.sig files
-        error "$argv0: database signature found, but signing is disabled"
+        error '%s: database signature found, but signing is disabled' "$argv0"
 
         printf '%q\n' >&2 "${db_sigs[@]}"
         exit 1
@@ -221,7 +219,7 @@ while IFS= read -ru "$fd" path; do
         done < <(PKGDEST="$db_root" makepkg --packagelist)
 
         if [[ ${mark[*]} ]]; then
-            warning "skipping built package (use -f to overwrite)"
+            warning '%s: skipping built package (use -f to overwrite)' "$argv0"
 
             printf '%q\n' >&2 "${mark[@]}"
             continue
@@ -249,13 +247,13 @@ while IFS= read -ru "$fd" path; do
 
     # pkglist should not be empty (#513)
     if [[ ${pkglist[*]} == '!(*.sig)' ]]; then
-        error "$argv0: invalid argument (no packages found)"
+        error '%s: invalid argument (no packages found)' "$argv0"
         exit 22
     fi
 
     for p in "${pkglist[@]}"; do
         if [[ -f $p.sig ]]; then
-            warning "$argv0: existing package signature found"
+            warning '%s: existing package signature found' "$argv0"
             siglist+=("$p".sig)
 
         elif ((sign_pkg)); then

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -3,7 +3,6 @@
 readonly argv0=depends
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 readonly max_request=30
-readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 mode=pkgname
@@ -32,7 +31,7 @@ chain() {
     num=$(count json/0)
 
     if ((num < 1)); then
-        printf '%s: no packages found\n' "$argv0" >&2
+        printf >&2 '%s: no packages found\n' "$argv0"
         exit 1
     fi
 
@@ -73,16 +72,11 @@ trap_exit() {
 }
 
 usage() {
-    plain 'usage: %s [-abnt]' "$argv0" >&2
+    printf >&2 'usage: %s [-abnt]\n' "$argv0"
     exit 1
 }
 
-source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
-
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
-    colorize
-fi
 
 opt_short='abnt'
 opt_long=('table' 'pkgbase' 'pkgname' 'pkgname-all')
@@ -119,7 +113,7 @@ if cd "$tmp" && mkdir json tsv; then
         1) true # no dependencies
            ;;
         $max_request)
-            error "$argv0: total requests: $((max_request+1)) (out of range)"
+            printf >&2 '%s: total requests: %d (out of range)\n' "$argv0" $((max_request+1))
             exit 34 ;;
     esac
 
@@ -156,7 +150,7 @@ if cd "$tmp" && mkdir json tsv; then
             cat tsv/n
             ;;
         *)
-            error "$argv0: invalid argument"
+            printf >&2 '%s: invalid argument' "$argv0"
             exit 22 ;;
     esac
 else

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -4,7 +4,6 @@ readonly argv0=fetch
 readonly AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
 readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
-readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 verbose=0 recurse=0 fetch_args=('--verbose') confirm_seen=0
@@ -25,8 +24,8 @@ XyAgICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
-    colorize
+if [[ ! -v NO_COLOR ]] && [[ ! -o xtrace ]]; then
+    [[ -t 2 ]] && colorize
 fi
 
 opt_short='rvL:'

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -5,7 +5,6 @@ readonly argv0=pkglist
 readonly cache=${XDG_CACHE_HOME:-$HOME/.cache}/aurutils/$argv0
 readonly AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 delay=300
@@ -22,7 +21,7 @@ list_update() {
     if wget -O - -o last_transfer "$1" | gzip -d - > "$2"; then
         extract_date "$2"
     else
-        printf >&2 'warning: failed to retrieve package list\n'
+        printf >&2 '%s: warning: failed to retrieve package list\n' "$argv0"
     fi
 }
 
@@ -30,21 +29,16 @@ list_http_date() {
     if wget -S --spider -o last_transfer "$1"; then
         awk -F', ' '/Date:/ {print $2}' last_transfer
     else
-        printf >&2 'warning: failed to retrieve HTTP date\n'
+        printf >&2 '%s: warning: failed to retrieve HTTP date\n' "$argv0"
     fi
 }
 
 usage() {
-    plain 'usage: %s [-bt] [-FP pattern]' "$argv0" >&2
+    printf >&2 'usage: %s [-bt] [-FP pattern]\n' "$argv0"
     exit 1
 }
 
-source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
-
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
-    colorize
-fi
 
 opt_short='t:bFP'
 opt_long=('pkgbase' 'fixed-strings' 'perl-regexp' 'time:')

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -3,7 +3,6 @@
 readonly argv0=query
 readonly AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}):${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 declare -i rpc_ver=5
@@ -31,16 +30,11 @@ uri_search() {
 }
 
 usage() {
-    plain 'usage: %s [-t [info|search] ] [-b by]' "$argv0" >&2
+    printf 'usage: %s [-t [info|search] ] [-b by]' "$argv0" >&2
     exit 1
 }
 
-source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
-
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
-    colorize
-fi
 
 opt_short='b:t:'
 opt_long=('by:' 'type:' 'aur-url:' 'rpc-ver:' 'rpc-url:')

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -2,7 +2,6 @@
 # aur-repo - manage local repositories
 readonly argv0=repo
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default arguments
 modifier=local
@@ -17,16 +16,11 @@ db_namever() {
 }
 
 usage() {
-    plain 'usage: %s [-d repo] [-r path] [-alSu]' "$argv0" >&2
+    printf >&2 'usage: %s [-d repo] [-r path] [-alSu]\n' "$argv0"
     exit 1
 }
 
-source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
-
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
-    colorize
-fi
 
 ## option parsing
 opt_short='c:d:r:aluS'
@@ -82,7 +76,7 @@ while read -r key _ value; do
                     if ! [[ $db_root ]]; then
                         db_root=$server
                     elif [[ $db_root != "$server" ]]; then
-                        warning "$db_name: --root and pacman.conf mismatch"
+                        printf >&2 '%s: warning: --root and pacman.conf mismatch (%s)\n' "$argv0" "$db_name"
                     fi ;;
             esac
             ;;
@@ -104,7 +98,7 @@ case $mode in
         if [[ ${conf_repo[*]} ]]; then
             printf '%q/%q.db\n' "${conf_repo[@]}"
         else
-            plain "no file:// repository configured"
+            printf >&2 '%s: no file:// repository configured\n' "$argv0"
         fi
         exit 0 ;;
 esac
@@ -114,10 +108,10 @@ if ! [[ $db_name ]]; then
         2) db_root=${conf_repo[0]}
            db_name=${conf_repo[1]}
            ;;
-        0) error "no file:// repository found"
+        0) printf >&2 '%s: no file:// repository found\n' "$argv0"
            exit 2
            ;;
-        *) error "repository choice is ambiguous (use -d to specify)"
+        *) printf >&2 '%s: repository choice is ambiguous (use -d to specify)\n' "$argv0"
            printf '%q\n' "${conf_repo[@]}" | paste - - | column -t >&2
            exit 1
            ;;
@@ -133,13 +127,13 @@ case $modifier in
     # - $db_root/$db_name (path)
     local)
         if ! [[ $db_root ]]; then
-            error "$db_name: repository path not found"
+            printf >&2 '%s: %s: repository path not found\n' "$argv0" "$db_name"
             exit 2
         elif [[ $db_root == *://* ]]; then
-            error "$db_root: object is remote (use -S to query)"
+            printf >&2 '%s: %s: object is remote (use -S to query)\n' "$argv0" "$db_root"
             exit 66
         elif ! [[ -d $db_root ]]; then
-            error "$db_root: not a directory"
+            printf >&2 '%s: %s: not a directory\n' "$argv0" "$db_root"
             exit 20
         else
             contents() { bsdcat "$db_root/$db_name".db | db_namever; }

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -3,7 +3,6 @@
 readonly argv0=repo-filter
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 readonly arch_repo=(core extra testing community{,-testing} multilib{,-testing})
-readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # The command line will hit ARG_MAX on approximately 70k packages;
 # spread arguments with xargs (and printf, as a shell built-in).
@@ -25,12 +24,7 @@ usage() {
     exit 1
 }
 
-source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
-
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
-    colorize
-fi
 
 opt_short='d:a'
 opt_long=('all' 'sync' 'database:' 'repo:')
@@ -111,9 +105,9 @@ satisfies "${strset[@]}" | provides | while read -r package virtual; do
     fi
 
     case $version in
-        1) plain "dependency $virtual satisfied by $package" >&2
+        1) printf >&2 'dependency %s satisfied by %s\n' "$virtual" "$package"
            printf '%s\n' "$virtual" ;;
-        *) plain "dependency $virtual$version satisfied by $package" >&2
+        *) printf >&2 'dependency %s%s satisfied by %s\n' "$virtual" "$version" "$package"
            printf '%s\n' "$virtual" ;;
     esac
 done

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -3,7 +3,6 @@
 readonly argv0=search
 readonly AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 multiple=section
@@ -114,7 +113,10 @@ usage() {
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
+if [[ ! -v NO_COLOR ]] && [[ ! -o xtrace ]]; then
+    # We use colored messages on both stdout and stderr, and these may
+    # be desired even if stdout is not connected to a terminal. (in
+    # particular, aur search foo | less -R, #585)
     colorize
 fi
 
@@ -199,7 +201,7 @@ error=$(jq -r '.error' "$tmp")
 
 case $count in
     0) if [[ $error != 'null' ]]; then
-           error "$error"
+           error '%s' "$error"
            exit 2
        else
            # no results found

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -2,7 +2,6 @@
 # aur-srcver - update and print package revisions
 readonly argv0=srcver
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-readonly AUR_COLOR=${AUR_COLOR-auto}
 
 srcver_pkgbuild_info() {
     env -C "$1" -i bash -c '
@@ -25,16 +24,11 @@ trap_exit() {
 }
 
 usage() {
-    plain 'usage: %s [--noprepare] <pkgbase> [<pkgbase> ...]' "$argv0" >&2
+    printf >&2 'usage: %s [--noprepare] <pkgbase> [<pkgbase> ...]\n' "$argv0"
     exit 1
 }
 
-source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
-
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
-    colorize
-fi
 
 opt_short=j:
 opt_long=('no-prepare' 'jobs:')
@@ -96,10 +90,10 @@ for n in "$@"; do
 done
 
 for f in "${failed[@]}"; do
-    warning 'makepkg %s failed for package %s' "${makepkg_args[*]}" "$f"
+    printf >&2 '%s: makepkg %s failed for package %s\n' "$argv0" "${makepkg_args[*]}" "$f"
 
     cat "$tmp/$f"/log >&2
-    plain '8<----'  >&2
+    printf >&2 '8<----\n'
 done
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -7,7 +7,6 @@ readonly XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 readonly AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default arguments
 build_args=()
@@ -80,8 +79,8 @@ source /usr/share/makepkg/util/util.sh
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
-    colorize
+if [[ ! -v NO_COLOR ]] && [[ ! -o xtrace ]]; then
+    [[ -t 2 ]] && colorize
 fi
 
 opt_short='B:C:d:D:M:AcfkLnpPrRsTu'
@@ -162,7 +161,7 @@ if ((rotate)); then
 fi
 
 if ! (($# + update)); then
-    error "$argv0: no targets specified"
+    error '%s: no targets specified' "$argv0"
     exit 1
 fi
 
@@ -177,9 +176,9 @@ aur repo "${repo_args[@]}" --list --status-file=db >db_info
 } <db
 
 if [[ -w $db_root/$db_name.db ]]; then
-    msg "Using [$db_name] repository" >&2
+    msg 'Using [%s] repository' "$db_name" >&2
 else
-    error "$argv0: $db_root/$db_name.db: permission denied"
+    error '%s: %s: permission denied' "$argv0" "$db_root/$db_name.db"
     exit 13
 fi
 
@@ -233,7 +232,7 @@ if order depends >queue_0; then
     tac queue_0 | lib32 | complement filter >queue_1
 else
     # input contains a loop
-    error "$argv0: invalid argument"
+    error '%s: invalid argument' "$argv0"
     exit 22
 fi
 

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -3,7 +3,6 @@
 set -o pipefail
 readonly argv0=vercmp
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-readonly AUR_COLOR=${AUR_COLOR-auto}
 
 # default options
 format=check
@@ -19,11 +18,11 @@ cmp_equal_or_newer() {
         esac
 
         case $op in
-           -1) plain "$pkg: $v_cmp is newer than $v_in" >&2
+           -1) plain '%s: %s is newer than %s' "$pkg" "$v_cmp" "$v_in" >&2
                printf '%s\n' "$pkg" ;;
             0) printf '%s\n' "$pkg" ;;
-            1) msg2 "$pkg: $v_cmp -> $v_in" >&2 ;;
-            2) msg2 "$pkg: (none) -> $v_in" >&2 ;;
+            1) msg2 '%s: %s -> %s' "$pkg" "$v_cmp" "$v_in" ;;
+            2) msg2 '%s: (none) -> %s' "$pkg" "$v_in" ;;
         esac
     done
 }
@@ -69,15 +68,15 @@ trap_exit() {
 }
 
 usage() {
-    plain 'usage: %s [-p path] [-acq]' "$argv0" >&2
+    plain >&2 'usage: %s [-p path] [-acq]' "$argv0"
     exit 1
 }
 
 source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == always ]] ; then
-    colorize
+if [[ ! -v NO_COLOR ]] && [[ ! -o xtrace ]]; then
+    [[ -t 2 ]] && colorize
 fi
 
 opt_short='p:u:acq'

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -113,17 +113,11 @@ applicable.
 
 .SH ENVIRONMENT
 .TP
-.B AUR_COLOR
-Output colorization can be controlled by setting this environment variable
-to
-.B always
-to force colorization on,
-.B auto
-to colorize output only if both \fBstdout\fR and \fBstderr\fR are connected to
-a terminal, while
-.B never
-or any unrecognized value will disable colorization completely. The default value is
-.BR auto .
+
+.TP
+.B NO_COLOR
+Output colorization can be disabled by setting this environment
+variable to any value.
 
 .SH CREATING A LOCAL REPOSITORY
 A local repository may be configured directly in


### PR DESCRIPTION
This commit replaces `AUR_COLOR` with `NO_COLOR`, effectively removing `AUR_COLOR=always`. `aur-search` is now colorized unconditionally, leaving disabling colors to the user.

For simplicity, colors are removed from the plumbing commands as well.

Fixes #585

----
Taken from https://github.com/rafasc/aurutils/commit/4c8222fe2f487f696f751608954b6ff1906896ac