### PR TITLE
add mollyguard for aur-build/aur-sync

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -52,6 +52,13 @@ if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == alw
     colorize
 fi
 
+# mollyguard for makepkg
+if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
+    warning 'aur-%s is not meant to be run as root.' "$argv0"
+    warning 'To proceed anyway, set the %s variable.' 'AUR_ASROOT'
+    exit 1
+fi
+
 ## option parsing
 opt_short='a:B:C:d:D:M:r:cfNRXsv'
 opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign'

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -84,6 +84,13 @@ if [[ ( -t 1 && -t 2 && ! -o xtrace && $AUR_COLOR == auto ) || $AUR_COLOR == alw
     colorize
 fi
 
+# mollyguard for makepkg
+if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
+    warning 'aur-%s is not meant to be run as root.' "$argv0"
+    warning 'To proceed anyway, set the %s variable.' 'AUR_ASROOT'
+    exit 1
+fi
+
 opt_short='B:C:d:D:M:AcfkLnpPrRsTu'
 opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:'
           'root:' 'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue'


### PR DESCRIPTION
`makepkg` does not support `--asroot` since pacman 4.2, and extra care should be taken when trying to run it as root (such as dropping privileges). Add a mollyguard to prevent this from accidentally happening, e.g. through `sudo aur sync`.

Since the behavior is self-explanatory and not required for normal operation, I did not document the variable in `aur-build(1)` or `aur-sync(1)`.