### PR TITLE
aur-srcver: remove makepkg --log

### DIFF
--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -45,7 +45,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-makepkg_args=('--nobuild' '--nodeps' '--skipinteg' '--log')
+makepkg_args=('--nobuild' '--nodeps' '--skipinteg')
 num_procs=$(("$(nproc)" + 2))
 
 while true; do


### PR DESCRIPTION
`--log` was added as workaround when `makepkg` output went "missing" while using `parallel`. Since we no longer use parallel (and `--log` apparently stacks the logs, potentially resulting in dozens of log files), remove the option again.