### PR TITLE
shellcheck: minimize exclusions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ completion:
 	@$(MAKE) -C completions bash zsh
 
 shellcheck: aur
-	@shellcheck -x -f gcc -e 2094,2035,2086,2016,1071 aur lib/*
+	@shellcheck -x -f gcc -e 1071 aur lib/*
 
 install-aur: aur
 	@install -Dm755 aur       -t '$(DESTDIR)$(BINDIR)'

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -4,6 +4,7 @@ readonly argv0=srcver
 readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 srcver_pkgbuild_info() {
+    # shellcheck disable=SC2016
     env -C "$1" -i bash -c '
         PATH= source PKGBUILD
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -192,6 +192,7 @@ fi
 } >argv
 
 if [[ -s argv ]]; then
+    # shellcheck disable=SC2094
     # $1 pkgname $2 depends $3 pkgbase $4 pkgver
     xargs --arg-file=argv aur depends --table >depends
 else


### PR DESCRIPTION
Only ignore unsuported languages (SC1071)

Hide false positives on a case by case basis