### PR TITLE
aur-sync: add --provides-any

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -89,7 +89,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:'
           'force' 'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph'
           'no-ver-shallow' 'no-view' 'print' 'provides' 'rm-deps'
           'sign' 'temp' 'upgrades' 'pkgver' 'rebuild' 'rebuild-tree'
-          'build-command:' 'ignore-file:')
+          'build-command:' 'ignore-file:' 'provides-any')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile'
             'noconfirm' 'nover' 'nograph' 'nover-shallow' 'noview'
             'rebuildtree' 'rmdeps')
@@ -119,6 +119,7 @@ while true; do
         -f|--force)           build_args+=(-f) ;;
         -L|--log)             makepkg_args+=(--log) ;;
         -P|--provides)        provides=1 ;;
+        --provides-any)       provides_any=1 ;;
         -n|--no?(-)confirm)   makepkg_args+=(--noconfirm) ;;
         -p|--print)           build=0 ;;
         -r|--rm?(-)deps)      makepkg_args+=(--rmdeps) ;;
@@ -221,8 +222,10 @@ cut -f2 --complement depends | sort -u >pkginfo
       esac
   fi
 
-  if ((provides)); then
-      # note: this uses pacman's copy of the repo (as used by makepkg -s)
+  # note: this uses pacman's copy of the repo (as used by makepkg -s)
+  if (( provides_any )); then
+      cut -f1 pkginfo | complement argv | aur repo-filter
+  elif (( provides )); then
       cut -f1 pkginfo | complement argv | aur repo-filter -d "$db_name"
   fi
 } >filter

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -138,11 +138,17 @@ upgrades are taken as target regardless of this setting.
 
 .RS
 .B Note:
-This option does not take other repositories than the local repository 
-into account. Furthermore, the version output from
+The version output from
 .BR aur\-vercmp (1)
 is unaffected by this option.
 .RE
+
+.TP
+.B \-\-provides\-any
+As
+.BR \-\-provides ,
+but considers virtual dependencies in any available pacman
+repository.
 
 .TP
 .BI \-d " NAME" "\fR,\fP \-\-database=" NAME


### PR DESCRIPTION
This allows to take packages from other (local) repositories as dependencies. See also https://github.com/AladW/aurutils/pull/581#issuecomment-532862450.