### PR TITLE
aur-build: ensure aur-repo always gets the pacman config

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -13,6 +13,7 @@ gpg_args=(--detach-sign --no-armor --batch)
 makechrootpkg_args=(-cu)
 makepkg_args=(--clean --syncdeps)
 repo_add_args=()
+pacman_conf="/etc/pacman.conf"
 
 # default options
 chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0
@@ -63,7 +64,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset queue db_name db_path db_root build_cmd m_conf p_conf results_file
+unset queue db_name db_path db_root build_cmd m_conf results_file
 while true; do
     case "$1" in
         -a|--arg-file)      shift; queue=$1 ;;
@@ -77,7 +78,7 @@ while true; do
         -v|--verify)        repo_add_args+=(-v) ;;
         -B|--build-command) shift; build_cmd+=("$1") ;;
         -D|--directory)     shift; chroot_args+=(-D "$1") ;;
-        -C|--pacman-conf)   shift; chroot_args+=(-C "$1"); p_conf=$1 ;;
+        -C|--pacman-conf)   shift; chroot_args+=(-C "$1"); pacman_conf=$1 ;;
         -M|--makepkg-conf)  shift; chroot_args+=(-M "$1"); m_conf=$1 ;;
         -N|--no-sync)       no_sync=1 ;;
         -R|--remove)        repo_add_args+=(-R) ;;
@@ -114,7 +115,7 @@ fi
 case $db_name in
     "")
         case $db_root in
-            "") db_path=$(aur repo)
+            "") db_path=$(aur repo --pacman-conf "$pacman_conf")
                 db_name=$(basename "$db_path" .db)
                 db_root=$(dirname "$db_path")
                 ;;
@@ -183,7 +184,7 @@ if ((chroot)); then
 fi
 
 # Configuration for host builds.
-pacman-conf --config "${p_conf:-/etc/pacman.conf}" | conf_single "$db_name" >"$tmp"/custom.conf
+pacman-conf --config "$pacman_conf" | conf_single "$db_name" >"$tmp"/custom.conf
 
 # PKGDEST is defined later through makepkg.conf (#513)
 unset PKGDEST

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -99,14 +99,14 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset pkg pkg_i ignore_file
+unset pkg pkg_i ignore_file pacman_conf
 while true; do
     case "$1" in
         -d|--database)        shift; repo_args+=(-d "$1") ;;
         -B|--build-command)   shift; build_args+=(-B "$1") ;;
         -D|--directory)       shift; build_args+=(-D "$1") ;;
         -M|--makepkg-conf)    shift; build_args+=(--makepkg-conf "$1") ;;
-        -C|--pacman-conf)     shift; build_args+=(--pacman-conf "$1") ;;
+        -C|--pacman-conf)     shift; pacman_conf="$1"; build_args+=(--pacman-conf "$1") ;;
         --bind)               shift; makechrootpkg_args+=(-D "$1") ;;
         --bind-rw)            shift; makechrootpkg_args+=(-d "$1") ;;
         --ignore)             shift; IFS=, read -a pkg -r <<< "$1"
@@ -169,7 +169,7 @@ mkdir -p "$AURDEST"
 cd_safe "$tmp"
 
 # retrieve path to local repo (#448)
-aur repo "${repo_args[@]}" --list --status-file=db >db_info
+aur repo --pacman-conf "${pacman_conf:-/etc/pacman.conf}" "${repo_args[@]}" --list --status-file=db >db_info
 
 { IFS= read -r db_name
   IFS= read -r db_root


### PR DESCRIPTION
* [aur-build] Ensure we propegate pacman.conf to aur-repo when finding
              the repository we build against.
* [aur-build] Renamed p_conf to pacman_conf for internal consistency

* [aur-chroot] Ensure pacman.conf is propegated to aur-repo when we find
               the build repo.