### PR TITLE
man1: document pacman db size limits

### DIFF
--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -451,6 +451,15 @@ does not catch this signal, the
 .B \-\-rmdeps
 option is disabled by default.
 
+.BR pacman (8)
+has a size\-limit of 25\~MiB for databases. Using larger databases may result in an
+.B expected download size exceeded
+error. To avoid this issue, compress the database with
+.BR gzip (1).
+See
+.UR https://\:git.archlinux.org/\:pacman.git/\:commit/\:?id=\:6dc71926f9b16ebcf11b924941092d6eab204224
+.UE .
+
 .SH SEE ALSO
 .BR aur (1),
 .BR aur\-repo (1),

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -153,15 +153,15 @@ Append a section for the local repository to
 Create the repository root and database:
 .EX
 
-  $ sudo install -d /home/custompkgs -o $USER
-  $ repo-add /home/custompkgs/custom.db.tar
+  $ sudo install \-d /home/custompkgs \-o $USER
+  $ repo\-add /home/custompkgs/custom.db.tar.gz
 
 .EE
 If built packages are available, add them to the database:
 .EX
 
   $ cd /home/custompkgs
-  $ repo-add -n custom.db.tar ./*.pkg.tar.xz
+  $ repo\-add \-n custom.db.tar.gz *.pkg.tar.xz
 
 .EE
 Synchronize pacman:
@@ -183,8 +183,7 @@ when rebuilding packages without increasing
 .BR pkgrel .
 (See GitHub issue #85)
 
-There are several ways to avoid this. A first approach is to set the
-repository path as a
+To avoid this, set the repository path as a
 .B pacman
 .IR CacheDir ,
 together with the


### PR DESCRIPTION
Databases over 25M may result in "expected download size exceeded"
errors on pacman -Syu. Document this limitation, and change the example
on creating a new repository to enable gz compression.

Fixes #594