### PR TITLE
Use AUR_SEEN instead of AURUTILS_SEEN

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -106,7 +106,7 @@ fi | while read -r pkg; do
     export GIT_DIR GIT_WORK_TREE=$pkg
 
     if (( confirm_seen )); then
-        git update-ref AURUTILS_SEEN HEAD
+        git update-ref AUR_SEEN HEAD
         msg2 'Marked %s as seen' "$pkg"
         continue
     fi
@@ -118,7 +118,7 @@ fi | while read -r pkg; do
         exit 1
     fi
 
-    seen=$(git rev-parse --quiet --verify AURUTILS_SEEN)
+    seen=$(git rev-parse --quiet --verify AUR_SEEN)
 
     if [[ "$seen" != $(git rev-parse HEAD) ]]; then
         log_range=(HEAD ${seen:+^$seen})

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -66,7 +66,7 @@ The logs shown by
 .B aur\-fetch
 show changes that happened since the commit referenced by the
 special reference
-.B AURUTILS_SEEN
+.B AUR_SEEN
 stored inside the repository.
 .PP
 This reference can be created with with:


### PR DESCRIPTION
AUR_SEEN is becoming the standard ref name, yay and pacaur also support
this.