### PR TITLE
scripts: remove readonly variable assignments

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -2,14 +2,13 @@
 # aur-build - build packages to a local repository
 set -o errexit
 shopt -s extglob
-readonly argv0=build
-readonly startdir=$PWD
-readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
-readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+argv0=build
+startdir=$PWD
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # hardware name
 machine=$(uname -m)
-readonly machine
 
 # default arguments
 archbuild_args=()

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -1,8 +1,8 @@
 #!/bin/bash
 # aur-depends - retrieve package dependencies using AurJson
-readonly argv0=depends
-readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-readonly max_request=30
+argv0=depends
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+max_request=30
 
 # default options
 mode=pkgname

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -1,9 +1,9 @@
 #!/bin/bash
 # aur-fetch - retrieve build files from the AUR
-readonly argv0=fetch
-readonly AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
-readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
-readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
+argv0=fetch
+AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 
 # default options
 verbose=0 recurse=0 fetch_args=('--verbose') confirm_seen=0

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -1,10 +1,10 @@
 #!/bin/bash
 # aur-pkglist - print the AUR package list
 set -o pipefail
-readonly argv0=pkglist
-readonly cache=${XDG_CACHE_HOME:-$HOME/.cache}/aurutils/$argv0
-readonly AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
-readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+argv0=pkglist
+cache=${XDG_CACHE_HOME:-$HOME/.cache}/aurutils/$argv0
+AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
 delay=300

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -1,8 +1,8 @@
 #!/bin/bash
 # aur-query - interface with AurJson
-readonly argv0=query
-readonly AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
-readonly PS4='+(${BASH_SOURCE}:${LINENO}):${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+argv0=query
+AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
+PS4='+(${BASH_SOURCE}:${LINENO}):${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
 declare -i rpc_ver=5

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -1,7 +1,7 @@
 #!/bin/bash
 # aur-repo - manage local repositories
-readonly argv0=repo
-readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+argv0=repo
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
 modifier=local

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -1,8 +1,8 @@
 #!/bin/bash
 # aur-repo-filter - filter packages in the Arch Linux repositories
-readonly argv0=repo-filter
-readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-readonly arch_repo=(core extra testing community{,-testing} multilib{,-testing})
+argv0=repo-filter
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+arch_repo=(core extra testing community{,-testing} multilib{,-testing})
 
 # The command line will hit ARG_MAX on approximately 70k packages;
 # spread arguments with xargs (and printf, as a shell built-in).

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -1,8 +1,8 @@
 #!/bin/bash
 # aur-search - search for AUR packages
-readonly argv0=search
-readonly AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
-readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+argv0=search
+AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
 multiple=section

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -1,7 +1,7 @@
 #!/bin/bash
 # aur-srcver - update and print package revisions
-readonly argv0=srcver
-readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+argv0=srcver
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 srcver_pkgbuild_info() {
     env -C "$1" -i bash -c '

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -2,11 +2,11 @@
 # aur-sync - download and build AUR packages automatically
 set -o errexit
 shopt -s extglob
-readonly argv0=sync
-readonly XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
-readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
-readonly AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
-readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+argv0=sync
+XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
 build_args=()

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -1,8 +1,8 @@
 #!/bin/bash
 # aur-vercmp - check packages for AUR updates
 set -o pipefail
-readonly argv0=vercmp
-readonly PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+argv0=vercmp
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
 format=check

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -352,8 +352,8 @@ in $PATH, for example
 .EX
   #!/bin/bash
   # Remove unused build files in aur-sync cache
-  readonly XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
-  readonly AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/sync}
+  XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
+  AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/sync}
   
   # Assumes build files were retrieved through git(1)
   find "$AURDEST" -name .git -execdir git clean -xf \\;

--- a/man7/aurvcs.7
+++ b/man7/aurvcs.7
@@ -30,11 +30,11 @@ Any option arguments are forwarded to
 .SS Program source
 .EX
 #!/bin/bash
-readonly argv0=vercmp\-devel
-readonly XDG_CACHE_HOME=${XDG_CACHE_HOME:\-$HOME/.cache}
-readonly AURDEST=${AURDEST:\-$XDG_CACHE_HOME/aurutils/sync}
-readonly AURVCS=${AURVCS:\-.*\-(cvs|svn|git|hg|bzr|darcs)$}
-readonly PS4=\(aq+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }\(aq
+argv0=vercmp\-devel
+XDG_CACHE_HOME=${XDG_CACHE_HOME:\-$HOME/.cache}
+AURDEST=${AURDEST:\-$XDG_CACHE_HOME/aurutils/sync}
+AURVCS=${AURVCS:\-.*\-(cvs|svn|git|hg|bzr|darcs)$}
+PS4=\(aq+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }\(aq
 
 filter_vcs() {
     awk \-v "mask=$AURVCS" \(aq$1 \(ti mask {print $1}\(aq "$@"

--- a/man7/aurvcs.7
+++ b/man7/aurvcs.7
@@ -30,11 +30,9 @@ Any option arguments are forwarded to
 .SS Program source
 .EX
 #!/bin/bash
-argv0=vercmp\-devel
 XDG_CACHE_HOME=${XDG_CACHE_HOME:\-$HOME/.cache}
 AURDEST=${AURDEST:\-$XDG_CACHE_HOME/aurutils/sync}
 AURVCS=${AURVCS:\-.*\-(cvs|svn|git|hg|bzr|darcs)$}
-PS4=\(aq+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }\(aq
 
 filter_vcs() {
     awk \-v "mask=$AURVCS" \(aq$1 \(ti mask {print $1}\(aq "$@"


### PR DESCRIPTION
Some programs rely on setting `PS4` to a different value. As `readonly` variables in general have had no effect in `aurutils` over the course of its existence, let's remove them wholesale.
    
Fixes #524

