### PR TITLE
README: add rebuild-detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See [ISSUE_TEMPLATE.md](ISSUE_TEMPLATE.md). For informal discussion, see the
 
 The following (third-party) projects may be used together with `aurutils`:
 
-* [aur-talk](https://aur.archlinux.org/packages/aur-talk-git/) - fetch and display AUR package comments (requires: `hq`)
+* [aur-talk](https://aur.archlinux.org/packages/aur-talk-git/) - fetch and display AUR package comments (requires: [hq](https://www.archlinux.org/packages/community/x86_64/hq/))
 * [aur-out-of-date](https://aur.archlinux.org/packages/aur-out-of-date/) - compare AUR to upstream version
 * [aurto](https://aur.archlinux.org/packages/aurto/) - automatically update a local repository with trust management
-* [hq](https://www.archlinux.org/packages/community/x86_64/hq/) - HTML processor inspired by jq
+* [rebuild-detector](https://aur.archlinux.org/packages/rebuild-detector/) - detects which packages need to be rebuilt


### PR DESCRIPTION
As building AUR packages is the user's responsibility, so is rebuilding them for example on `soname` changes in official repository packages. Add a hint in the `README` for a project which helps with this task.
    
Fixes #612
