### PR TITLE
move NEWS.md to aurutils.changelog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,1 @@
+makepkg/aurutils.changelog

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -1,12 +1,13 @@
 # Maintainer: Alad Wenter <https://github.com/AladW>
 pkgname=aurutils-git
-pkgver=2.3.1.r40.g660748b
+pkgver=2.3.1.r114.g90e4b42
 pkgrel=1
 pkgdesc='helper tools for the arch user repository'
 url='https://github.com/AladW/aurutils'
 arch=('any')
 license=('custom:ISC')
 source=('git+https://github.com/AladW/aurutils')
+changelog=aurutils.changelog
 sha256sums=('SKIP')
 conflicts=('aurutils')
 provides=("aurutils=${pkgver%%.r*}")

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -174,3 +174,4 @@
   + add `bash` completion (requires: `bash-completion`)
   + add `zsh` completion in a later release (#458)
 * Fixes for known issues in `1.5.3`.
+


### PR DESCRIPTION
This allows viewing release changes with:
```
 $ pacman -Qc aurutils-git
```
The only required change is the newline at the end of the file; see `PKGBUILD(5)`. As the changelog uses markdown, it can be viewed in `html` as follows:
```
 $ pacman -Qc aurutils-git | md2html | lynx -stdin
```
where `md2html` is part of the `md4c` package.

Fixes #624