### PR TITLE
aur fetch: learn to parallelize

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -37,7 +37,9 @@ source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
 
 if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
-    [[ -t 2 ]] && colorize
+    if [[ -t 2 ]]; then
+        colorize; diff_args+=('--color')
+    fi
 fi
 
 opt_short='rRvL:'

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -12,9 +12,17 @@ diff_args=('--patch' '--stat')
 
 # default options
 verbose=0 recurse=0 confirm_seen=0 rebase=-1 results=0 log_fmt=diff
+n_procs=$(nproc)
 
 # empty tree object
 git_empty_tree=$(git hash-object -t tree /dev/null)
+
+trap_exit() {
+    # Do not remove error files if an error occured (#593)
+    if [[ ! -v AUR_DEBUG ]]; then
+        rm -rf "$tmp"
+    fi
+}
 
 usage() {
     cat <<! | base64 -d
@@ -34,7 +42,7 @@ fi
 
 opt_short='rRvL:'
 opt_long=('recurse' 'verbose' 'write-log:' 'confirm-seen'
-          'rebase' 'reset' 'results:' 'format:')
+          'rebase' 'reset' 'results:' 'format:' 'jobs:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -53,6 +61,9 @@ while true; do
             verbose=1 ;;
         --format)
             shift; log_fmt=$1 ;;
+        --jobs)
+            shift
+            n_procs=$1 ;;
         -R|--rebase)
             rebase=1 ;;
         --reset)
@@ -104,11 +115,12 @@ if (( confirm_seen )); then
     msg "Marking repositories as seen"
 fi
 
-if (( recurse )); then
-    aur depends --pkgbase "$@"
-else
-   printf '%s\n' "$@"
-fi | while read -r pkg; do
+tmp=$(mktemp -d --tmpdir "aurutils-$argv0.XXXXXXXX") || exit
+trap 'trap_exit' EXIT
+
+
+aur_fetch_job() {
+    pkg=$1
     # Avoid issues with filesystem boundaries. (#274)
     export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
 
@@ -118,7 +130,7 @@ fi | while read -r pkg; do
             git update-ref AUR_SEEN HEAD
 
             msg2 'Marked repository %s as seen' "$pkg"
-            continue # skip diff logic
+            exit 0 # skip diff logic
         fi
 
         if (( rebase > 0 )) || {
@@ -173,6 +185,35 @@ fi | while read -r pkg; do
     else
         error '%s: %s: Failed to clone repository' "$argv0" "$pkg"
     fi
-done
+}
 
+
+if (( recurse )); then
+    aur depends --pkgbase "$@"
+else
+    printf '%s\n' "$@"
+fi >"$tmp/queue"
+
+i=0 # "allocate" slots
+while (( i++ < n_procs )); do true & done
+
+# run jobs. We need to go through the loop n_proc more times to
+# to ensure we read exit codes from processes that are still running
+# when the queue finishes.
+while { read -r pkg || (( --i > 0 )); } ; do
+    wait -n || { ret=$?; break; }               #simulate fail=1 from now,fail=1
+    if [[ $pkg ]]; then
+        aur_fetch_job "$pkg" >"$tmp/$pkg.out" 2>"$tmp/$pkg.err" &
+    fi
+done < <(sort -u "$tmp/queue" | sed '/^$/d')
+
+if (( ret )); then # simulate now from now,fail=1
+    # shellcheck disable=SC2046
+    kill $(jobs -np)
+fi
+
+wait # wait for process to terminate
+cat "$tmp/"*.out
+cat "$tmp/"*.err >&2
+exit $ret
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -11,7 +11,7 @@ pull_args=('--verbose')
 diff_args=('--patch' '--stat')
 
 # default options
-verbose=0 recurse=0 confirm_seen=0 rebase=-1 results=0
+verbose=0 recurse=0 confirm_seen=0 rebase=-1 results=0 log_fmt=diff
 
 # empty tree object
 git_empty_tree=$(git hash-object -t tree /dev/null)
@@ -34,7 +34,7 @@ fi
 
 opt_short='rRvL:'
 opt_long=('recurse' 'verbose' 'write-log:' 'confirm-seen'
-          'rebase' 'reset' 'results:')
+          'rebase' 'reset' 'results:' 'format:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -51,6 +51,8 @@ while true; do
             recurse=1 ;;
         -v|--verbose)
             verbose=1 ;;
+        --format)
+            shift; log_fmt=$1 ;;
         -R|--rebase)
             rebase=1 ;;
         --reset)
@@ -67,6 +69,10 @@ while true; do
     esac
     shift
 done
+
+if ! [[ $log_fmt =~ ^(log|diff)$ ]]; then
+    error '%s: %s format is not supported' "$argv0" "$log_fmt" && exit 1
+fi
 
 if [[ -v $log_dir ]] && [[ ! -d $log_dir ]]; then
     error '%s: %s: Not a directory' "$argv0" "$log_dir"
@@ -139,11 +145,11 @@ fi | while read -r pkg; do
 
             # Contents have changed since last inspection; print differences.
             if (( verbose )); then
-                git --no-pager log "${diff_args[@]}" "$range"
+                git --no-pager "$log_fmt" "${diff_args[@]}" "$range"
             fi
 
             if [[ $log_dir ]]; then
-                git --no-pager log "${diff_args[@]}" "$range" >"$log_dir/$pkg.log"
+                git --no-pager "$log_fmt" "${diff_args[@]}" "$range" >"$log_dir/$pkg.$log_fmt"
             fi
         fi
 

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -36,6 +36,10 @@ Print logs to
 .BR stdout .
 .
 .TP
+.BR \-\-format= [ diff | log ]
+Specifies the format logs are generated.
+.
+.TP
 .B \-\-reset
 Reset to the upstream commit, discarding local changes.
 .IP
@@ -92,7 +96,7 @@ updates to existing repositories.
 .
 .SS LOGS
 The logs shown by
-.B aur\-fetch
+.BR aur\-fetch (1)
 show changes that happened since the commit referenced by the
 special reference
 .B AUR_SEEN
@@ -105,14 +109,14 @@ This reference can be created with with:
 .EE
 .PP
 which will mark the current commit as seen, signaling
-.B aur\-fetch
+.BR aur\-fetch (1)
 that current changes should not be shown in future logs.
 .
 .
 .SS REBASE
 This option should be used with care. While it enables users
 to keep personalized changes to PKGBUILDS, it will cause failures if
-.B "git\-rebase"
+.BR git\-rebase (1)
 does not apply cleanly. The user is expected to fix those issues
 before continuing.
 .PP
@@ -127,6 +131,7 @@ Trusted Users have removed from the git history.
 .BR git (1),
 .BR git\-clone (1),
 .BR git\-config (1),
+.BR git\-diff (1),
 .BR git\-fetch (1),
 .BR git\-log (1),
 .BR git\-pull (1),


### PR DESCRIPTION
Rewrite of `aur-fetch` to implement features such as
- ~ability to choose between `git reset (default)`/`pull --rebase` to update cached repos. (discard local commits vs trying to reapply local commits on top of the incoming changes)~ #639
- ~ability to choose between a `git log` or `git diff` to generate review patches.~ #640
- fetch packages in parallel