### PR TITLE
aur-build: remove default arguments

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -72,9 +72,9 @@ opt_short='a:B:d:D:AcfnrsvLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:'
           'makepkg-conf:' 'remove' 'build-command:' 'pkgver' 'prefix:'
-          'rmdeps' 'noconfirm' 'ignorearch' 'log' 'recreate' 'new' 'bind:'
+          'rmdeps' 'no-confirm' 'ignore-arch' 'log' 'recreate' 'new' 'bind:'
           'bind-rw:' 'prevent-downgrade' 'temp' 'syncdeps' 'clean')
-opt_hidden=('dump-options')
+opt_hidden=('dump-options' 'gpg-sign' 'ignorearch' 'noconfirm' 'nosync')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -73,7 +73,8 @@ opt_short='a:B:d:D:AcfnrsvLNR'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:'
           'makepkg-conf:' 'remove' 'build-command:' 'pkgver' 'prefix:'
-          'rmdeps' 'noconfirm' 'ignorearch' 'log' 'recreate')
+          'rmdeps' 'noconfirm' 'ignorearch' 'log' 'recreate'
+          'prevent-downgrade' 'new')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -119,6 +120,10 @@ while true; do
             repo_add_args+=(-v) ;;
         -R|--remove)
             repo_add_args+=(-R) ;;
+        --new)
+            repo_add_args+=(-n) ;;
+        --prevent-downgrade)
+            repo_add_args+=(-p) ;;
         # common makepkg options
         -r|--rmdeps)
             makepkg_args+=(--rmdeps) ;;

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -12,12 +12,11 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 machine=$(uname -m)
 
 # default arguments
-archbuild_args=()
 chroot_prefix=aur
 gpg_args=(--detach-sign --no-armor --batch)
-makechrootpkg_args=()
-makepkg_args=(--clean --syncdeps)
-repo_add_args=()
+
+# do not hardcode (optional) arguments to build commands
+unset makepkg_args makechrootpkg_args archbuild_args repo_add_args
 
 # default options
 chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0
@@ -49,7 +48,7 @@ trap_exit() {
 }
 
 usage() {
-    plain 'usage: %s [-d repo] [-aCDMr path] [-cfNRXsv] [--] <makepkg args>' "$argv0" >&2
+    plain 'usage: %s [-acfBNS] [-d repo] [--root path] [--] <makepkg args>' "$argv0" >&2
     exit 1
 }
 
@@ -69,12 +68,12 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
 fi
 
 ## option parsing
-opt_short='a:B:d:D:AcfnrsvLNR'
+opt_short='a:B:d:D:AcfnrsvLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:'
           'makepkg-conf:' 'remove' 'build-command:' 'pkgver' 'prefix:'
-          'rmdeps' 'noconfirm' 'ignorearch' 'log' 'recreate'
-          'prevent-downgrade' 'new')
+          'rmdeps' 'noconfirm' 'ignorearch' 'log' 'recreate' 'new' 'bind:'
+          'bind-rw:' 'prevent-downgrade' 'temp' 'syncdeps' 'clean')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -90,32 +89,55 @@ while true; do
             shift; queue=$1 ;;
         -B|--build-command)
             shift; build_cmd+=("$1") ;;
-        --makepkg-conf)
-            shift; makepkg_conf=$1 ;;
         -f|--force)
             overwrite=1 ;;
-        # database options
-        -d|--database|--repo)
-            shift; db_name=$1 ;;
-        --root)
-            shift; db_root=$1 ;;
-        --pacman-conf)
-            shift; pacman_conf=$1 ;;
-        -N|--no-sync)
-            no_sync=1 ;;
-        # chroot options
         -c|--chroot)
             chroot=1 ;;
-        -D|--directory)
-            shift; archbuild_args+=(-r "$1") ;;
+        -d|--database|--repo)
+            shift; db_name=$1 ;;
+        -N|--nosync|--no-sync)
+            no_sync=1 ;;
+        --makepkg-conf)
+            shift; makepkg_conf=$1 ;;
+        --pacman-conf)
+            shift; pacman_conf=$1 ;;
         --prefix)
             shift; chroot_prefix=$1 ;;
-        --recreate)
-            archbuild_args+=(-c) ;;
-        # common repo-add options
-        -s|--sign)
+        --pkgver)
+            run_pkgver=1
+            makepkg_args+=(--holdver) ;;
+        --results)
+            shift; results_file=$1 ;;
+        --root)
+            shift; db_root=$1 ;;
+        -S|--sign|--gpg-sign)
             sign_pkg=1
             repo_add_args+=(-s) ;;
+        # devtools options
+        -D|--directory)
+            shift; archbuild_args+=(-r "$1") ;;
+        --recreate)
+            archbuild_args+=(-c) ;;
+        --bind)
+            shift; makechrootpkg_args+=(-D "$1") ;;
+        --bind-rw)
+            shift; makechrootpkg_args+=(-d "$1") ;;
+        -T|--temp)
+            makechrootpkg_args+=(-T) ;;
+        # makepkg options
+        -A|--ignorearch|--ignore-arch)
+            makepkg_args+=(--ignorearch) ;;
+        --clean)
+            makepkg_args+=(--clean) ;;
+        -L|--log)
+            makepkg_args+=(--log) ;;
+        -n|--noconfirm|--no-confirm)
+            makepkg_args+=(--noconfirm) ;;
+        -r|--rmdeps)
+            makepkg_args+=(--rmdeps) ;;
+        -s|--syncdeps)
+            makepkg_args+=(--syncdeps) ;;
+        # repo-add options
         -v|--verify)
             repo_add_args+=(-v) ;;
         -R|--remove)
@@ -124,21 +146,7 @@ while true; do
             repo_add_args+=(-n) ;;
         --prevent-downgrade)
             repo_add_args+=(-p) ;;
-        # common makepkg options
-        -r|--rmdeps)
-            makepkg_args+=(--rmdeps) ;;
-        -n|--noconfirm)
-            makepkg_args+=(--noconfirm) ;;
-        -A|--ignorearch)
-            makepkg_args+=(--ignorearch) ;;
-        -L|--log)
-            makepkg_args+=(--log) ;;
         # other options
-        --pkgver)
-            run_pkgver=1
-            makepkg_args+=(--holdver) ;;
-        --results)
-            shift; results_file=$1 ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}"
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
@@ -154,14 +162,12 @@ var_tmp=$(mktemp -d --tmpdir="${TMPDIR:-/var/tmp/}" "aurutils-$argv0.XXXXXXXX") 
 trap 'trap_exit' EXIT
 trap 'exit' INT
 
-# makechrootpkg arguments can only be appended to the defaults
-# specified in archbuild (-cn), unlike makepkg where we override our
-# own set of defaults (-cs).
+# Pass all arguments after -- to makepkg
 if (( $# )); then
     if (( chroot )); then
-        makechrootpkg_args=("$@")
+        makechrootpkg_args+=("$@")
     else
-        makepkg_args=("$@")
+        makepkg_args+=("$@")
     fi
 fi
 
@@ -287,6 +293,9 @@ while IFS= read -ru "$fd" path; do
         env PKGDEST="$var_tmp" AUR_REPO="$db_name" AUR_DBROOT="$db_root" "${build_cmd[@]}"
     elif (( chroot )); then
         printf '%s\n' >&2 "Running $chroot_prefix-$machine-build"
+        # archbuild hardcodes makechrootpkg -c -n -C. In turn, makechrootpkg
+        # hardcodes makepkg --syncdeps --noconfirm --log --holdver --skipinteg.
+        # These options cannot overriden, only appended to.
         env PKGDEST="$var_tmp" "$chroot_prefix"-"$machine"-build \
             "${archbuild_args[@]}" -- -d "$db_root" "${makechrootpkg_args[@]}"
     else

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -58,7 +58,7 @@ while true; do
         --confirm-seen)
             confirm_seen=1 ;;
         --results)
-            results_file=$1 ;;
+            shift; results_file=$1 ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}"
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -38,7 +38,7 @@ usage() {
 source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='b:t:'
-opt_long=('by:' 'type:' 'aur-url:' 'rpc-ver:' 'rpc-url:')
+opt_long=('by:' 'type:' 'rpc-ver:' 'rpc-url:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -28,7 +28,7 @@ usage() {
 source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='d:a'
-opt_long=('all' 'sync' 'database:' 'repo:' 'sysroot:')
+opt_long=('all' 'sync' 'database:' 'sysroot:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -120,8 +120,8 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
 fi
 
 opt_short='k:adimnqrsv'
-opt_long=('any' 'info' 'search' 'desc' 'maintainer' 'name' 'depends'
-          'makedepends' 'optdepends' 'checkdepends' 'key:' 'raw')
+opt_long=('any' 'info' 'search' 'desc' 'maintainer' 'name' 'depends' 'verbose'
+          'makedepends' 'optdepends' 'checkdepends' 'key:' 'raw' 'short')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -99,7 +99,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:'
           'sign' 'temp' 'upgrades' 'pkgver' 'rebuild' 'rebuild-tree'
           'build-command:' 'ignore-file:' 'remove' 'provides-from:'
           'new' 'prevent-downgrade' 'verify')
-opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile'
+opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:'
             'noconfirm' 'nover' 'nograph' 'nover-shallow' 'noview'
             'rebuildtree' 'rmdeps' 'gpg-sign')
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -91,7 +91,7 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
     exit 1
 fi
 
-opt_short='B:d:D:AcfkLnpPrRsTuv'
+opt_short='B:d:D:AcfLnpPrRSTuv'
 opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:'
           'root:' 'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue'
           'force' 'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph'
@@ -149,11 +149,11 @@ while true; do
             shift; repo_args+=(-r "$1") ;;
         # build options
         -B|--build-command)
-            shift; build_args+=(-B "$1") ;;
+            shift; build_args+=(--build-command "$1") ;;
         -c|--chroot)
-            build_args+=(-c) ;;
+            build_args+=(--chroot) ;;
         -f|--force)
-            build_args+=(-f) ;;
+            build_args+=(--force) ;;
         --makepkg-conf)
             shift; build_args+=(--makepkg-conf "$1") ;;
         --pacman-conf)
@@ -161,10 +161,10 @@ while true; do
         --pkgver)
             build_args+=(--pkgver) ;;
         -S|--sign|--gpg-sign)
-            build_args+=(-s) ;;
+            build_args+=(--sign) ;;
         # build options (devtools)
         -D|--directory)
-            shift; build_args+=(-D "$1") ;;
+            shift; build_args+=(--directory "$1") ;;
         --bind)
             shift; build_args+=(--bind "$1") ;;
         --bind-rw)
@@ -173,7 +173,7 @@ while true; do
             build_args+=(-T) ;;
         # build options (makepkg)
         -A|--ignorearch|--ignore-arch)
-            build_args+=(-A) ;;
+            build_args+=(--ignorearch) ;;
         -L|--log)
             build_args+=(--log) ;;
         -n|--noconfirm|--no-confirm)
@@ -182,9 +182,9 @@ while true; do
             build_args+=(--rmdeps) ;;
         # build options (repo-add)
         -R|--remove)
-            build_args+=(-R) ;;
+            build_args+=(--remove) ;;
         -v|--verify)
-            build_args+=(-v) ;;
+            build_args+=(--verify) ;;
         --prevent-downgrade)
             build_args+=(--prevent-downgrade) ;;
         --new)

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -93,13 +93,14 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
     exit 1
 fi
 
-opt_short='B:C:d:D:M:AcfkLnpPrRsTu'
+opt_short='B:d:D:AcfkLnpPrRsTuv'
 opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:'
           'root:' 'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue'
           'force' 'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph'
           'no-ver-shallow' 'no-view' 'print' 'provides' 'rm-deps'
           'sign' 'temp' 'upgrades' 'pkgver' 'rebuild' 'rebuild-tree'
-          'build-command:' 'ignore-file:' 'remove' 'provides-from:')
+          'build-command:' 'ignore-file:' 'remove' 'provides-from:'
+          'new' 'prevent-downgrade' 'verify')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile'
             'noconfirm' 'nover' 'nograph' 'nover-shallow' 'noview'
             'rebuildtree' 'rmdeps')
@@ -112,59 +113,16 @@ set -- "${OPTRET[@]}"
 unset pkg pkg_i repo repo_p ignore_file
 while true; do
     case "$1" in
-        -d|--database|--repo)
-            shift; repo_args+=(-d "$1") ;;
-        -B|--build-command)
-            shift; build_args+=(-B "$1") ;;
-        -D|--directory)
-            shift; build_args+=(-D "$1") ;;
-        -M|--makepkg-conf)
-            shift; build_args+=(--makepkg-conf "$1") ;;
-        -C|--pacman-conf)
-            shift; build_args+=(--pacman-conf "$1") ;;
-        --bind)
-            shift; makechrootpkg_args+=(-D "$1") ;;
-        --bind-rw)
-            shift; makechrootpkg_args+=(-d "$1") ;;
+        # sync options
+        --allan)
+            rotate=1 ;;
+        --continue)
+            download=0 ;;
         --ignore)
             shift; IFS=, read -a pkg -r <<< "$1"
             pkg_i+=("${pkg[@]}") ;;
         --ignorefile|--ignore-file)
             shift; ignore_file=$1 ;;
-        --root)
-            shift; repo_args+=(-r "$1") ;;
-        -A|--ignorearch|--ignore-arch)
-            makepkg_args+=(--ignorearch)
-            makechrootpkg_makepkg_args+=(-A) ;;
-        -c|--chroot)
-            chroot=1; build_args+=(-c) ;;
-        -f|--force)
-            build_args+=(-f) ;;
-        -L|--log)
-            makepkg_args+=(--log) ;;
-        -P|--provides)
-            provides=1 ;;
-        --provides-from)
-            shift; IFS=, read -a repo -r <<< "$1"
-            repo_p+=("${repo[@]}") ;;
-        -n|--noconfirm|--no-confirm)
-            makepkg_args+=(--noconfirm) ;;
-        -p|--print)
-            build=0 ;;
-        -r|--rmdeps|--rm-deps)
-            makepkg_args+=(--rmdeps) ;;
-        -R|--remove)
-            build_args+=(-R) ;;
-        -s|--sign)
-            build_args+=(-sv) ;;
-        -T|--temp)
-            makechrootpkg_args+=(-T) ;;
-        -u|--upgrades)
-            update=1 ;;
-        --allan)
-            rotate=1 ;;
-        --continue)
-            download=0 ;;
         --nograph|--no-graph)
             graph=0 ;;
         --nover|--no-ver)
@@ -173,12 +131,68 @@ while true; do
             chkver_depth=1 ;;
         --noview|--no-view)
             view=0 ;;
-        --pkgver)
-            build_args+=(--pkgver) ;;
+        -P|--provides)
+            provides=1 ;;
+        --provides-from)
+            shift; IFS=, read -a repo -r <<< "$1"
+            repo_p+=("${repo[@]}") ;;
+        -p|--print)
+            build=0 ;;
         --rebuild)
             build_args+=(-f); chkver_depth=1 ;;
         --rebuildtree|--rebuild-tree)
             build_args+=(-f); chkver_depth=0 ;;
+        # database options
+        -d|--database|--repo)
+            shift; repo_args+=(-d "$1") ;;
+        --root)
+            shift; repo_args+=(-r "$1") ;;
+        # build options
+        -B|--build-command)
+            shift; build_args+=(-B "$1") ;;
+        -f|--force)
+            build_args+=(-f) ;;
+        --makepkg-conf)
+            shift; build_args+=(--makepkg-conf "$1") ;;
+        --pacman-conf)
+            shift; build_args+=(--pacman-conf "$1") ;;
+        --pkgver)
+            build_args+=(--pkgver) ;;
+        # chroot options
+        -c|--chroot)
+            chroot=1; build_args+=(-c) ;;
+        -D|--directory)
+            shift; build_args+=(-D "$1") ;;
+        --bind)
+            shift; makechrootpkg_args+=(-D "$1") ;;
+        --bind-rw)
+            shift; makechrootpkg_args+=(-d "$1") ;;
+        -T|--temp)
+            makechrootpkg_args+=(-T) ;;
+        # makepkg options
+        -A|--ignorearch|--ignore-arch)
+            makepkg_args+=(--ignorearch)
+            makechrootpkg_makepkg_args+=(-A) ;;
+        -L|--log)
+            makepkg_args+=(--log) ;;
+        -n|--noconfirm|--no-confirm)
+            makepkg_args+=(--noconfirm) ;;
+        -r|--rmdeps|--rm-deps)
+            makepkg_args+=(--rmdeps) ;;
+        # repo-add options
+        -R|--remove)
+            build_args+=(-R) ;;
+        -s|--sign)
+            build_args+=(-s) ;;
+        -v|--verify)
+            build_args+=(-v) ;;
+        -u|--upgrades)
+            update=1 ;;
+        --prevent-downgrade)
+            build_args+=(--prevent-downgrade) ;;
+        --new)
+            build_args+=(--new) ;;
+        # other options
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}"
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -9,17 +9,15 @@ AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
-build_args=()
-makechrootpkg_args=()
-makechrootpkg_makepkg_args=()
-makepkg_args=(--clean --syncdeps)
+build_args=(--clean --syncdeps)
+build_extra_args=()
 repo_args=()
 
 # default options (enabled)
 build=1 chkver_depth=2 download=1 view=1 provides=0 graph=1
 
 # default options (disabled)
-chroot=0 rotate=0 update=0
+rotate=0 update=0
 
 lib32() {
     awk -v arch="$(uname -m)" '{
@@ -74,7 +72,7 @@ trap_exit() {
 }
 
 usage() {
-    plain 'usage: %s [-d repo] [-CDM path] [-AcfkLnpPsTu] [--] pkgname...' "$argv0" >&2
+    plain 'usage: %s [-d repo] [--root path] [-cdfPpSu] [--] pkgname...' "$argv0" >&2
     exit 1
 }
 
@@ -103,7 +101,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:'
           'new' 'prevent-downgrade' 'verify')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile'
             'noconfirm' 'nover' 'nograph' 'nover-shallow' 'noview'
-            'rebuildtree' 'rmdeps')
+            'rebuildtree' 'rmdeps' 'gpg-sign')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -142,6 +140,8 @@ while true; do
             build_args+=(-f); chkver_depth=1 ;;
         --rebuildtree|--rebuild-tree)
             build_args+=(-f); chkver_depth=0 ;;
+        -u|--upgrades)
+            update=1 ;;
         # database options
         -d|--database|--repo)
             shift; repo_args+=(-d "$1") ;;
@@ -150,6 +150,8 @@ while true; do
         # build options
         -B|--build-command)
             shift; build_args+=(-B "$1") ;;
+        -c|--chroot)
+            build_args+=(-c) ;;
         -f|--force)
             build_args+=(-f) ;;
         --makepkg-conf)
@@ -158,36 +160,31 @@ while true; do
             shift; build_args+=(--pacman-conf "$1") ;;
         --pkgver)
             build_args+=(--pkgver) ;;
-        # chroot options
-        -c|--chroot)
-            chroot=1; build_args+=(-c) ;;
+        -S|--sign|--gpg-sign)
+            build_args+=(-s) ;;
+        # build options (devtools)
         -D|--directory)
             shift; build_args+=(-D "$1") ;;
         --bind)
-            shift; makechrootpkg_args+=(-D "$1") ;;
+            shift; build_args+=(--bind "$1") ;;
         --bind-rw)
-            shift; makechrootpkg_args+=(-d "$1") ;;
+            shift; build_args+=(--bind-rw "$1") ;;
         -T|--temp)
-            makechrootpkg_args+=(-T) ;;
-        # makepkg options
+            build_args+=(-T) ;;
+        # build options (makepkg)
         -A|--ignorearch|--ignore-arch)
-            makepkg_args+=(--ignorearch)
-            makechrootpkg_makepkg_args+=(-A) ;;
+            build_args+=(-A) ;;
         -L|--log)
-            makepkg_args+=(--log) ;;
+            build_args+=(--log) ;;
         -n|--noconfirm|--no-confirm)
-            makepkg_args+=(--noconfirm) ;;
+            build_args+=(--noconfirm) ;;
         -r|--rmdeps|--rm-deps)
-            makepkg_args+=(--rmdeps) ;;
-        # repo-add options
+            build_args+=(--rmdeps) ;;
+        # build options (repo-add)
         -R|--remove)
             build_args+=(-R) ;;
-        -s|--sign)
-            build_args+=(-s) ;;
         -v|--verify)
             build_args+=(-v) ;;
-        -u|--upgrades)
-            update=1 ;;
         --prevent-downgrade)
             build_args+=(--prevent-downgrade) ;;
         --new)
@@ -204,7 +201,13 @@ done
 
 tmp=$(mktemp -d --tmpdir "aurutils-$argv0.XXXXXXXX") || exit
 tmp_view=$(mktemp -d --tmpdir "aurutils-$argv0-view.XXXXXXXX") || exit
+
 trap 'trap_exit' EXIT
+
+# pass all arguments after -- to aur-build
+if (( $# )); then
+    build_extra_args+=("$@")
+fi
 
 # append contents of ignore file
 if [[ -f ${ignore_file=$XDG_CONFIG_HOME/aurutils/sync/ignore} ]]; then
@@ -361,14 +364,8 @@ if (( view )); then
 fi
 
 if (( build )); then
-    build_args+=(--arg-file "$tmp"/queue --database "$db_name" --root "$db_root")
-
-    if (( chroot )); then
-        aur build "${build_args[@]}" -- "${makechrootpkg_args[@]}" \
-            -- "${makechrootpkg_makepkg_args[@]}"
-    else
-        aur build "${build_args[@]}" -- "${makepkg_args[@]}"
-    fi
+    aur build --arg-file "$tmp"/queue --database "$db_name" --root "$db_root" \
+        "${build_args[@]}" -- "${build_extra_args[@]}"
 else
     xargs -a "$tmp"/queue -I{} printf '%s\n' "$(pwd -P)"/{}
 fi

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -48,76 +48,12 @@ would set the build command to
 .BR "makepkg \-sri" .
 .
 .TP
-.BI \-d " NAME" "\fR,\fP \-\-database=" NAME
-The name of the pacman database.
-.
-.TP
-.BR \-f ", " \-\-force
-Continue the build process if a package with the same name is found.
-.
-.TP
-.BR \-N ", " \-\-no\-sync
-Do not sync the local repository after building.
-.
-.TP
-.BI \-\-root= DIR
-The root directory for the repository. The
-.I root
-is the location for the pacman database
-.RI ( foo.db ),
-built packages, and secondary files such as the files database
-.RI ( foo.files ).
-This defaults to the value of the
-.B Server
-directive for the configured repository.
-.RS
-.B Note:
-The
-.I Server
-directive configured in
-.BR pacman.conf (5)
-is used for
-.BR pacman (8)
-sync operations regardless of this setting. See also
-.BR \-N .
-.RE
-.
-.TP
-.BI \-\-results= file
-Write absolute paths of successfully built packages to
-.IR file .
-.
-.TP
-.BR \-\-pkgver
-Run
-.B "makepkg \-\-noprepare \-od"
-before checking existing packages (effectively running an existing
-.B pkgver()
-function). This option adds
-.B \-\-holdver
-to the default
-.BR makepkg (8)
-options.
-.
-.SS archbuild options
-.TP
 .BR \-c ", " \-\-chroot
 Build packages inside a
 .BR systemd\-nspawn (1)
 container with
 .BR archbuild .
-.IP
-The default build command is
-.BR "makechrootpkg \-c \-n \-C" .
-All arguments specified after
-.B \-\-
-are appended to this set of options. Run
-.B "makechrootpkg \-h"
-for a list of available
-.B makechrootpkg
-options.
-.IP
-The prerequisites for this option are as follows:
+The prerequisites for using this option are as follows:
 .RS
 .IP \(bu 2
 Ensure the optional dependency
@@ -139,7 +75,93 @@ Place the pacman configuration in
 .br
 E.g.,
 .BR /usr/share/devtools/pacman\-aur.conf .
+.PP
 .RE
+.
+.TP
+.BI \-d " NAME" "\fR,\fP \-\-database=" NAME
+The name of the pacman database.
+.
+.TP
+.BR \-f ", " \-\-force
+Continue the build process if a package with the same name is found.
+.
+.TP
+.BR \-N ", " \-\-no\-sync
+Do not sync the local repository after building.
+.
+.TP
+.BR \-\-pkgver
+Run
+.B "makepkg \-\-noprepare \-od"
+before checking existing packages (effectively running an existing
+.B pkgver()
+function). This option adds
+.B \-\-holdver
+to the default
+.BR makepkg (8)
+options.
+.
+.TP
+.B \-\-pacman\-conf
+.
+.TP
+.B \-\-makepkg\-conf
+.
+.TP
+.BI \-\-results= file
+Write absolute paths of successfully built packages to
+.IR file .
+.
+.TP
+.BI \-\-root= DIR
+The root directory for the repository. The
+.I root
+is the location for the pacman database
+.RI ( foo.db ),
+built packages, and secondary files such as the files database
+.RI ( foo.files ).
+This defaults to the value of the
+.B Server
+directive for the configured repository.
+.
+.RS
+.B Note:
+The
+.I Server
+directive configured in
+.BR pacman.conf (5)
+is used for
+.BR pacman (8)
+sync operations regardless of this setting. See also
+.BR \-N .
+.RE
+.
+.TP
+.BR \-S ", " \-\-sign ", " \-\-gpg\-sign
+Sign built packages and the database
+.RB ( "repo\-add \-s" )
+with
+.BR gpg (1).
+To use another key than the default, the
+.B GPGKEY
+environment variable can be set to the appropriate key identifier.
+.
+.SS makechrootpkg options
+Additional options may be passed to
+.B makechrootpkg
+by placing them after
+.B --
+in the
+.B aur\-build
+command-line. For a list of available options, run
+.B "makechrootpkg \-h".
+.PP
+The default set of options used in
+.B archbuild
+is
+.BR "makechrootpkg \-c \-n \-C" ,
+and cannot be overridden.
 .
 .TP
 .BI \-D " DIR" "\fR,\fP \-\-directory=" DIR
@@ -154,33 +176,40 @@ or
 .B /copy
 if unset).
 .
-.RS
 .TP
-.B Note:
-If the
-.B \-T
-option is specified to
-.BR makechrootpkg ,
-the user container has a random name and is removed on build
-completion.
-.RE
+.BI \-\-bind= DIR
+Bind a directory read-only. (\fBmakechrootpkg \-D\fR)
+.
+.TP
+.BI \-\-bind\-rw= DIR
+Bind a directory read-write. (\fBmakechrootpkg \-d\fR)
+.
+.TP
+.BI \-\-prefix= PREFIX
+Select the configuration/binary to chroot-build packages.
+By default,
+.I PREFIX
+is set to
+.BR aur .
 .
 .TP
 .B \-\-recreate
 Recreate the chroot before building packages.
 .
 .TP
-.BI \-\-prefix= prefix
-Select the configuration/binary to chroot-build packages.
-By default,
-.I prefix
-is set to
-.BR aur .
+.BR \-T ", " \-\-temp
+Build in a temporary container. (\fBmakechrootpkg \-T\fR) Temporary
+means that the user container has a random name and is removed on
+build completion.
 .
 .SS makepkg options
-The default build command is
-.BR "makepkg \-\-clean \-\-syncdeps" .
-Any arguments specified after \-\- replace this set of options.
+Additional options may be passed to
+.B makepkg
+by placing them after
+.B --
+in the
+.B aur\-build
+command-line.
 .
 .TP
 .BR \-A ", " \-\-ignorearch
@@ -188,6 +217,11 @@ Ignore a missing or incomplete
 .I arch
 field in the build script.
 .RB ( makepkg " " \-A )
+.
+.TP
+.BR \-\-clean
+Clean up leftover work files and directories after a successful build.
+.RB ( makepkg " " \-c )
 .
 .TP
 .BR \-L ", " \-\-log
@@ -204,6 +238,12 @@ Do not wait for user input.
 Remove dependencies installed by makepkg.
 .RB ( makepkg " " \-\-rmdeps )
 .
+.TP
+.BR \-s ", " \-\-syncdeps
+Install missing dependencies using
+.BR pacman .
+.RB ( makepkg " " \-\-syncdeps )
+.
 .SS repo\-add options
 .TP
 .BR \-R ", " \-\-remove
@@ -212,20 +252,15 @@ database.
 .RB ( "repo\-add \-R" ).
 .
 .TP
-.BR \-s ", " \-\-sign
-Sign built packages and the database
-.RB ( "repo\-add \-s" )
-with
-.BR gpg (1).
-To use another key than the default, the
-.B GPGKEY
-environment variable can be set to the appropriate key identifier.
-.
-.TP
 .BR \-v ", " \-\-verify
 Verify the PGP signature of the database before
 updating.
 .RB ( "repo\-add \-v" ).
+.
+.TP
+.BR \-\-new
+Only add packages that are not already in the database.
+.RB ( "repo\-add \-n" ).
 .
 .TP
 .BR \-\-prevent\-downgrade
@@ -356,8 +391,8 @@ uses
 internally. For example, to replace
 .I gcc
 with
-.I gcc\-multilib
-, run
+.IR gcc\-multilib ,
+run
 .B "arch\-nspawn /var/lib/archbuild/aur\-x86_64/root pacman \-S gcc\-multilib"
 as root.
 .PP
@@ -438,19 +473,6 @@ to avoid libalpm from skipping entries if the locale is not set
 (FS#49342). Packages are signed manually with
 .B "gpg \-\-batch \-\-detach\-sign \-\-no\-armor"
 (FS#49946).
-.PP
-When using
-.BR "makepkg \-\-rmdeps" ,
-installed dependencies will be removed through
-.BR "pacman \-Rn" .
-When answering "n" to the resulting prompt,
-.B makepkg
-will exit with "An unknown error has occurred", and send SIGUSR1 to its
-parent group. As
-.B aur\-build
-does not catch this signal, the
-.B \-\-rmdeps
-option is disabled by default.
 .PP
 .BR pacman (8)
 has a size-limit of 25\~MiB for databases. Using larger databases may result in an

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -208,7 +208,7 @@ Remove dependencies installed by makepkg.
 .TP
 .BR \-R ", " \-\-remove
 Remove old package files from disk when updating their entry in the
-database
+database.
 .RB ( "repo\-add \-R" ).
 .
 .TP
@@ -226,6 +226,12 @@ environment variable can be set to the appropriate key identifier.
 Verify the PGP signature of the database before
 updating.
 .RB ( "repo\-add \-v" ).
+.
+.TP
+.BR \-\-prevent\-downgrade
+Do not add packages to the database if a newer version is already
+present.
+.RB ( "repo\-add \-p" ).
 .
 .SH ENVIRONMENT
 .TP

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -37,11 +37,9 @@ intervention),
 terminates immediately.
 .
 .SH OPTIONS
-.SS Build options
 .TP
-.BR \-f ", " \-\-force
-Continue the build process if a package with the same name exists.
-.RB ( "aur build \-f" )
+.B \-\-continue
+Do not download package files.
 .
 .TP
 .BI \-\-ignore= PACKAGE
@@ -73,42 +71,13 @@ upgrade candidates from
 Version checks for package dependencies remain enabled.
 .
 .TP
-.BR \-p ", " \-\-print
-Print target packages and their paths instead of building them.
-.
-.TP
-.BR \-\-pkgver
-Run
-.B "makepkg \-od \-\-noprepare"
-before the build process.
-.RB ( "aur\-build \-\-pkgver" )
-.
-.TP
-.BR \-s ", " \-\-sign
-Sign built packages with
-.BR gpg (1).
-(\fBaur build \-sv\fR)
-.
-.TP
-.BR \-\-rebuild
-Alias for
-.BR "\-f \-\-nover\-shallow" .
-.
-.TP
-.BR \-\-rebuildtree ", " \-\-rebuild\-tree
-Alias for
-.BR "\-f \-\-nover" .
-.
-.SS Download options
-.TP
-.B \-\-continue
-Do not download package files.
-.
-.TP
 .BR \-\-noview ", " \-\-no\-view
 Do not present build files for inspection.
 .
-.SS Repository options
+.TP
+.BR \-p ", " \-\-print
+Print target packages and their paths instead of building them.
+.
 .TP
 .BR \-P ", " \-\-provides
 Take virtual dependencies
@@ -128,6 +97,17 @@ to \-\-provides\-from=b,a) and dependencies are installed according to
 the order defined in
 .BR pacman.conf (5).
 .
+.TP
+.BR \-u ", " \-\-upgrades
+Update all obsolete AUR packages in a local repository.
+.
+.SS Database options
+Values for the following options are automatically selected, if a
+single local repository is defined in
+.BR pacman.conf (5).
+See
+.BR aur\-repo (1)
+for details.
 .
 .TP
 .BI \-d " NAME" "\fR,\fP \-\-database=" NAME
@@ -147,43 +127,16 @@ The location of the repository root. Defaults to the
 .I Server
 value of the configured repository.
 .
-.TP
-.BI \-R ", " \-\-remove
-Remove old package files from disk when updating their entry in the
-database
-.RB ( "aur\-build \-R" ).
-.
-.TP
-.BR \-u ", " \-\-upgrades
-Update all obsolete AUR packages in a local repository.
-.
-.SS makepkg options
+.SS Build options
 The default build command is
 .BR "makepkg \-\-clean \-\-syncdeps" .
-.
-.TP
-.BR \-A ", " \-\-ignorearch ", " \-\-ignore\-arch
-Ignore a missing or incomplete
-.I arch
-field in the build script. (\fBmakepkg \-A\fR)
-.
-.TP
-.BR \-L ", " \-\-log
-Enable logging to a text file in the build directory. (\fBmakepkg
-\-L\fR)
-.
-.TP
-.BR \-n ", " \-\-noconfirm ", " \-\-no\-confirm
-Do not wait for user input. (\fBmakepkg \-\-noconfirm\fR)
-.
-.TP
-.BR \-r ", " \-\-rmdeps ", " \-\-rm\-deps
-Remove dependencies installed by makepkg. (\fBmakepkg \-\-rmdeps\fR)
-.
-.SS makechrootpkg options
-The default build command is
-.BR "makechrootpkg \-c \-n \-C" .
-See
+Additional options may be passed to
+.B aur\-build
+by placing them after
+.B --
+in the
+.B aur\-sync
+command-line. See
 .BR aur\-build (1)
 for details.
 .
@@ -192,20 +145,32 @@ for details.
 Build packages in a systemd\-nspawn container. (\fBaur build \-c\fR)
 .
 .TP
-.BI \-D " DIR" "\fR,\fP \-\-directory=" DIR
-The path pointing to the container. (\fBaur build \-D\fR)
+.BR \-f ", " \-\-force
+Continue the build process if a package with the same name exists.
+.RB ( "aur build \-f" )
 .
 .TP
-.BI \-\-bind= DIR
-Bind a directory read-only. (\fBmakechrootpkg \-D\fR)
+.BR \-\-pkgver
+Run
+.B "makepkg \-od \-\-noprepare"
+before the build process.
+.RB ( "aur\-build \-\-pkgver" )
 .
 .TP
-.BI \-\-bind\-rw= DIR
-Bind a directory read-write. (\fBmakechrootpkg \-d\fR)
+.BR \-\-rebuild
+Alias for
+.BR "\-f \-\-nover\-shallow" .
 .
 .TP
-.BR \-T ", " \-\-temp
-Build in a temporary container. (\fBmakechrootpkg \-T\fR)
+.BR \-\-rebuildtree ", " \-\-rebuild\-tree
+Alias for
+.BR "\-f \-\-nover" .
+.
+.TP
+.BR \-S ", " \-\-sign ", " \-\-gpg-sign
+Sign built packages with
+.BR gpg (1).
+.RB ( "aur build \-S" )
 .
 .SH ENVIRONMENT
 .TP


### PR DESCRIPTION
Traditionally, `aur-build` has a set of default (`makepkg`, `makechrootpkg`) options that can be overridden by a new set of options, specified after `--`. This means adding a simple option like `-r` is done as follows:
```
$ aur build -- -r -sc
```
where `-sc` are the default `aur-build` options (here, we've replaced `makepkg -sc` with `makepkg -src` in the `aur-build` invocation). A possible option is to append to the default options, instead of overwrite them:
```
$ aur build -- -r
```
In this case `aur-build` contains a set of `hardcoded` options which may not be suitable to all users.

This commit removes any notion of default arguments for `makepkg` or other wrapped build commands. For convenience, common options are parsed directly from the command-line, including `makechrootpkg` options included in `aur-sync`. The above example would then be written as:
```
  $ aur build -rsc
```
which runs `makepkg -src`. The base command:

  $ aur build

would then run `makepkg` without arguments. As the `-s` /  `--syncdeps` option conflicts with `--sign`, rename the short option for `--sign` to `-S`. Coincidentally, this is the same short option used in `git-commit(1)` for GPG signing.

`aur-sync` operation is mostly unaffected, as it specifies --clean --syncdeps as default arguments to aur-build. Otherwise, aur-build is now fully decoupled from aur-sync.

**Note:** A workaround to keep `aur-sync -Ac` functional with the above changes is added through `build_extra_args`. In particular, `aur-sync -Ac` now translates to:
```
$ aur sync -c -- -- -A
```