### PR TITLE
aur-fetch: unset GIT_DIR and GIT_WORK_TREE

### DIFF
--- a/test/issue-636
+++ b/test/issue-636
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+argv0=issue-636
+tmp="$(mktemp -d --tmpdir "aurutils-$argv0.XXXXXXXX")"
+
+trap_exit() {
+    rm -rf "$tmp"
+}
+
+trap 'trap_exit' EXIT
+
+cd "$tmp" || exit
+
+aur fetch aurutils aurutils-git


### PR DESCRIPTION
Using `master` at 1b4782e2e10acb807c87d81b03f1d9b583bb9d4, `aur-fetch` exits with nonzero status under the following conditions:

1. It needs to fetch more than one repository
2. At least one repository (other than the first one listed on the command line) is being fetched for the first time (initial `git clone`):

```
$ cd "$(mktemp -d)"
$ aur fetch aurutils aurutils-git 
Cloning into 'aurutils'...                                         
remote: Enumerating objects: 348, done.                            
remote: Counting objects: 100% (348/348), done.                    
remote: Compressing objects: 100% (232/232), done.                 
remote: Total 348 (delta 117), reused 347 (delta 116)              
Receiving objects: 100% (348/348), 66.21 KiB | 622.00 KiB/s, done. 
Resolving deltas: 100% (117/117), done.                            
HEAD is now at 3872019 upgpkg: aurutils 2.3.2-1                    
From https://aur.archlinux.org/aurutils                            
 = [up to date]      master     -> origin/master                   
Already up to date.                                                
Current branch master is up to date.                               
fatal: working tree 'aurutils' already exists.                     
==> ERROR: fetch: aurutils-git: Failed to clone repository 
```

The issue appears to be that `aur-fetch` doesn't unset `GIT_DIR` or `GIT_WORK_TREE` at the beginning of the "main" loop, thus reusing the values of `GIT_DIR` and `GIT_WORK_TREE` set on the *prior* iteration.

This merge request adds `unset GIT_DIR GIT_WORK_TREE` to the beginning of the main loop in `aur-fetch`, as well as a regression test case.

TIA for your consideration :)