### PR TITLE
aur-fetch: add --rebase, --results

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -225,13 +225,12 @@ else
 fi
 
 # Write successfully built packages to file (#437)
-if [[ -v results_file ]]; then
-    if [[ -w $results_file ]]; then
-        results=1
-    else
-        error '%s: %s: permission denied' "$argv0" "$results_file"
-        exit 13
-    fi
+if [[ -v results_file && -w $results_file ]]; then
+    : >"$results_file" # truncate file
+    results=1
+elif [[ -v results_file ]]; then
+    error '%s: %s: permission denied' "$argv0" "$results_file"
+    exit 13
 fi
 
 if (( sign_pkg )); then
@@ -341,7 +340,7 @@ while IFS= read -ru "$fd" path; do
     LANG=C repo-add "${repo_add_args[@]}" "$db_path" "${pkglist[@]}"
 
     if (( results )); then
-        printf '%s\n' "${pkglist[@]}" | tee -a "$results_file"
+        printf "build:file://${db_path%/*}/%s\n" "${pkglist[@]}" | tee -a "$results_file"
     fi
 
     if (( chroot )) || (( no_sync )); then

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -11,7 +11,7 @@ pull_args=('--verbose')
 diff_args=('--patch' '--stat')
 
 # default options
-verbose=0 recurse=0 confirm_seen=0 rebase=-1
+verbose=0 recurse=0 confirm_seen=0 rebase=-1 results=0
 
 # empty tree object
 git_empty_tree=$(git hash-object -t tree /dev/null)
@@ -34,7 +34,7 @@ fi
 
 opt_short='rRvL:'
 opt_long=('recurse' 'verbose' 'write-log:' 'confirm-seen'
-          'rebase' 'reset')
+          'rebase' 'reset' 'results:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -57,6 +57,8 @@ while true; do
             rebase=0 ;;
         --confirm-seen)
             confirm_seen=1 ;;
+        --results)
+            results_file=$1 ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}"
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
@@ -69,6 +71,14 @@ done
 if [[ -v $log_dir ]] && [[ ! -d $log_dir ]]; then
     error '%s: %s: Not a directory' "$argv0" "$log_dir"
     exit 20
+fi
+
+if [[ -v results_file && -w $results_file ]]; then
+    : >"$results_file" # truncate file
+    results=1
+elif [[ -v results_file ]]; then
+    error '%s: %s: permission denied' "$argv0" "$results_file"
+    exit 13
 fi
 
 if ! (( $# )); then
@@ -96,7 +106,7 @@ fi | while read -r pkg; do
     # Avoid issues with filesystem boundaries. (#274)
     export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
 
-    # reset/rebase if we're on valid repo
+    # Reset/rebase if we're on valid repo
     if git rev-parse --git-dir 2>/dev/null; then
         if (( confirm_seen )); then
             git update-ref AUR_SEEN HEAD
@@ -136,6 +146,10 @@ fi | while read -r pkg; do
                 git --no-pager log "${diff_args[@]}" "$range" >"$log_dir/$pkg.log"
             fi
         fi
+
+        if (( results )); then
+            printf 'fetch:file://%s\n' "$PWD/$pkg" | tee -a "$results_file"
+        fi
     # Otherwise, try to clone anew
     elif git clone "$AUR_LOCATION/$pkg".git "$GIT_DIR"; then
         if (( confirm_seen )); then
@@ -146,6 +160,10 @@ fi | while read -r pkg; do
 
         # Show PKGBUILDs first. (#399)
         git config diff.orderFile "$orderfile"
+
+        if (( results )); then
+            printf 'clone:file://%s\n' "$PWD/$pkg" | tee -a "$results_file"
+        fi
     else
         error '%s: %s: Failed to clone repository' "$argv0" "$pkg"
     fi

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -6,19 +6,22 @@ AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 
-# default options
-verbose=0 recurse=0 fetch_args=('--verbose') confirm_seen=0
+# default arguments
+pull_args=('--verbose')
+diff_args=('--patch' '--stat')
 
-gen_patchfile() {
-    git diff-tree --patch --stat "${2:-$(git hash-object -t tree /dev/null)}" "$1"
-}
+# default options
+verbose=0 recurse=0 confirm_seen=0 rebase=-1
+
+# empty tree object
+git_empty_tree=$(git hash-object -t tree /dev/null)
 
 usage() {
     cat <<! | base64 -d
 ICAgICAgICAgICAgIC4tLX5+LF9fCjotLi4uLiwtLS0tLS0tYH5+Jy5fLicKIGAtLCwsICAs
 XyAgICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
 !
-    plain 'usage: %s [-L directory] [-rv] pkgname...' "$argv0" >&2
+    plain >&2 'usage: %s [-L directory] [-Rrv] pkgname...' "$argv0"
     exit 1
 }
 
@@ -29,8 +32,9 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
     [[ -t 2 ]] && colorize
 fi
 
-opt_short='rvL:'
-opt_long=('recurse' 'verbose' 'write-log:' 'force' 'confirm-seen')
+opt_short='rRvL:'
+opt_long=('recurse' 'verbose' 'write-log:' 'confirm-seen'
+          'rebase' 'reset')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -47,12 +51,14 @@ while true; do
             recurse=1 ;;
         -v|--verbose)
             verbose=1 ;;
-        --force)
-            fetch_args+=('--force') ;;
+        -R|--rebase)
+            rebase=1 ;;
+        --reset)
+            rebase=0 ;;
         --confirm-seen)
             confirm_seen=1 ;;
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}" 
+            printf -- '--%s\n' "${opt_long[@]}"
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break ;;
@@ -70,10 +76,8 @@ if ! (( $# )); then
     exit 1
 fi
 
-# Prepare configuration directory.
-mkdir -p "$XDG_CONFIG_HOME"/aurutils/$argv0
-
 # Default to showing PKGBUILD first in patch. (#399)
+mkdir -p "$XDG_CONFIG_HOME/aurutils/$argv0"
 orderfile=$XDG_CONFIG_HOME/aurutils/$argv0/orderfile
 
 if [[ ! -s $orderfile ]]; then
@@ -89,49 +93,61 @@ if (( recurse )); then
 else
    printf '%s\n' "$@"
 fi | while read -r pkg; do
-    if [[ ! -e $pkg ]]; then
-        if git clone "$AUR_LOCATION"/"$pkg".git; then
-            # show PKGBUILDS first (#399)
-            git -C "$pkg" config diff.orderFile "$orderfile"
-            # only allow fast-forward fetches. (#)
-            git -C "$pkg" config remote.origin.fetch 'refs/heads/*:refs/remotes/origin/*'
+    # Avoid issues with filesystem boundaries. (#274)
+    export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
+
+    # reset/rebase if we're on valid repo
+    if git rev-parse --git-dir 2>/dev/null; then
+        if (( confirm_seen )); then
+            git update-ref AUR_SEEN HEAD
+
+            msg2 'Marked repository %s as seen' "$pkg"
+            continue # skip diff logic
+        fi
+
+        if (( rebase > 0 )) || {
+               (( rebase < 0 )) && [[ $(git config --get --bool aurutils.rebase) == "true" ]]
+           }; then
+            git reset --hard HEAD >&2
+
+            if ! git pull --rebase "${pull_args[@]}"; then
+                error '%s: %s: Failed to integrate changes' "$argv0" "$pkg"
+                exit 1
+            fi
         else
-            error '%s: %s: Failed to clone repository' "$argv0" "$pkg"
-            exit 1
-        fi
-    fi
-    # Avoid issues with filesystem boundaries, (#274)
-    # and make sure we have a valid git repository.
-    GIT_DIR=$(git rev-parse --resolve-git-dir "$pkg"/.git) || exit
-    export GIT_DIR GIT_WORK_TREE=$pkg
-
-    if (( confirm_seen )); then
-        git update-ref AUR_SEEN HEAD
-        msg2 'Marked %s as seen' "$pkg"
-        continue
-    fi
-
-    # Discard any local uncommited changes. (#552)
-    git reset --hard HEAD >&2
-    if ! git pull --rebase "${fetch_args[@]}"; then
-        error '%s: Failed to integrate changes.' "$pkg"
-        exit 1
-    fi
-
-    seen=$(git rev-parse --quiet --verify AUR_SEEN)
-
-    if [[ "$seen" != $(git rev-parse HEAD) ]]; then
-        log_range=(HEAD ${seen:+^$seen})
-
-        if (( verbose )); then
-            gen_patchfile "${log_range[@]}"
+            git fetch -v >&2
+            git reset --hard 'HEAD@{upstream}' >&2
         fi
 
-        if [[ $log_dir ]]; then
-            logfile="$log_dir/$pkg".patch
-            gen_patchfile "${log_range[@]}" >"$logfile"
-            plain '%s' "$logfile"
+        if ! seen=$(git rev-parse --quiet --verify AUR_SEEN); then
+            warning '%s: AUR_SEEN object not found, assuming empty tree' "$argv0"
+            seen=$git_empty_tree
         fi
+
+        if [[ $seen != "$(git rev-parse HEAD)" ]]; then
+            range=${seen:+$seen..}HEAD
+
+            # Contents have changed since last inspection; print differences.
+            if (( verbose )); then
+                git --no-pager log "${diff_args[@]}" "$range"
+            fi
+
+            if [[ $log_dir ]]; then
+                git --no-pager log "${diff_args[@]}" "$range" >"$log_dir/$pkg.log"
+            fi
+        fi
+    # Otherwise, try to clone anew
+    elif git clone "$AUR_LOCATION/$pkg".git "$GIT_DIR"; then
+        if (( confirm_seen )); then
+            git update-ref AUR_SEEN HEAD
+
+            msg2 'Marked new repository %s as seen' "$pkg"
+        fi
+
+        # Show PKGBUILDs first. (#399)
+        git config diff.orderFile "$orderfile"
+    else
+        error '%s: %s: Failed to clone repository' "$argv0" "$pkg"
     fi
 done
 

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -6,6 +6,7 @@ aur\-fetch \- download packages from the AUR
 .SY "aur fetch"
 .OP \-L log_dir
 .OP \-r
+.OP \-R
 .OP \-v
 .IR package " [" package... ]
 .YS
@@ -35,31 +36,41 @@ Print logs to
 .BR stdout .
 .
 .TP
-.BR \-\-force
-.B aur\-fetch
-will refuse to fetch if history was rewritten. This option allows
-overriding that check. (see \fIHISTORY REWRITES\fR under \fINOTES\fR)
+.B \-\-reset
+Reset to the upstream commit, discarding local changes.
+.IP
+When neither
+.BR \-\-rebase " or " \-\-reset
+are specified, the default behaviour is
+.BR \-\-reset ,
+unless
+.BR rebase.aurutils " is set to " true
+in which case
+.B \-\-rebase
+will be used.
+.IP
+If specified,
+.BR \-\-reset " takes precedence over " aurutils.rebase .
+.
+.TP
+.BR \-R ", " \-\-rebase
+Instead of resetting to the upstream commit, update with
+.BR "git pull \-\-rebase" .
+This can be used to keep locally committed changes to PKGBUILDS.
+Uncommitted changes are discarded. See
+.BR NOTES .
+.IP
+This feature can be enabled on a per-repository basis by setting
+.BR aurutils.rebase " to " true
+in the git configuration.
 .
 .TP
 .B \-\-confirm\-seen
-Marks the package's checked out commit as seen.
+Marks the package's checked out commit as seen. See
+.BR NOTES .
 .
 .
 .SH NOTES
-.
-.SS HISTORY REWRITES
-.B aur\-fetch
-will refuse to fetch rewritten history by default. This happens rarely,
-as only Trusted Users have permissions to force-push to the AUR.
-.PP
-In those situations, something serious may have happened that may
-require the user to do manual intervention on the machine.
-To raise awareness to these events,
-.B aur\-fetch
-will refuse to fetch unless
-.B \-\-force
-is passed.
-.
 .
 .SS LOGS
 The logs shown by
@@ -78,23 +89,17 @@ This reference can be created with with:
 which will mark the current commit as seen, signaling
 .B aur\-fetch
 that current changes should not be shown in future logs.
-.PP
-When this reference is missing,
-.B aur\-fetch
-will consider the entire history as changes.
 .
 .
-.SS LOCAL MODIFICATIONS (EXPERIMENTAL)
-While
-.B aur\-fetch
-will try to preserve changes committed locally, by trying to reapply
-them on top of the incoming new changes, it will discard any uncommitted
-changes present in the repository.
+.SS REBASE
+This option should be used with care. While it enables users
+to keep personalized changes to PKGBUILDS, it will cause failures if
+.B "git\-rebase"
+does not apply cleanly. The user is expected to fix those issues
+before continuing.
 .PP
-If the changes cannot be applied cleanly,
-.B aur\-fetch
-will exit with error, leaving the repository files with conflict
-markers for the user to resolve.
+More importantly, it may inadvertently keep malicious commits that
+Trusted Users have removed from the git history.
 .
 .SH SEE ALSO
 .ad l
@@ -103,6 +108,7 @@ markers for the user to resolve.
 .BR aur\-depends (1),
 .BR git (1),
 .BR git\-clone (1),
+.BR git\-config (1),
 .BR git\-fetch (1),
 .BR git\-log (1),
 .BR git\-pull (1),

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -69,6 +69,24 @@ in the git configuration.
 Marks the package's checked out commit as seen. See
 .BR NOTES .
 .
+.TP
+.BI \-\-results= file
+Writes
+.IB action :file:// path
+pairs to the specified
+.IR file .
+Possible values for
+.I action
+are
+.B clone
+and
+.BR fetch .
+.I path
+is the absolute path to the processed package repository.
+.IP
+Can be used by higher level tools to differentiate new clones from
+updates to existing repositories.
+.
 .
 .SH NOTES
 .


### PR DESCRIPTION
Implements:
* ability to choose between git reset (default)/pull --rebase to update cached repos. (discard local commits vs trying to reapply local commits on top of the incoming changes)

from #634. Additionally adds a `--results` flag to allow for separation of "new" and "existing" packages in `aur-sync`, see #379.