### PR TITLE
aur-chroot: use custom pacman.conf

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -23,15 +23,25 @@ ignore_defaults() {
     } { print }'
 }
 
-host_with_cache() {
-    printf '[%s]\n' options
-    pacman-conf -c "$pacman_conf" --verbose CacheDir
-
-    for a in "$@"; do
-        printf '[%s]\n' "$a"
-        pacman-conf -c "$pacman_conf" --repo "$a"
-    done
-}
+host_with_cache() {    
+    printf '[%s]\n' options    
+     
+    pacman-conf -c "$pacman_conf" --verbose CacheDir    
+     
+    for a in "$@"; do    
+        printf '[%s]\n' "$a"    
+        set +e    
+        pacman-conf -c "$pacman_conf" --repo "$a" > /dev/null 2>&1    
+        if [[ $? = 0 ]]    
+        then    
+            set -e                  
+            pacman-conf -c "$pacman_conf" --repo "$a"    
+        else    
+            set -e                  
+            pacman-conf --repo "$a"    
+        fi        
+    done    
+}    
 
 trap_exit() {
     if ! [[ -o xtrace ]]; then

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -23,25 +23,20 @@ ignore_defaults() {
     } { print }'
 }
 
-host_with_cache() {    
-    printf '[%s]\n' options    
-     
-    pacman-conf -c "$pacman_conf" --verbose CacheDir    
-     
-    for a in "$@"; do    
-        printf '[%s]\n' "$a"    
-        set +e    
-        pacman-conf -c "$pacman_conf" --repo "$a" > /dev/null 2>&1    
-        if [[ $? = 0 ]]    
-        then    
-            set -e                  
-            pacman-conf -c "$pacman_conf" --repo "$a"    
-        else    
-            set -e                  
-            pacman-conf --repo "$a"    
-        fi        
-    done    
-}    
+host_with_cache() {
+    printf '[%s]\n' options
+
+    pacman-conf -c "$pacman_conf" --verbose CacheDir
+
+    for a in "$@"; do
+        printf '[%s]\n' "$a"
+	    set +e
+        if ! pacman-conf -c "$pacman_conf" --repo "$a" 2>&1; then
+	        set -e
+	        pacman-conf --repo "$a"
+    	fi    
+    done
+}
 
 trap_exit() {
     if ! [[ -o xtrace ]]; then

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -25,11 +25,11 @@ ignore_defaults() {
 
 host_with_cache() {
     printf '[%s]\n' options
-    pacman-conf --verbose CacheDir
+    pacman-conf -c "$pacman_conf" --verbose CacheDir
 
     for a in "$@"; do
         printf '[%s]\n' "$a"
-        pacman-conf --repo "$a"
+        pacman-conf -c "$pacman_conf" --repo "$a"
     done
 }
 


### PR DESCRIPTION
This resolves issue #642. With this PR, pacman-conf runs against the custom pacman.conf file if such a file was specified in the arguments of aur-chroot. 

Signed-off-by: Michael Picht <mipi@fsfe.org>