### PR TITLE
adjusted data retrieval from pacman.conf

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -29,7 +29,13 @@ host_with_cache() {
 
     for a in "$@"; do
         printf '[%s]\n' "$a"
-        pacman-conf --repo "$a"
+        set +e
+        if ! pacman-conf -c "$pacman_conf" --repo "$a" 2>&1; then
+            set -e
+            pacman-conf --repo "$a"
+        else
+            set -e
+        fi    
     done
 }
 
@@ -82,7 +88,7 @@ if (($#)); then
 fi
 
 # baseline configuration
-pacman_conf=${pacman_conf-/usr/share/devtools/pacman-multilib.conf}
+pacman_conf=${pacman_conf-/usr/share/devtools/pacman-extra.conf}
 makepkg_conf=${makepkg_conf-/usr/share/devtools/makepkg-$machine.conf}
 
 # CacheDir will be replaced by devtools (#416)


### PR DESCRIPTION
1. First try to retrieve data from custom pacman.conf, then from default.
1. Default is pacman-extra.conf (instead of pacman-multilib.conf

Signed-off-by: Michael Picht <mipi@fsfe.org>