### PR TITLE
aur-repo: add --path

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -70,7 +70,7 @@ fi
 
 ## option parsing
 opt_short='a:B:d:D:AcfnrsvLNR'
-opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign'
+opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:'
           'makepkg-conf:' 'remove' 'build-command:' 'pkgver' 'prefix:'
           'rmdeps' 'noconfirm' 'ignorearch' 'log' 'recreate')
@@ -94,7 +94,7 @@ while true; do
         -f|--force)
             overwrite=1 ;;
         # database options
-        -d|--database)
+        -d|--database|--repo)
             shift; db_name=$1 ;;
         --root)
             shift; db_root=$1 ;;

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -167,7 +167,7 @@ fi
 case $db_name in
     "")
         case $db_root in
-            "") db_path=$(aur repo)
+            "") db_path=$(aur repo --path)
                 db_name=$(basename "$db_path" .db)
                 db_root=$(dirname "$db_path")
                 ;;
@@ -176,7 +176,7 @@ case $db_name in
         esac ;;
     *)
         case $db_root in
-            "") db_path=$(aur repo -d "$db_name")
+            "") db_path=$(aur repo --path -d "$db_name")
                 db_name=$(basename "$db_path" .db)
                 db_root=$(dirname "$db_path")
                 ;;

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -91,7 +91,7 @@ while true; do
         -u|--upgrades)
             mode=upgrades ;;
         --path)
-            mode=path ;;
+            mode=path; modifier=path ;;
         --repo-list)
             mode=repo_list ;;
         -S|--sync)
@@ -113,7 +113,7 @@ done
 : "${db_name=$AUR_REPO}"
 : "${db_root=$AUR_DBROOT}"
 
-unset conf_repo server
+unset conf_file_repo server
 
 while read -r key _ value; do
     case $key=$value in
@@ -125,8 +125,8 @@ while read -r key _ value; do
             ;;
         Server=file://*)
             server=${value#file://}
-            conf_serv+=("$server")
-            conf_repo+=("$section")
+            conf_file_serv+=("$server")
+            conf_file_repo+=("$section")
 
             case $section in
                 $db_name)
@@ -149,28 +149,33 @@ while read -r key _ value; do
 done < <(pacman-conf --config "${pacman_conf:-/etc/pacman.conf}")
 
 # exclusive modes
-case $mode in
-    #requires (none)
-    repo_list)
-        if [[ ${conf_repo[*]} ]]; then
-            printf '%q\n' "${conf_repo[@]}"
-        else
-            printf >&2 '%s: no file:// repository configured\n' "$argv0"
-        fi
-        exit 0 ;;
-esac
+if [[ $mode == repo_list ]]; then
+    if ! [[ ${conf_file_repo[*]} ]]; then
+        printf >&2 '%s: no file:// repository configured\n' "$argv0"
+        exit 2
+    fi
+
+    if [[ $mode == path ]]; then
+        for i in "${!conf_file_repo[@]}"; do
+            printf '%q/%q\n' "${conf_file_serv[$i]}" "${conf_file_repo[$i]}"
+        done
+    else
+        printf '%q\n' "${conf_file_repo[@]}"
+    fi
+    exit 0
+fi
 
 if ! [[ $db_name ]]; then
-    case ${#conf_repo[@]} in
-        1) db_root=${conf_serv[0]}
-           db_name=${conf_repo[0]}
+    case ${#conf_file_repo[@]} in
+        1) db_root=${conf_file_serv[0]}
+           db_name=${conf_file_repo[0]}
            ;;
-        0) printf >&2 '%s: no file:// repository found\n' "$argv0"
+        0) printf >&2 '%s: no file:// repository configured\n' "$argv0"
            exit 2
            ;;
         *) printf >&2 '%s: repository choice is ambiguous (use -d to specify)\n' "$argv0"
-           for i in "${!conf_repo[@]}"; do
-               printf '%q\t%q\n' "${conf_repo[$i]}" "${conf_serv[$i]}"
+           for i in "${!conf_file_repo[@]}"; do
+               printf '%q\t%q\n' "${conf_file_repo[$i]}" "${conf_file_serv[$i]}"
            done | column -t >&2
            exit 1
            ;;
@@ -195,14 +200,16 @@ case $modifier in
             printf >&2 '%s: %s: not a directory\n' "$argv0" "$db_root"
             exit 20
         else
-            contents() { db_table "$table_format" "$db_root/$db_name".db ; }
-        fi
-        ;;
+            contents() {
+                db_table "$table_format" "$db_root/$db_name".db
+            }
+        fi ;;
     #requires
     # - [$db_name] (pacman.conf)
     sync)
-        contents() { db_table "$table_format" "$pacman_dbpath/sync/$db_name".db ; }
-        ;;
+        contents() {
+            db_table "$table_format" "$pacman_dbpath/sync/$db_name".db
+        } ;;
 esac
 
 case $mode in

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -159,7 +159,7 @@ if [[ $mode == repo_list ]]; then
 
     if [[ $modifier == path ]]; then
         for i in "${!conf_file_repo[@]}"; do
-            printf '%q/%q\n' "${conf_file_serv[$i]}" "${conf_file_repo[$i]}"
+            printf '%q/%q.db\n' "${conf_file_serv[$i]}" "${conf_file_repo[$i]}"
         done
     else
         printf '%q\n' "${conf_file_repo[@]}"

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -66,7 +66,7 @@ source /usr/share/makepkg/util/parseopts.sh
 
 ## option parsing
 opt_short='c:d:r:aluS'
-opt_long=('database:' 'pacman-conf:' 'root:' 'path' 'all' 'list'
+opt_long=('database:' 'repo:' 'pacman-conf:' 'root:' 'path' 'all' 'list'
           'repo-list' 'sync' 'upgrades' 'table')
 opt_hidden=('dump-options' 'status-file:')
 
@@ -78,7 +78,7 @@ set -- "${OPTRET[@]}"
 unset mode db_name db_root status_file pacman_conf vercmp_args
 while true; do
     case $1 in
-        -d|--database)
+        -d|--database|--repo)
             shift; db_name=$1 ;;
         -r|--root)
             shift; db_root=$1 ;;

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -90,10 +90,10 @@ while true; do
             mode=packages ;;
         -u|--upgrades)
             mode=upgrades ;;
-        --path)
-            mode=path; modifier=path ;;
         --repo-list)
             mode=repo_list ;;
+        --path)
+            modifier=path ;;
         -S|--sync)
             modifier=sync ;;
         --table)
@@ -155,7 +155,7 @@ if [[ $mode == repo_list ]]; then
         exit 2
     fi
 
-    if [[ $mode == path ]]; then
+    if [[ $modifier == path ]]; then
         for i in "${!conf_file_repo[@]}"; do
             printf '%q/%q\n' "${conf_file_serv[$i]}" "${conf_file_repo[$i]}"
         done
@@ -219,11 +219,13 @@ case $mode in
     packages)
         contents
         ;;
-    path)
-        printf '%s\n' "$db_root/$db_name".db
-        ;;
     *)
-        usage ;;
+        case $modifier in
+            path)
+                printf '%s\n' "$db_root/$db_name".db ;;
+            *)
+                usage ;;
+        esac ;;
 esac
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -4,15 +4,14 @@
 argv0=repo
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
-# default arguments
-modifier=local
-vercmp_args=()
-table_format=0
+# default options
+modifier=local table_format=0
 
 db_table() {
     bsdtar -Oxf "$2" '*/desc' | awk -v table="$1" '
     function print_previous() {
         table ? format = "%s\t%s\t%s\t%s\n" : format = "%1$s\t%4$s\n"
+
         if (table && length(dependencies) > 0) {
             for (i in dependencies) {
                 printf format, pkgname, dependencies[i], pkgbase, pkgver
@@ -67,8 +66,8 @@ source /usr/share/makepkg/util/parseopts.sh
 
 ## option parsing
 opt_short='c:d:r:aluS'
-opt_long=('database:' 'pacman-conf:' 'root:'
-          'all' 'list' 'repo-list' 'sync' 'upgrades' 'table')
+opt_long=('database:' 'pacman-conf:' 'root:' 'path' 'all' 'list'
+          'repo-list' 'sync' 'upgrades' 'table')
 opt_hidden=('dump-options' 'status-file:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -76,7 +75,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset mode db_name db_root status_file pacman_conf
+unset mode db_name db_root status_file pacman_conf vercmp_args
 while true; do
     case $1 in
         -d|--database)
@@ -86,18 +85,19 @@ while true; do
         -c|--pacman-conf)
             shift; pacman_conf=$1 ;;
         -a|--all)
-            mode=list_upgrades
-            vercmp_args+=(-a) ;;
+            mode=upgrades; vercmp_args+=(-a) ;;
         -l|--list)
-            mode=list_packages ;;
-        -S|--sync)
-            modifier=sync ;;
+            mode=packages ;;
         -u|--upgrades)
-            mode=list_upgrades ;;
-        --table)
-            table_format=1 ;;
+            mode=upgrades ;;
+        --path)
+            mode=path ;;
         --repo-list)
             mode=repo_list ;;
+        -S|--sync)
+            modifier=sync ;;
+        --table)
+            table_format=1 ;;
         --status-file)
             shift; status_file=$1 ;;
         --dump-options)
@@ -125,7 +125,8 @@ while read -r key _ value; do
             ;;
         Server=file://*)
             server=${value#file://}
-            conf_repo+=("$server" "$section")
+            conf_serv+=("$server")
+            conf_repo+=("$section")
 
             case $section in
                 $db_name)
@@ -152,7 +153,7 @@ case $mode in
     #requires (none)
     repo_list)
         if [[ ${conf_repo[*]} ]]; then
-            printf '%q/%q.db\n' "${conf_repo[@]}"
+            printf '%q\n' "${conf_repo[@]}"
         else
             printf >&2 '%s: no file:// repository configured\n' "$argv0"
         fi
@@ -161,14 +162,16 @@ esac
 
 if ! [[ $db_name ]]; then
     case ${#conf_repo[@]} in
-        2) db_root=${conf_repo[0]}
-           db_name=${conf_repo[1]}
+        1) db_root=${conf_serv[0]}
+           db_name=${conf_repo[0]}
            ;;
         0) printf >&2 '%s: no file:// repository found\n' "$argv0"
            exit 2
            ;;
         *) printf >&2 '%s: repository choice is ambiguous (use -d to specify)\n' "$argv0"
-           printf '%q\n' "${conf_repo[@]}" | paste - - | column -t >&2
+           for i in "${!conf_repo[@]}"; do
+               printf '%q\t%q\n' "${conf_repo[$i]}" "${conf_serv[$i]}"
+           done | column -t >&2
            exit 1
            ;;
     esac
@@ -203,15 +206,17 @@ case $modifier in
 esac
 
 case $mode in
-    list_upgrades)
+    upgrades)
         contents | aur vercmp "${vercmp_args[@]}"
         ;;
-    list_packages)
+    packages)
         contents
         ;;
-    *)
+    path)
         printf '%s\n' "$db_root/$db_name".db
         ;;
+    *)
+        usage ;;
 esac
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -65,9 +65,9 @@ usage() {
 source /usr/share/makepkg/util/parseopts.sh
 
 ## option parsing
-opt_short='c:d:r:aluS'
+opt_short='c:d:r:alquS'
 opt_long=('database:' 'repo:' 'pacman-conf:' 'root:' 'path' 'all' 'list'
-          'repo-list' 'sync' 'upgrades' 'table')
+          'repo-list' 'sync' 'upgrades' 'table' 'quiet')
 opt_hidden=('dump-options' 'status-file:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -84,10 +84,12 @@ while true; do
             shift; db_root=$1 ;;
         -c|--pacman-conf)
             shift; pacman_conf=$1 ;;
-        -a|--all)
-            mode=upgrades; vercmp_args+=(-a) ;;
         -l|--list)
             mode=packages ;;
+        -a|--all)
+            mode=upgrades; vercmp_args+=(-a) ;;
+        -q|--quiet)
+            mode=upgrades; vercmp_args+=(-q) ;;
         -u|--upgrades)
             mode=upgrades ;;
         --repo-list)
@@ -220,12 +222,11 @@ case $mode in
         contents
         ;;
     *)
-        case $modifier in
-            path)
-                printf '%s\n' "$db_root/$db_name".db ;;
-            *)
-                usage ;;
-        esac ;;
+        if [[ $modifier == path ]]; then
+            printf '%s\n' "$db_root/$db_name".db
+        else
+            usage
+        fi ;;
 esac
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -41,7 +41,7 @@ while true; do
     case "$1" in
         -a|--all|--sync)
             sync_repo=1 ;;
-        -d|--database)
+        -d|--database|--repo)
             shift; argv_repo+=("$1") ;;
         --sysroot)
             shift; sift_args+=("--sysroot=$1") ;;

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -94,7 +94,7 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
 fi
 
 opt_short='B:C:d:D:M:AcfkLnpPrRsTu'
-opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:'
+opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:'
           'root:' 'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue'
           'force' 'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph'
           'no-ver-shallow' 'no-view' 'print' 'provides' 'rm-deps'
@@ -112,7 +112,7 @@ set -- "${OPTRET[@]}"
 unset pkg pkg_i repo repo_p ignore_file
 while true; do
     case "$1" in
-        -d|--database)
+        -d|--database|--repo)
             shift; repo_args+=(-d "$1") ;;
         -B|--build-command)
             shift; build_args+=(-B "$1") ;;


### PR DESCRIPTION
Add the `--path` command-line option to print paths, and exit with `usage` if not specified. This way, the user must explicitely specify the operation they want to perform (issue #555).

Change `--repo-list` to only print the names of `file://` repositories, for easy processing where only these names are required (e.g. `aur-build -d` or `aur-sync -d`). The previous behavior, where paths are printed in full, can be achieved by combining `--repo-list` with `--path`.

----
In summary, we have the following options:

1. `aur repo --repo-list`
-> Print `file://` repository names
    
2. `aur repo --repo-list --path`
-> Print paths of all `file://` repositories
    
3. `aur repo --path`
-> Print path of single `file://` repository

4. `aur-repo`
-> Print usage text

----
Closes #555
