### PR TITLE
aur-fetch: add --sync

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -105,11 +105,11 @@ if (( recurse )); then
 else
    printf '%s\n' "$@"
 fi | while read -r pkg; do
-    # Avoid issues with filesystem boundaries. (#274)
-    export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
+    # Reset/rebase if we are on valid repo
+    if GIT_DIR=$pkg/.git git rev-parse --git-dir >/dev/null 2>&1; then
+        # Avoid issues with filesystem boundaries. (#274)
+        export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
 
-    # Reset/rebase if we're on valid repo
-    if git rev-parse --git-dir >/dev/null; then
         if (( confirm_seen )); then
             git update-ref AUR_SEEN HEAD
 
@@ -160,10 +160,12 @@ fi | while read -r pkg; do
         fi
 
     # Otherwise, try to clone anew
-    elif git clone "$AUR_LOCATION/$pkg".git "$GIT_DIR"; then
+    elif git clone "$AUR_LOCATION/$pkg"; then
+        # Avoid issues with filesystem boundaries. (#274)
+        export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
+
         if (( confirm_seen )); then
             git update-ref AUR_SEEN HEAD
-
             msg2 'Marked new repository %s as seen' "$pkg"
         fi
 

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -178,6 +178,7 @@ fi | while read -r pkg; do
         fi
     else
         error '%s: %s: Failed to clone repository' "$argv0" "$pkg"
+        exit 1
     fi
 done
 

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -78,12 +78,9 @@ if [[ -v $log_dir ]] && [[ ! -d $log_dir ]]; then
     exit 20
 fi
 
-if [[ -v results_file && -w $results_file ]]; then
+if [[ -v results_file ]]; then
     : >"$results_file" # truncate file
     results=1
-elif [[ -v results_file ]]; then
-    error '%s: %s: permission denied' "$argv0" "$results_file"
-    exit 13
 fi
 
 if ! (( $# )); then

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -13,9 +13,6 @@ diff_args=('--patch' '--stat')
 # default options
 verbose=0 recurse=0 confirm_seen=0 results=0 sync=no
 
-# empty tree object
-git_empty_tree=$(git hash-object -t tree /dev/null)
-
 usage() {
     cat <<! | base64 -d
 ICAgICAgICAgICAgIC4tLX5+LF9fCjotLi4uLiwtLS0tLS0tYH5+Jy5fLicKIGAtLCwsICAs
@@ -117,7 +114,7 @@ fi | while read -r pkg; do
             continue # skip diff logic
         fi
 
-        git fetch --verbose >&2
+        git fetch --verbose >&2 || exit 1
 
         case $sync in
             auto)
@@ -138,8 +135,8 @@ fi | while read -r pkg; do
         }
 
         if ! seen=$(git rev-parse --quiet --verify AUR_SEEN); then
-            warning '%s: AUR_SEEN object not found, assuming empty tree' "$argv0"
-            seen=$git_empty_tree
+            warning '%s: AUR_SEEN object not found for %s, assuming empty tree' "$pkg" "$argv0"
+            seen=$(git hash-object -t tree /dev/null)
         fi
 
         if [[ $seen != "$(git rev-parse HEAD)" ]]; then

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -11,7 +11,7 @@ pull_args=('--verbose')
 diff_args=('--patch' '--stat')
 
 # default options
-verbose=0 recurse=0 confirm_seen=0 rebase=-1 results=0
+verbose=0 recurse=0 confirm_seen=0 results=0 sync=no
 
 # empty tree object
 git_empty_tree=$(git hash-object -t tree /dev/null)
@@ -32,9 +32,8 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
     [[ -t 2 ]] && colorize
 fi
 
-opt_short='rRvL:'
-opt_long=('recurse' 'verbose' 'write-log:' 'confirm-seen'
-          'rebase' 'reset' 'results:')
+opt_short='rvL:S'
+opt_long=('recurse' 'verbose' 'write-log:' 'confirm-seen' 'sync:' 'results:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -51,10 +50,16 @@ while true; do
             recurse=1 ;;
         -v|--verbose)
             verbose=1 ;;
-        -R|--rebase)
-            rebase=1 ;;
-        --reset)
-            rebase=0 ;;
+        -S)
+            sync=auto ;;
+        --sync)
+            case $2 in
+                auto|reset|rebase|no)
+                    sync=$2 ;;
+                *)
+                    error "$argv0: invalid --sync option"
+                    usage ;;
+            esac ;;
         --confirm-seen)
             confirm_seen=1 ;;
         --results)
@@ -107,7 +112,7 @@ fi | while read -r pkg; do
     export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
 
     # Reset/rebase if we're on valid repo
-    if git rev-parse --git-dir 2>/dev/null; then
+    if git rev-parse --git-dir >/dev/null; then
         if (( confirm_seen )); then
             git update-ref AUR_SEEN HEAD
 
@@ -115,19 +120,25 @@ fi | while read -r pkg; do
             continue # skip diff logic
         fi
 
-        if (( rebase > 0 )) || {
-               (( rebase < 0 )) && [[ $(git config --get --bool aurutils.rebase) == "true" ]]
-           }; then
-            git reset --hard HEAD >&2
+        git fetch --verbose >&2
 
-            if ! git pull --rebase "${pull_args[@]}"; then
-                error '%s: %s: Failed to integrate changes' "$argv0" "$pkg"
-                exit 1
-            fi
-        else
-            git fetch -v >&2
-            git reset --hard 'HEAD@{upstream}' >&2
-        fi
+        case $sync in
+            auto)
+                if [[ $(git config --get --bool aurutils.rebase) == "true" ]]; then
+                    plain 'aurutils.rebase is set for %s' "$pkg"
+                    sync=rebase
+                else
+                    sync=reset
+                fi ;;&
+            rebase)
+                git reset --hard 'HEAD' >&2
+                git rebase "${pull_args[@]}" >&2 ;;
+            reset)
+                git reset --hard 'HEAD@{upstream}' >&2 ;;
+        esac || {
+            error '%s: %s: Failed to integrate changes' "$argv0" "$pkg"
+            exit 1
+        }
 
         if ! seen=$(git rev-parse --quiet --verify AUR_SEEN); then
             warning '%s: AUR_SEEN object not found, assuming empty tree' "$argv0"
@@ -150,6 +161,7 @@ fi | while read -r pkg; do
         if (( results )); then
             printf 'fetch:file://%s\n' "$PWD/$pkg" | tee -a "$results_file"
         fi
+
     # Otherwise, try to clone anew
     elif git clone "$AUR_LOCATION/$pkg".git "$GIT_DIR"; then
         if (( confirm_seen )); then

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -297,7 +297,7 @@ fi
 if (( download )); then
     msg "Retrieving package files" >&2
     parallel -Xj +3 --nice 10 --halt now,fail=1 --keep-order \
-        aur fetch -L "$tmp_view" :::: "$tmp"/queue
+        aur fetch -L "$tmp_view" -S :::: "$tmp"/queue
 fi
 
 # link build files in the queue (absolute links)


### PR DESCRIPTION
Make `aur-fetch` non-destructive by default, to either update AUR_SEEN (if `--confirm-seen` is specified) or run `git-fetch -v`. 

If `--sync=reset` or `--sync=rebase` are specified, `git reset --hard HEAD@{upstream}`, and `git reset --HARD; git merge` are run, respectively. 

`sync=auto` decides the action based on the `aurutils.rebase` configuration setting, defaulting to `--reset`, and this option is used by `aur-sync`.

----
As usual, documentation updates are missing.