### PR TITLE
Allow overriding pacman.conf for repo selection

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -121,7 +121,9 @@ while true; do
         -M|--makepkg-conf)
             shift; build_args+=(--makepkg-conf "$1") ;;
         -C|--pacman-conf)
-            shift; build_args+=(--pacman-conf "$1") ;;
+            shift;
+            build_args+=(--pacman-conf "$1");
+            repo_args+=(--pacman-conf "$1") ;;
         --bind)
             shift; makechrootpkg_args+=(-D "$1") ;;
         --bind-rw)


### PR DESCRIPTION
The ``pacman.conf`` file might specify an alternate location for your
packages repository – for example, it might specify the ``file://`` path
while you usually use a path on the internet. This is for example useful
if you use the same ``pacman.conf`` on a bunch of machines.

This change passes on ``--pacman-conf`` from ``sync`` to the
repo-manipulating commands.