### PR TITLE
Ensure aur-repo always gets the pacman config

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -18,6 +18,9 @@ gpg_args=(--detach-sign --no-armor --batch)
 # do not hardcode (optional) arguments to build commands
 unset makepkg_args makechrootpkg_args archbuild_args repo_add_args
 
+# Use this pacman config location
+pacman_conf="/etc/pacman.conf"
+
 # default options
 chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0
 
@@ -178,7 +181,7 @@ fi
 case $db_name in
     "")
         case $db_root in
-            "") db_path=$(aur repo --path)
+            "") db_path=$(aur repo --path --pacman-conf "$pacman_conf")
                 db_name=$(basename "$db_path" .db)
                 db_root=$(dirname "$db_path")
                 ;;
@@ -187,7 +190,7 @@ case $db_name in
         esac ;;
     *)
         case $db_root in
-            "") db_path=$(aur repo --path -d "$db_name")
+            "") db_path=$(aur repo --path --pacman-conf "$pacman_conf" -d "$db_name")
                 db_name=$(basename "$db_path" .db)
                 db_root=$(dirname "$db_path")
                 ;;

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -8,6 +8,7 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
+
 # default arguments
 build_args=(--clean --syncdeps)
 build_extra_args=()
@@ -108,7 +109,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset pkg pkg_i repo repo_p ignore_file
+unset pkg pkg_i repo repo_p ignore_file pacman_conf
 while true; do
     case "$1" in
         # sync options
@@ -157,7 +158,7 @@ while true; do
         --makepkg-conf)
             shift; build_args+=(--makepkg-conf "$1") ;;
         --pacman-conf)
-            shift; build_args+=(--pacman-conf "$1") ;;
+            shift; pacman_conf="$1"; build_args+=(--pacman-conf "$1") ;;
         --pkgver)
             build_args+=(--pkgver) ;;
         -S|--sign|--gpg-sign)
@@ -231,7 +232,7 @@ mkdir -p "$AURDEST"
 cd_safe "$tmp"
 
 # retrieve path to local repo (#448)
-aur repo "${repo_args[@]}" --list --status-file=db >db_info
+aur repo --pacman-conf "${pacman_conf:-/etc/pacman.conf}" "${repo_args[@]}" --list --status-file=db >db_info
 
 { IFS= read -r db_name
   IFS= read -r db_root

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -109,7 +109,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset pkg pkg_i repo repo_p ignore_file pacman_conf
+unset pkg pkg_i repo repo_p ignore_file
 while true; do
     case "$1" in
         # sync options
@@ -158,7 +158,7 @@ while true; do
         --makepkg-conf)
             shift; build_args+=(--makepkg-conf "$1") ;;
         --pacman-conf)
-            shift; pacman_conf="$1"; build_args+=(--pacman-conf "$1") ;;
+            shift; build_args+=(--pacman-conf "$1"); repo_args+=(--pacman-conf "$1") ;;
         --pkgver)
             build_args+=(--pkgver) ;;
         -S|--sign|--gpg-sign)
@@ -232,7 +232,7 @@ mkdir -p "$AURDEST"
 cd_safe "$tmp"
 
 # retrieve path to local repo (#448)
-aur repo --pacman-conf "${pacman_conf:-/etc/pacman.conf}" "${repo_args[@]}" --list --status-file=db >db_info
+aur repo "${repo_args[@]}" --list --status-file=db >db_info
 
 { IFS= read -r db_name
   IFS= read -r db_root


### PR DESCRIPTION
Rebases @Foxboron's PR #614 on master.

* [aur-build] Ensure we propegate pacman.conf to aur-repo when finding
              the repository we build against.
* [aur-build] Renamed p_conf to pacman_conf for internal consistency
* [aur-sync] Ensure pacman.conf is propegated to aur-repo when we find
             the build repo.