### PR TITLE
scripts: readd aur-chroot

### DIFF
--- a/completions/command_opts.sh
+++ b/completions/command_opts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-have_optdump=('build' 'depends' 'fetch' 'pkglist' 'repo' 'repo-filter' 'query'
-              'search' 'srcver' 'sync' 'vercmp')
+have_optdump=('build' 'chroot' 'depends' 'fetch' 'pkglist' 'repo' 'repo-filter'
+              'query' 'search' 'srcver' 'sync' 'vercmp')
 no_optdump=('graph')
 
 default_opts() {

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -8,17 +8,18 @@ startdir=$PWD
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
-# hardware name
-machine=$(uname -m)
+# default options
+chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0 prefix=aur
 
 # default options
 chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0 chroot_prefix=aur
 
 # default arguments
+chroot_args=()
+conf_args=()
 gpg_args=(--detach-sign --no-armor --batch)
 makepkg_args=()
-makechrootpkg_args=()
-archbuild_args=()
+makechrootpkg_args=(-cu)
 repo_add_args=()
 repo_args=()
 
@@ -61,7 +62,7 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
 fi
 
 ## option parsing
-opt_short='a:B:d:D:AcfnrsvLNRST'
+opt_short='a:B:d:D:AcCfnrsvLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:'
           'remove' 'build-command:' 'pkgver' 'prefix:' 'rmdeps'
@@ -74,7 +75,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset build_cmd db_name db_path db_root queue results_file
+unset build_cmd db_name db_path db_root results_file queue
 while true; do
     case "$1" in
         # build options
@@ -88,13 +89,14 @@ while true; do
             chroot=1 ;;
         -d|--database|--repo)
             shift; db_name=$1 ;;
+        --makepkg-conf)
+            shift; chroot_args+=(--makepkg-conf "$1") ;;
+        --pacman-conf)
+            shift; chroot_args+=(--pacman-conf "$1")
+            repo_args+=(--pacman-conf "$1")
+            conf_args+=(--config "$1") ;;
         -N|--nosync|--no-sync)
             no_sync=1 ;;
-        --pacman-conf)
-            shift; conf_args+=(--config "$1")
-            repo_args+=(--pacman-conf "$1") ;;
-        --prefix)
-            shift; chroot_prefix=$1 ;;
         --pkgver)
             run_pkgver=1
             makepkg_args+=(--holdver) ;;
@@ -105,21 +107,21 @@ while true; do
         -S|--sign|--gpg-sign)
             sign_pkg=1
             repo_add_args+=(-s) ;;
-        # devtools options
+        # chroot options
         -D|--directory)
-            shift; archbuild_args+=(-r "$1") ;;
-        --recreate)
-            archbuild_args+=(-c) ;;
+            shift; makechrootpkg_args+=(-r "$1") ;;
         --bind)
             shift; makechrootpkg_args+=(-D "$1") ;;
         --bind-rw)
-            shift; makechrootpkg_args+=(-d "$1") ;;
+            shift; makechrootpkg_args+=(-d"$1") ;;
+        --prefix)
+            shift; prefix=$1 ;;
         -T|--temp)
             makechrootpkg_args+=(-T) ;;
         # makepkg options
         -A|--ignorearch|--ignore-arch)
             makepkg_args+=(--ignorearch) ;;
-        --clean)
+        -C|--clean)
             makepkg_args+=(--clean) ;;
         -L|--log)
             makepkg_args+=(--log) ;;
@@ -154,19 +156,18 @@ var_tmp=$(mktemp -d --tmpdir="${TMPDIR:-/var/tmp/}" "aurutils-$argv0.XXXXXXXX") 
 trap 'trap_exit' EXIT
 trap 'exit' INT
 
-# Pass all arguments after -- to makepkg
+# Append remaining options to the makechrootpkg command-line
 if (( $# )); then
-    if (( chroot )); then
-        makechrootpkg_args+=("$@")
-    else
-        makepkg_args+=("$@")
-    fi
+    makechrootpkg_args+=("$@")
+    makepkg_args+=("$@")
 fi
 
 # Assign environment variables (#443)
 : "${db_name=$AUR_REPO}"
 : "${db_root=$AUR_DBROOT}"
 
+# Automatically choose repository root and name based on pacman
+# configuration and user environment.
 case $db_name in
     "")
         case $db_root in
@@ -187,7 +188,7 @@ case $db_name in
         esac ;;
 esac
 
-# Resolve symbolic link to database
+# Resolve symbolic link to database.
 if ! db_path=$(readlink -e -- "$db_path"); then
     error '%s: %s: no such file or directory' "$argv0" "$db_path"
     exit 2
@@ -202,25 +203,23 @@ if [[ -v results_file ]]; then
     results=1
 fi
 
-# Provisions for symbolic links to /usr/bin/archbuild. Because archbuild
-# only allows to pass bind mounts to makechrootpkg, and not arch-nspawn,
-# the below relies on the implicit mounting of file:// repositories
-# by arch-nspawn in devtools>=20190821. (#591)
 if (( chroot )); then
-    if ! type -P "$chroot_prefix"-"$machine"-build >/dev/null; then
-        error '%s: %s: command not found' "$argv0" "$chroot_prefix"-"$machine"-build
-        exit 1
-    fi
+    # Defaults to /usr/share/devtools/pacman-aur.conf
+    chroot_args+=(--prefix "$prefix")
 
-    chroot_pacman_conf=/usr/share/devtools/pacman-$chroot_prefix.conf
+    # Update pacman and makepkg configuration for the chroot build
+    # queue. A full system upgrade is run on the /root container to
+    # avoid lenghty upgrades for makechrootpkg -u.
+    aur chroot "${chroot_args[@]}" --no-build
+else
+    # Configuration for host builds.
+    # XXX move to aur-repo
+    { printf '[options]\n'
+      pacconf "${conf_args[@]}" --raw --options
 
-    if ! [[ -e $chroot_pacman_conf ]]; then
-        error '%s: pacman-%s.conf: no such file or directory' "$argv0" "$chroot_prefix"
-        exit 2
-    elif ! pacman-conf --config="$chroot_pacman_conf" --repo="$db_name" >/dev/null; then
-        error '%s: %s: local repository %s not configured' "$argv0" "$chroot_pacman_conf" "$db_name"
-        exit 1
-    fi
+      printf '[%s]\n' "$db_name"
+      pacconf "${conf_args[@]}" --raw --repo="$db_name"
+    } > "$tmp"/custom.conf
 fi
 
 if [[ -v queue ]]; then
@@ -245,14 +244,6 @@ else
         exit 1
     fi
 fi
-
-# Configuration for host builds.
-{ printf '[options]\n'
-  pacconf "${conf_args[@]}" --raw --options
-
-  printf '[%s]\n' "$db_name"
-  pacconf "${conf_args[@]}" --raw --repo="$db_name"
-} > "$tmp"/custom.conf
 
 while IFS= read -ru "$fd" path; do
     cd_safe "$startdir/$path"
@@ -282,12 +273,9 @@ while IFS= read -ru "$fd" path; do
         printf '%s\n' >&2 "Running custom command: ${build_cmd[*]}"
         env PKGDEST="$var_tmp" AUR_REPO="$db_name" AUR_DBROOT="$db_root" "${build_cmd[@]}"
     elif (( chroot )); then
-        printf '%s\n' >&2 "Running $chroot_prefix-$machine-build"
-        # archbuild hardcodes makechrootpkg -c -n -C. In turn, makechrootpkg
-        # hardcodes makepkg --syncdeps --noconfirm --log --holdver --skipinteg.
-        # These options cannot overriden, only appended to.
-        env PKGDEST="$var_tmp" "$chroot_prefix"-"$machine"-build \
-            "${archbuild_args[@]}" -- -d "$db_root" "${makechrootpkg_args[@]}"
+        printf '%s\n' >&2 "Running makechrootpkg ${makechrootpkg_args[@]}"
+        env PKGDEST="$var_tmp" aur chroot "${chroot_args[@]}" --no-prepare \
+            -- "${makechrootpkg_args[@]}"
     else
         printf '%s\n' >&2 "Running makepkg ${makepkg_args[*]}"
         env PKGDEST="$var_tmp" makepkg "${makepkg_args[@]}"

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -274,8 +274,8 @@ while IFS= read -ru "$fd" path; do
         env PKGDEST="$var_tmp" AUR_REPO="$db_name" AUR_DBROOT="$db_root" "${build_cmd[@]}"
     elif (( chroot )); then
         printf '%s\n' >&2 "Running makechrootpkg ${makechrootpkg_args[@]}"
-        env PKGDEST="$var_tmp" aur chroot "${chroot_args[@]}" --no-prepare \
-            -- "${makechrootpkg_args[@]}"
+        env PKGDEST="$var_tmp" aur chroot "${chroot_args[@]}" \
+            --bind-rw "$db_root" --no-prepare -- "${makechrootpkg_args[@]}"
     else
         printf '%s\n' >&2 "Running makepkg ${makepkg_args[*]}"
         env PKGDEST="$var_tmp" makepkg "${makepkg_args[@]}"

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -1,0 +1,115 @@
+#!/bin/bash
+# aur-chroot - build packages with systemd-nspawn
+[[ -v AUR_DEBUG ]] && set -o xtrace
+set -o errexit
+argv0=chroot
+PATH=/bin:/usr/bin
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+machine=$(uname -m)
+
+# default arguments
+directory=/var/lib/aurbuild/$machine
+makechrootpkg_args=(-c) # sync /root container to /$USER copy
+makepkg_conf=/usr/share/devtools/makepkg-$machine.conf
+prefix=extra
+
+# default options
+prepare=1 build=1 create=0 
+
+usage() {
+    printf >&2 'usage: %s [--create] [-CDM path] -- <makechrootpkg args>\n' "$argv0"
+    exit 1
+}
+
+source /usr/share/makepkg/util/parseopts.sh
+
+opt_short='C:D:M:'
+opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'no-build' 'no-prepare'
+          'create' 'prefix:' 'bind:' 'bind-ro:' 'temp')
+opt_hidden=('dump-options' 'nobuild' 'noprepare')
+
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
+
+unset bindmounts_ro bindmounts_rw pacman_conf
+while true; do
+    case "$1" in
+        --create)
+            create=1 ;;
+        --no-build|--nobuild)
+            build=0 ;;
+        --no-prepare|--noprepare)
+            prepare=0 ;;
+        --prefix)
+            shift; prefix=$1 ;;
+        # arch-nspawn options
+        -C|--pacman-conf)
+            shift; pacman_conf=$1 ;;
+        -D|--directory)
+            shift; directory=$1 ;;
+        -M|--makepkg-conf)
+            shift; makepkg_conf=$1 ;;
+        # makechrootpkg options
+        --bind)
+            shift; bindmounts_ro+=("$1") ;;
+        --bind-rw)
+            shift; bindmounts_rw+=(-d "$1") ;;
+        # other options
+        --dump-options)
+            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
+            exit ;;
+        --) shift; break ;;
+    esac
+    shift
+done
+
+# Use remaining options for the makechrootpkg command-line
+if (( $# )); then
+    makechrootpkg_args=("$@")
+fi
+
+# pacman configuration
+case $prefix in
+    multilib*)
+        base_packages=('multilib-devel') ;;
+    *)
+        base_packages=('base-devel') ;;
+esac
+pacman_conf=${pacman_conf:-/usr/share/devtools/pacman-$prefix.conf}
+
+# bind mount file:// paths to container (#461)
+while read -r key _ value; do
+    case $key=$value in
+        Server=file://*)
+            bindmounts_ro+=("${value#file://}") ;;
+    esac
+done < <(pacman-conf --config "$pacman_conf")
+
+if (( create )); then
+    # parent path is not created by mkarchroot (#371)
+    if [[ ! -d $directory ]]; then
+        sudo install -d "$directory" -m 755 -v
+    fi
+
+    sudo mkarchroot -C "$pacman_conf" -M "$makepkg_conf" \
+         "$directory"/root "${base_packages[@]}"
+    exit 0
+fi
+
+if (( prepare )); then
+    # locking is done by systemd-nspawn
+    sudo arch-nspawn -C "$pacman_conf" -M "$makepkg_conf" "$directory"/root \
+         "${bindmounts_ro[@]/#/--bind-ro=}" \
+         "${bindmounts_rw[@]/#/--bind=}" pacman -Syu --noconfirm
+fi
+
+if (( build )); then
+    sudo --preserve-env=GNUPGHOME,PKGDEST makechrootpkg -r "$directory" \
+         "${bindmounts_ro[@]/#/-D}" \
+         "${bindmounts_rw[@]/#/-d}" "${makechrootpkg_args[@]}"
+fi
+
+# vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -205,7 +205,7 @@ tmp_view=$(mktemp -d --tmpdir "aurutils-$argv0-view.XXXXXXXX") || exit
 
 trap 'trap_exit' EXIT
 
-# pass all arguments after -- to aur-build
+# Append remaining options to the aur-build command-line
 if (( $# )); then
     build_extra_args+=("$@")
 fi


### PR DESCRIPTION
This is a compromise between the previous `aur-chroot` and a full delegation to `archbuild`. In particular, a dedicated `pacman.conf` is used for the chroot (defaulting to `/usr/share/devtools/pacman-extra.conf`, with `extra` as a configurable prefix) with no additional processing.

`aur-chroot` differs as follows from `archbuild`:

* `Include` directives are supported;
* `makechrootpkg` arguments can be overridden from the command line;
* the distinction between `multilib-devel` and `base-devel` is derived from the supplied prefix instead of `$0`;
* the `arch-nspawn`, `mkarchroot` and `makechrootpkg` steps can be used seperately;
* both `makepkg.conf` and `pacman.conf` can be specified from the command-line.