### PR TITLE
scripts: fix use of msg/msg2

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -51,7 +51,7 @@ trap_exit() {
 }
 
 usage() {
-    plain 'usage: %s [-acfBNS] [-d repo] [--root path] [--] <makepkg args>' "$argv0" >&2
+    plain >&2 'usage: %s [-acfBNS] [-d repo] [--root path] [--] <makepkg args>' "$argv0"    
     exit 1
 }
 

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -94,7 +94,7 @@ if [[ ! -s $orderfile ]]; then
 fi
 
 if (( confirm_seen )); then
-    msg "Marking repositories as seen"
+    msg >&2 "Marking repositories as seen"
 fi
 
 if (( recurse )); then
@@ -110,7 +110,7 @@ fi | while read -r pkg; do
         if (( confirm_seen )); then
             git update-ref AUR_SEEN HEAD
 
-            msg2 'Marked repository %s as seen' "$pkg"
+            msg2 >&2 'Marked repository %s as seen' "$pkg"
             continue # skip diff logic
         fi
 
@@ -119,7 +119,7 @@ fi | while read -r pkg; do
         case $sync in
             auto)
                 if [[ $(git config --get --bool aurutils.rebase) == "true" ]]; then
-                    plain 'aurutils.rebase is set for %s' "$pkg"
+                    plain >&2 'aurutils.rebase is set for %s' "$pkg"
                     sync=rebase
                 else
                     sync=reset

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -123,12 +123,15 @@ fi | while read -r pkg; do
                     sync=rebase
                 else
                     sync=reset
-                fi ;;&
-            rebase)
-                git reset --hard 'HEAD' >&2
-                git rebase "${pull_args[@]}" >&2 ;;
-            reset)
-                git reset --hard 'HEAD@{upstream}' >&2 ;;
+                fi ;&
+            *)  # expand $sync with newly assigned value
+                case $sync in
+                    rebase)
+                        git reset --hard 'HEAD' >&2
+                        git rebase "${pull_args[@]}" >&2 ;;
+                    reset)
+                        git reset --hard 'HEAD@{upstream}' >&2 ;;
+                esac ;;
         esac || {
             error '%s: %s: Failed to integrate changes' "$argv0" "$pkg"
             exit 1

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -21,7 +21,7 @@ provides() {
 }
 
 usage() {
-    plain 'usage: %s [-d repo] [-S]' "$argv0" >&2
+    plain >&2 'usage: %s [-d repo] [-S]' "$argv0"
     exit 1
 }
 

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -105,7 +105,7 @@ trap_exit() {
 }
 
 usage() {
-    plain 'usage: %s [-adimnqrsv] [-k key] pkgname...' "$argv0" >&2
+    plain >&2 'usage: %s [-adimnqrsv] [-k key] pkgname...' "$argv0"
     exit 1
 }
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -73,7 +73,7 @@ trap_exit() {
 }
 
 usage() {
-    plain 'usage: %s [-d repo] [--root path] [-cdfPpSu] [--] pkgname...' "$argv0" >&2
+    plain >&2 'usage: %s [-d repo] [--root path] [-cdfPpSu] [--] pkgname...' "$argv0"
     exit 1
 }
 
@@ -239,7 +239,7 @@ aur repo "${repo_args[@]}" --list --status-file=db >db_info
 } <db
 
 if [[ -w $db_root/$db_name.db ]]; then
-    msg 'Using [%s] repository' "$db_name" >&2
+    msg >&2 'Using [%s] repository' "$db_name"
 else
     error '%s: %s: permission denied' "$argv0" "$db_root/$db_name.db"
     exit 13
@@ -259,7 +259,7 @@ if [[ -s argv ]]; then
     # $1 pkgname $2 depends $3 pkgbase $4 pkgver
     xargs --arg-file=argv aur depends --table >depends
 else
-    plain "there is nothing to do" >&2
+    plain >&2 "there is nothing to do"
     exit
 fi
 
@@ -308,12 +308,12 @@ cut -f1,2 pkginfo | select_pkgbase - queue_1 >queue
 if [[ -s queue ]]; then
     cd_safe "$AURDEST"
 else
-    plain "there is nothing to do" >&2
+    plain >&2 "there is nothing to do"
     exit
 fi
 
 if (( download )); then
-    msg "Retrieving package files" >&2
+    msg >&2 "Retrieving package files"
     parallel -Xj +3 --nice 10 --halt now,fail=1 --keep-order \
         aur fetch -L "$tmp_view" -S :::: "$tmp"/queue
 fi

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -18,11 +18,11 @@ cmp_equal_or_newer() {
         esac
 
         case $op in
-           -1) plain '%s: %s is newer than %s' "$pkg" "$v_cmp" "$v_in" >&2
+           -1) plain >&2 '%s: %s is newer than %s' "$pkg" "$v_cmp" "$v_in" >&2
                printf '%s\n' "$pkg" ;;
             0) printf '%s\n' "$pkg" ;;
-            1) msg2 '%s: %s -> %s' "$pkg" "$v_cmp" "$v_in" ;;
-            2) msg2 '%s: (none) -> %s' "$pkg" "$v_in" ;;
+            1) msg2 >&2 '%s: %s -> %s' "$pkg" "$v_cmp" "$v_in" ;;
+            2) msg2 >&2 '%s: (none) -> %s' "$pkg" "$v_in" ;;
         esac
     done
 }


### PR DESCRIPTION
`msg`/`msg2` using `stdout` breaks the version output in `aur-sync`, and there is otherwise no reason to use these functions for non-stderr output.