### PR TITLE
Fix building in chroot

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -11,9 +11,6 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 # default options
 chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0 prefix=aur
 
-# default options
-chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0 chroot_prefix=aur
-
 # default arguments
 chroot_args=()
 conf_args=()
@@ -42,7 +39,7 @@ trap_exit() {
 }
 
 usage() {
-    plain >&2 'usage: %s [-acfBNS] [-d repo] [--root path] [--] <makepkg args>' "$argv0"    
+    plain >&2 'usage: %s [-acfBNS] [-d repo] [--root path] [--] <makepkg args>' "$argv0"
     exit 1
 }
 
@@ -273,9 +270,9 @@ while IFS= read -ru "$fd" path; do
         printf '%s\n' >&2 "Running custom command: ${build_cmd[*]}"
         env PKGDEST="$var_tmp" AUR_REPO="$db_name" AUR_DBROOT="$db_root" "${build_cmd[@]}"
     elif (( chroot )); then
-        printf '%s\n' >&2 "Running makechrootpkg ${makechrootpkg_args[@]}"
-        env PKGDEST="$var_tmp" aur chroot "${chroot_args[@]}" \
-            --bind-rw "$db_root" --no-prepare -- "${makechrootpkg_args[@]}"
+        printf '%s\n' >&2 "Running makechrootpkg ${makechrootpkg_args[*]}"
+        env PKGDEST="$var_tmp" aur chroot "${chroot_args[@]}" --no-prepare \
+            -- "${makechrootpkg_args[@]}"
     else
         printf '%s\n' >&2 "Running makepkg ${makepkg_args[*]}"
         env PKGDEST="$var_tmp" makepkg "${makepkg_args[@]}"

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -14,7 +14,7 @@ makepkg_conf=/usr/share/devtools/makepkg-$machine.conf
 prefix=extra
 
 # default options
-prepare=1 build=1 create=0 
+prepare=1 build=1 create=0
 
 usage() {
     printf >&2 'usage: %s [--create] [-CDM path] -- <makechrootpkg args>\n' "$argv0"
@@ -25,7 +25,7 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='C:D:M:'
 opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'no-build' 'no-prepare'
-          'create' 'prefix:' 'bind:' 'bind-ro:' 'temp')
+          'create' 'prefix:' 'bind:' 'bind-rw:' 'temp')
 opt_hidden=('dump-options' 'nobuild' 'noprepare')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -55,7 +55,7 @@ while true; do
         --bind)
             shift; bindmounts_ro+=("$1") ;;
         --bind-rw)
-            shift; bindmounts_rw+=(-d "$1") ;;
+            shift; bindmounts_rw+=("$1") ;;
         # other options
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}"
@@ -84,7 +84,7 @@ pacman_conf=${pacman_conf:-/usr/share/devtools/pacman-$prefix.conf}
 while read -r key _ value; do
     case $key=$value in
         Server=file://*)
-            bindmounts_ro+=("${value#file://}") ;;
+            bindmounts_rw+=("${value#file://}") ;;
     esac
 done < <(pacman-conf --config "$pacman_conf")
 


### PR DESCRIPTION
Follow-up to https://github.com/AladW/aurutils/pull/655

Some typos fixed.

Most controversial question: as you can see I removed `--create` because I dont really see the need for it, aurutils is perfectly capable to figure out on its own if it needs to initialize chroot before building. Am I missing something?

This works when both `/var/lib/aurbuild` doesnt exist and when it is already initialized.