### PR TITLE
aur-chroot: create automatically when necessary

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -63,8 +63,8 @@ opt_short='a:B:d:D:AcCfnrsvLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:'
           'remove' 'build-command:' 'pkgver' 'prefix:' 'rmdeps'
-          'no-confirm' 'ignore-arch' 'log' 'recreate' 'new' 'bind:'
-          'bind-rw:' 'prevent-downgrade' 'temp' 'syncdeps' 'clean')
+          'no-confirm' 'ignore-arch' 'log' 'new' 'bind:' 'bind-rw:' 
+          'prevent-downgrade' 'temp' 'syncdeps' 'clean')
 opt_hidden=('dump-options' 'gpg-sign' 'ignorearch' 'noconfirm' 'nosync')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -86,15 +86,15 @@ while read -r key _ value; do
     esac
 done < <(pacman-conf --config "$pacman_conf")
 
-# parent path is not created by mkarchroot (#371)
-if [[ ! -d $directory ]]; then
-    sudo install -d "$directory" -m 755 -v
-
-    sudo mkarchroot -C "$pacman_conf" -M "$makepkg_conf" \
-         "$directory"/root "${base_packages[@]}"
-fi
-
 if (( prepare )); then
+    # parent path is not created by mkarchroot (#371)
+    if [[ ! -d $directory ]]; then
+        sudo install -d "$directory" -m 755 -v
+
+        sudo mkarchroot -C "$pacman_conf" -M "$makepkg_conf" \
+             "$directory"/root "${base_packages[@]}"
+    fi
+
     # locking is done by systemd-nspawn
     sudo arch-nspawn -C "$pacman_conf" -M "$makepkg_conf" "$directory"/root \
          "${bindmounts_ro[@]/#/--bind-ro=}" \

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -14,10 +14,10 @@ makepkg_conf=/usr/share/devtools/makepkg-$machine.conf
 prefix=extra
 
 # default options
-prepare=1 build=1 create=0
+prepare=1 build=1
 
 usage() {
-    printf >&2 'usage: %s [--create] [-CDM path] -- <makechrootpkg args>\n' "$argv0"
+    printf >&2 'usage: %s [-CDM path] -- <makechrootpkg args>\n' "$argv0"
     exit 1
 }
 
@@ -25,7 +25,7 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='C:D:M:'
 opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'no-build' 'no-prepare'
-          'create' 'prefix:' 'bind:' 'bind-rw:' 'temp')
+          'prefix:' 'bind:' 'bind-rw:' 'temp')
 opt_hidden=('dump-options' 'nobuild' 'noprepare')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -36,8 +36,6 @@ set -- "${OPTRET[@]}"
 unset bindmounts_ro bindmounts_rw pacman_conf
 while true; do
     case "$1" in
-        --create)
-            create=1 ;;
         --no-build|--nobuild)
             build=0 ;;
         --no-prepare|--noprepare)
@@ -88,15 +86,12 @@ while read -r key _ value; do
     esac
 done < <(pacman-conf --config "$pacman_conf")
 
-if (( create )); then
-    # parent path is not created by mkarchroot (#371)
-    if [[ ! -d $directory ]]; then
-        sudo install -d "$directory" -m 755 -v
-    fi
+# parent path is not created by mkarchroot (#371)
+if [[ ! -d $directory ]]; then
+    sudo install -d "$directory" -m 755 -v
 
     sudo mkarchroot -C "$pacman_conf" -M "$makepkg_conf" \
          "$directory"/root "${base_packages[@]}"
-    exit 0
 fi
 
 if (( prepare )); then


### PR DESCRIPTION
I don't understand the purpose of `--create` and how it's intended to be used, I think `aur-chroot` can perfectly well understand when chroot needs to be initialized, so let's not even ask user to do so?