### PR TITLE
Run shellcheck and option parsing check on pushes and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    container: archlinux/base
+    steps:
+      - run: pacman -Syu --noconfirm base base-devel
+      - uses: actions/checkout@v2
+      - run: test/parseopt-consistency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ jobs:
     runs-on: ubuntu-latest
     container: archlinux/base
     steps:
-      - run: pacman -Syu --noconfirm base base-devel
+      - run: pacman -Syu --noconfirm base base-devel shellcheck
       - uses: actions/checkout@v2
-      - run: test/parseopt-consistency
+
+      - name: Option parsing consistency
+        run: test/parseopt-consistency
+
+      - name: Shellcheck
+        if: success() || failure() # Do not fail-fast
+        run: make shellcheck

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -139,7 +139,7 @@ while true; do
             repo_add_args+=(-p) ;;
         # other options
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break ;;

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -56,7 +56,7 @@ while true; do
             shift; bindmounts_rw+=("$1") ;;
         # other options
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break ;;

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -101,7 +101,7 @@ while true; do
         -t|--table)
             mode=table ;;
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break ;;

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -72,7 +72,7 @@ while true; do
         --results)
             shift; results_file=$1 ;;
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break ;;

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -58,7 +58,7 @@ while true; do
         -P|--perl-regexp)
             mode=regex ;;
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break ;;

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -58,7 +58,7 @@ while true; do
         --rpc-url)
             shift; rpc_url=$1 ;;
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break ;;

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -103,7 +103,7 @@ while true; do
         --status-file)
             shift; status_file=$1 ;;
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break ;;

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -46,7 +46,7 @@ while true; do
         --sysroot)
             shift; sift_args+=("--sysroot=$1") ;;
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break;;

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -161,7 +161,7 @@ while true; do
         -k|--key)
             shift; sort_key=$1 ;;
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break ;;

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -53,7 +53,7 @@ while true; do
         -j|--jobs)
             shift; num_procs=$1 ;;
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --)

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -192,7 +192,7 @@ while true; do
             build_args+=(--new) ;;
         # other options
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break ;;

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -109,7 +109,7 @@ while true; do
         -u|--upair)
             shift; upair=$1 ;;
         --dump-options)
-            printf -- '--%s\n' "${opt_long[@]}"
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
             exit ;;
         --) shift; break ;;

--- a/test/parseopt-consistency
+++ b/test/parseopt-consistency
@@ -1,6 +1,7 @@
 #!/bin/bash
 shopt -s extglob
 shopt -s nullglob
+export AUR_ASROOT=1
 
 parse_loop() {
   awk '/^while true; do$/,/^done$/ {

--- a/test/parseopt-consistency
+++ b/test/parseopt-consistency
@@ -1,0 +1,26 @@
+#!/bin/bash
+shopt -s extglob
+shopt -s nullglob
+
+parse_loop() {
+  awk '/^while true; do$/,/^done$/ {
+    if ( $0 ~ /^\s*-.*)$/ && $1 != "--)" ) {  # match -<something>) except --)
+      gsub(/[ )]/,"")                         # remove spaces and final parens
+      split($0, patterns,"|")                 # split on |
+      getline                                 # ask for next line for shift check
+      for (i in patterns) {                   # print options accordingly
+        print ($1 ~ /^shift/) ? patterns[i] ":" : patterns[i]
+      }
+    }
+  }'
+}
+
+ret=0
+for aurcmd in "${BASH_SOURCE%/*}"/../lib/!(aur-graph); do
+      diff --color -U0 --label "$aurcmd Options" --label "$aurcmd Loop" \
+        <(bash --pretty-print -O extglob "$aurcmd" | parse_loop | sort) \
+        <(AUR_DEBUG=1 command "$aurcmd" --dump-options 2>/dev/null | sort)
+      ((ret|=$?))
+done
+
+exit $ret


### PR DESCRIPTION
I'm willing to merge a PR that adds the `parseopt-consistency` test.
_Originally posted by @AladW in https://github.com/AladW/aurutils/pull/667#issuecomment-577803145_

I also included a small github action that runs it automatically on pushes and pull requests.
For now, only the parseopt check is done.

Later, we can include other tests and the shellcheck run. I left it out of this PR because I still didn't investigate how to cache/reuse the expensive `pacman -Syu`.

Or I can drop the actions commit for a later PR.