### PR TITLE
sync: do not save state information in vifminfo

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -326,7 +326,7 @@ trust_exit_success=0
 
 if type -P >/dev/null vifm; then
     # Avoid directory prefix in printed paths (#452)
-    viewer() ( cd "$1"; vifm -c 'view!' -c '0' - )
+    viewer() ( cd "$1"; vifm -c 'set vifminfo=' -c 'view!' -c '0' - )
     trust_exit_success=1
 else
     # shellcheck disable=SC2086


### PR DESCRIPTION
To help with review we call vifm with some commands via -c.
Depending on what the user has vifminfo set to, those changes may be
made persistent between sessions.

Since some of the options are only enabled for the specific usecase of
reviewing pkgbuilds, and to avoid cloberring the userstate, unset
vifminfo to prevent these changes from being written to the vifminfo
file.

---

This was something we found out when playing with `vifm`'s `millerview` and forgot about it.
