### PR TITLE
aur: respect AUR_EXEC_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ PREFIX ?= /usr
 SHRDIR ?= $(PREFIX)/share
 BINDIR ?= $(PREFIX)/bin
 LIBDIR ?= $(PREFIX)/lib
-AUR_LIB_DIR ?= $(LIBDIR)/$(PROGNM)
+AURUTILS_LIB_DIR ?= $(LIBDIR)/$(PROGNM)
 
 .PHONY: shellcheck install build completion aur
 
 build: aur completion
 
 aur: aur.in
-	sed 's|AUR_LIB_DIR|$(AUR_LIB_DIR)|' $< >$@
+	sed 's|AURUTILS_LIB_DIR|$(AURUTILS_LIB_DIR)|' $< >$@
 
 completion:
 	@$(MAKE) -C completions bash zsh

--- a/aur.in
+++ b/aur.in
@@ -1,6 +1,6 @@
 #!/bin/bash -
 readonly argv0=aur
-readonly lib_dir='AUR_LIB_DIR'
+readonly lib_dir=${AUR_EXEC_PATH:-'AURUTILS_LIB_DIR'}
 shopt -s nullglob
 
 if [[ -z $1 ]]; then

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -22,16 +22,16 @@ section.
 .SH AUR COMMANDS
 The below gives a short overview; see the respective documentation for
 details.
+.PP
 .BR aur (1)
 searches for commands in
 .BR /usr/lib/aurutils/
 by default, followed by
 .B $PATH
-as set in the environment.
-.PP
-A different path may be set at build time through the
-.B AUR_LIB_DIR
-macro, for example
+as set in the environment. A different path may be set at run-time
+through the
+.B AUR_EXEC_PATH
+environment variable, for example
 .IR /usr/local/lib/aurutils:/usr/lib/aurutils .
 .
 .P
@@ -114,6 +114,15 @@ for
 scripts) in
 .B aur
 programs.
+.
+.TP
+.B AUR_EXEC_PATH
+The path in which
+.B aur
+searches for commands, prepended to
+.BR $PATH .
+Defaults to
+.BR /usr/lib/aurutils .
 .
 .TP
 .B NO_COLOR


### PR DESCRIPTION
Defaults to `AURUTILS_LIB_DIR`, which is defined in the Makefile. The variable name is inspired by `GIT_EXEC_PATH`.

Fixes #645