### PR TITLE
Fix aurutils.rebase documentation

### DIFF
--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -48,7 +48,7 @@ When neither
 are specified, the default behaviour is
 .BR \-\-reset ,
 unless
-.BR rebase.aurutils " is set to " true
+.BR aurutils.rebase " is set to " true
 in which case
 .B \-\-rebase
 will be used.


### PR DESCRIPTION
The man page and the actual checked Git config had the section and key switched