### PR TITLE
Fix aur-fetch of more than one package

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -112,6 +112,8 @@ if (( recurse )); then
 else
    printf '%s\n' "$@"
 fi | while read -r pkg; do
+    unset GIT_DIR GIT_WORK_TREE
+
     # Reset/rebase if we are on valid repo
     if GIT_DIR=$pkg/.git git rev-parse --git-dir >/dev/null 2>&1; then
         # Avoid issues with filesystem boundaries. (#274)


### PR DESCRIPTION
There is a fix for this as part of #659, but the discussion on that has been happening for a month, and (at least as a newcomer to the project) it doesn’t look like it’ll be ready to merge soon. In the meantime, #636 is still broken, and it’s only a one-line fix.