### PR TITLE
aur-sync: fix passing args after '--'

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -207,7 +207,8 @@ trap 'trap_exit' EXIT
 
 # Append remaining options to the aur-build command-line
 if (( $# )); then
-    build_extra_args+=("$@")
+    # shellcheck disable=SC2207
+    build_extra_args=($(grep -o -- "-- .*" <<<"${@}"))
 fi
 
 # Append contents of ignore file


### PR DESCRIPTION
We have to strip `packagename` from `${@}` when setting `$build_extra_args`. Otherwise calling `aur-sync` with extra flags after `--` won't work.
Rationale:
[![asciicast](https://asciinema.org/a/gei6YyhCiP9SqbSCgxdwrf65a.svg)](https://asciinema.org/a/gei6YyhCiP9SqbSCgxdwrf65a)
_`aur-build` is free of the issue, as it doesn't trigger `unused_argv` in `parseopts`_