### PR TITLE
scripts: add eof seperator for rm commands

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -29,9 +29,9 @@ db_replaces() {
 
 trap_exit() {
     if [[ ! -v AUR_DEBUG ]]; then
-        rm -rf "$tmp"
+        rm -rf -- "$tmp"
         # Only remove package directory if all files were moved (#593)
-        rm -df "$var_tmp"
+        rm -df -- "$var_tmp"
     else
         printf >&2 'AUR_DEBUG: %s: temporary files at %s\n' "$argv0" "$tmp"
         printf >&2 'AUR_DEBUG: %s: temporary files at %s\n' "$argv0" "$var_tmp"

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -68,7 +68,7 @@ order() {
 
 trap_exit() {
     if [[ ! -v AUR_DEBUG ]]; then
-        rm -rf "$tmp"
+        rm -rf -- "$tmp"
     else
         printf >&2 'AUR_DEBUG: %s: temporary files at %s\n' "$argv0" "$tmp"
     fi

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -75,7 +75,7 @@ esac
 
 # store output on error
 wget_log=$(mktemp --tmpdir aurutils-wget.XXXXXXXX) || exit
-trap 'rm -rf "$wget_log"' EXIT
+trap 'rm -rf -- "$wget_log"' EXIT
 
 # check for interactive terminal
 if [[ -t 0 ]]; then

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -98,7 +98,7 @@ info_short() {
 
 trap_exit() {
     if [[ ! -v AUR_DEBUG ]]; then
-        rm -rf "$tmp"
+        rm -rf -- "$tmp"
     else
         printf >&2 'AUR_DEBUG: %s: temporary files at %s\n' "$argv0" "$tmp"
     fi

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -21,7 +21,7 @@ srcver_pkgbuild_info() {
 
 trap_exit() {
     if [[ ! -v AUR_DEBUG ]]; then
-        rm -rf "$tmp"
+        rm -rf -- "$tmp"
     else
         printf >&2 'AUR_DEBUG: %s: temporary files at %s\n' "$argv0" "$tmp"
     fi

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -64,7 +64,7 @@ order() {
 
 trap_exit() {
     if [[ ! -v AUR_DEBUG ]]; then
-        rm -rf "$tmp" "$tmp_view"
+        rm -rf -- "$tmp" "$tmp_view"
     else
         printf >&2 'AUR_DEBUG: %s: temporary files at %s\n' "$argv0" "$tmp"
         printf >&2 'AUR_DEBUG: %s: temporary files at %s\n' "$argv0" "$tmp_view"

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -68,7 +68,7 @@ parse_aur() {
 
 trap_exit() {
     if [[ ! -v AUR_DEBUG ]]; then
-        rm -rf "$tmp"
+        rm -rf -- "$tmp"
     else
         printf >&2 'AUR_DEBUG: %s: temporary files at %s\n' "$argv0" "$tmp"
     fi

--- a/test/issue-513
+++ b/test/issue-513
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 tmp_server=$(mktemp -d)
-trap 'rm -rf "$tmp_server"' EXIT
+trap 'rm -rf -- "$tmp_server"' EXIT
 
 pacman_config() {
     cat <<EOF

--- a/test/issue-636
+++ b/test/issue-636
@@ -4,7 +4,7 @@ argv0=issue-636
 tmp="$(mktemp -d --tmpdir "aurutils-$argv0.XXXXXXXX")"
 
 trap_exit() {
-    rm -rf "$tmp"
+    rm -rf -- "$tmp"
 }
 
 trap 'trap_exit' EXIT


### PR DESCRIPTION
Files created by `mktemp` may have an arbitrary parent directory by setting `TMPDIR`. For example:
```
 $ mkdir -p -- -/your/face
 $ TMPDIR=-/your/face mktemp -d
 -/your/face/tmp.SXrp6oQ7cj

 $ rm -rf -/your/face/tmp.SXrp6oQ7cj
 rm: invalid option -- '/'
 Try 'rm ./-/your/face/tmp.SXrp6oQ7cj' to remove the file '-/your/face/tmp.SXrp6oQ7cj'.
 Try 'rm --help' for more information.
```
Avoid this by specifying `--` after each `rm` invocation.