### PR TITLE
aur-sync: add AUR_CONFIRM_PAGER

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -321,45 +321,34 @@ fi
 # Link build files in the queue (absolute links)
 parallel -X ln -s "$(pwd -P)"/{} "$tmp_view" :::: "$tmp"/queue
 
-# Explicitly define if exit success is to be trusted (#561)
-trust_exit_success=0
-
-if type -P >/dev/null vifm; then
-    # Avoid directory prefix in printed paths (#452)
-    viewer() ( cd "$1"; vifm -c 'set vifminfo=' -c 'view!' -c '0' - )
-    trust_exit_success=1
-else
-    # shellcheck disable=SC2086
-    viewer() ( cd "$1"; command -- ${PAGER:-less -K -+F} )
-
-    # Trust our fallback
-    if [[ -z $PAGER ]]; then
-        trust_exit_success=1
-    fi
-fi
-
 # Check if dependency graph is valid
 if (( graph )); then
     aur graph "$tmp_view"/*/.SRCINFO >/dev/null
 fi
 
 if (( view )); then
-    # AUR_PAGER exit codes are respected by definition.
     if [[ -v AUR_PAGER ]]; then
         # shellcheck disable=SC2086
         command -- $AUR_PAGER "$tmp_view"
-    else
+
+        # Use an additional prompt for file managers with no support
+        # for exit codes greater 0 (#673)
+        if [[ -v AUR_CONFIRM_PAGER ]]; then
+            read -rp $'Press Return to continue or Ctrl+d to abort\n'
+        fi
+    elif type -P vifm >/dev/null; then
+        # Avoid directory prefix in printed paths (#452)
+        viewer() ( cd "$1"; vifm -c 'set vifminfo=' -c 'view!' -c '0' - )
+
         { # Print patch files
           find "$tmp_view" -maxdepth 1 -type f
 
           # Print build directories in dependency order
           xargs -I{} -a "$tmp"/queue find -L "$tmp_view"/{} -maxdepth 1
         } | viewer "$tmp_view"
-
-        # Ask for confirmation when viewer() exit success is not trusted (#530, #561)
-        if ! (( trust_exit_success )); then
-            read -rp $'Press Return to continue or Ctrl+d to abort\n'
-        fi
+    else
+        error '%s: no viewer found, please install vifm or define AUR_PAGER' "$argv0"
+        exit 1
     fi
     xargs -a "$tmp/queue" aur fetch --confirm-seen
 fi

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -1,4 +1,4 @@
-.TH AUR-SYNC 1 2019-01-24 AURUTILS
+.TH AUR-SYNC 1 2020-03-14 AURUTILS
 .SH Name
 aur\-sync \- download and build AUR packages automatically
 .
@@ -23,16 +23,8 @@ The value of
 if defined;
 .IP \(bu 4
 .BR vifm "(1), "
-if installed;
-.IP \(bu 4
-The value of
-.BR PAGER ", "
-if defined;
-.IP \(bu 4
-.BR "less \-K" .
-.P
-If the exit status of the pager exceeds 0 (for example, through user
-intervention),
+if installed. If the exit status of the pager exceeds 0 (for example,
+through user intervention),
 .B aur\-sync
 terminates immediately.
 .
@@ -176,15 +168,23 @@ Sign built packages with
 .TP
 .B AURDEST
 Determines where build files will be cloned. This must be an absolute path.
-Defaults to $XDG_CACHE_HOME/aurutils/sync
+Defaults to
+.IR $XDG_CACHE_HOME/aurutils/sync .
 .
 .TP
 .B AUR_PAGER
-.RS
 The file manager used to view and edit build files. This variable is
-split on white space, allowing
-.IR "AUR_PAGER=program \-option" .
-.RE
+split on white space to allow program options, for example:
+.IR "AUR_PAGER=less \-K" .
+.
+.TP
+.B AUR_CONFIRM_PAGER
+Display an additional prompt after the file manager has exited (see
+.BR AUR_PAGER ).
+If set, display an additional confirmation prompt after the file
+manager has exited successfully. This may be used for (GUI) file
+managers not supporting an exit status greater zero to indicate
+unreviewed files.
 .
 .SH NOTES
 .SS File inspection
@@ -193,12 +193,10 @@ aborts on build failure, or other errors such as an interrupted file
 review process by the user, in particular
 .B :cq
 in
-.BR vifm (1),
-or
-.B "Ctrl+C"
-in
-.BR less (1).
-.
+.BR vifm (1).
+See also
+.B AUR_CONFIRM_PAGER
+for adding a confirmation prompt if the viewer exited successfully.
 .PP
 To avoid downloading files again, the
 .B \-\-continue


### PR DESCRIPTION
Generalize an additional confirmation prompt for generic viewers set with `AUR_PAGER`, for example for use with GUI file managers without means to exit with status >0 if files were not reviewed or accepted by the user.

Fixes #673