### PR TITLE
aur-sync: --no-ver-shallow -> --no-ver-argv

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -95,12 +95,12 @@ opt_short='B:d:D:AcfLnpPrRSTuv'
 opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:'
           'root:' 'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue'
           'force' 'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph'
-          'no-ver-shallow' 'no-view' 'print' 'provides' 'rm-deps'
+          'no-ver-argv' 'no-view' 'print' 'provides' 'rm-deps'
           'sign' 'temp' 'upgrades' 'pkgver' 'rebuild' 'rebuild-tree'
           'build-command:' 'ignore-file:' 'remove' 'provides-from:'
           'new' 'prevent-downgrade' 'verify')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:'
-            'noconfirm' 'nover' 'nograph' 'nover-shallow' 'noview'
+            'noconfirm' 'nover' 'nograph' 'nover-argv' 'noview'
             'rebuildtree' 'rmdeps' 'gpg-sign')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -125,7 +125,7 @@ while true; do
             graph=0 ;;
         --nover|--no-ver)
             chkver_depth=0 ;;
-        --nover-shallow|--no-ver-shallow)
+        --nover-argv|--no-ver-argv)
             chkver_depth=1 ;;
         --noview|--no-view)
             view=0 ;;
@@ -272,7 +272,7 @@ cut -f2 --complement depends | sort -u >pkginfo
   fi
 
   # Packages with equal or newer versions are taken as complement
-  # for the queue. If chkver_shallow is enabled, packages on the
+  # for the queue. If chkver_argv is enabled, packages on the
   # command-line are excluded from this complement.
   if (( chkver_depth )); then
       # note: AUR cannot be queried by pkgbase (FS#57230)

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -64,7 +64,7 @@ Do not verify the AUR dependency graph with
 Disable version checking for packages.
 .
 .TP
-.BR \-\-nover\-shallow ", " \-\-no\-ver\-shallow
+.BR \-\-nover\-argv ", " \-\-no\-ver\-argv
 Disable version checking for packages specified on the command line or
 upgrade candidates from
 .BR \-\-upgrades .
@@ -159,7 +159,7 @@ before the build process.
 .TP
 .BR \-\-rebuild
 Alias for
-.BR "\-f \-\-nover\-shallow" .
+.BR "\-f \-\-nover\-argv" .
 .
 .TP
 .BR \-\-rebuildtree ", " \-\-rebuild\-tree


### PR DESCRIPTION
This explicitly specifies the packages that ignored for version checks in the option name.