### PR TITLE
aur-fetch: remove AUR_SEEN

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -14,7 +14,7 @@ usage() {
 ICAgICAgICAgICAgIC4tLX5+LF9fCjotLi4uLiwtLS0tLS0tYH5+Jy5fLicKIGAtLCwsICAs
 XyAgICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
 !
-    plain >&2 'usage: %s [-L directory] [-RrSv] pkgname...' "$argv0"
+    plain >&2 'usage: %s [-L directory] [-rSv] pkgname...' "$argv0"
     exit 1
 }
 
@@ -104,7 +104,6 @@ else
 fi | while read -r pkg; do
     unset GIT_DIR GIT_WORK_TREE
 
-    # Reset/rebase if we are on valid repo
     if GIT_DIR=$pkg/.git git rev-parse --git-dir >/dev/null 2>&1; then
         # Avoid issues with filesystem boundaries. (#274)
         export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
@@ -114,7 +113,7 @@ fi | while read -r pkg; do
         prev_head=$(git rev-parse 'HEAD')
         case $sync in
             auto)
-                if [[ $(git config --get --bool aurutils.rebase) == "true" ]]; then
+                if [[ $(git config --get --type bool aurutils.rebase) == "true" ]]; then
                     plain >&2 'aurutils.rebase is set for %s' "$pkg"
                     sync=rebase
                 else
@@ -136,7 +135,6 @@ fi | while read -r pkg; do
         if [[ $prev_head != "$(git rev-parse HEAD)" ]]; then
             range=$prev_head..HEAD
 
-            # Contents have changed since last inspection; print differences.
             if (( verbose )); then
                 git --no-pager "$log_fmt" --patch --stat "$range"
             fi

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -104,7 +104,7 @@ else
 fi | while read -r pkg; do
     unset GIT_DIR GIT_WORK_TREE
 
-    if GIT_DIR=$pkg/.git git rev-parse --git-dir >/dev/null 2>&1; then
+    if [[ -d $pkg/.git ]]; then
         # Avoid issues with filesystem boundaries. (#274)
         export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
 

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -108,12 +108,20 @@ fi | while read -r pkg; do
         # Avoid issues with filesystem boundaries. (#274)
         export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
 
-        git fetch --verbose >&2 || exit 1
+        # Retrieve new upstream revisions
+        git fetch --verbose >&2 || exit
+        fetch_head=$(git rev-parse FETCH_HEAD)
 
-        prev_head=$(git rev-parse 'HEAD')
+        # HEAD before git rebase or git reset
+        prev_head=$(git rev-parse HEAD)
+
+        if (( results )); then
+            printf 'fetch:%s:%s:file://%s\n' "$prev_head" "$fetch_head" "$PWD/$pkg" | tee -a "$results_file"
+        fi
+
         case $sync in
             auto)
-                if [[ $(git config --get --type bool aurutils.rebase) == "true" ]]; then
+                if [[ $(git config --get --type bool aurutils.rebase) == 'true' ]]; then
                     plain >&2 'aurutils.rebase is set for %s' "$pkg"
                     sync=rebase
                 else
@@ -123,20 +131,31 @@ fi | while read -r pkg; do
 
         case $sync in
             rebase)
-                { git stash
-                  git reset --hard 'HEAD'
-                  git rebase --verbose
-                } >&2 ;;
+                git stash
+                git reset --hard HEAD
+                git rebase --verbose
+                ;;
             reset)
-                { git stash
-                  git reset --hard 'HEAD@{upstream}'
-                } >&2 ;;
-        esac || {
-            error '%s: %s: failed to integrate changes' "$argv0" "$pkg"
+                git stash
+                git reset --hard 'HEAD@{upstream}'
+                ;;
+        esac >&2 || {
+            error '%s: %s: failed to %s repository' "$argv0" "$sync" "$pkg"
             exit 1
         }
 
-        if [[ $prev_head != "$(git rev-parse HEAD)" ]]; then
+        head=$(git rev-parse HEAD)
+
+        if (( results )); then
+            case $sync in
+                rebase) printf 'rebase:%s:%s:file://%s\n' "$prev_head" "$head" "$PWD/$pkg"
+                        ;;
+                reset)  printf 'reset:%s:%s:file://%s\n' "$prev_head" "$head" "$PWD/$pkg"
+                        ;;
+            esac | tee -a "$results_file"
+        fi
+
+        if [[ $prev_head != "$head" ]]; then
             range=$prev_head..HEAD
 
             if (( verbose )); then
@@ -148,10 +167,6 @@ fi | while read -r pkg; do
             fi
         fi
 
-        if (( results )); then
-            printf 'fetch:file://%s\n' "$PWD/$pkg" | tee -a "$results_file"
-        fi
-
     # Otherwise, try to clone anew
     elif git clone "$AUR_LOCATION/$pkg"; then
         export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
@@ -160,7 +175,7 @@ fi | while read -r pkg; do
         git config diff.orderFile "$orderfile"
 
         if (( results )); then
-            printf 'clone:file://%s\n' "$PWD/$pkg" | tee -a "$results_file"
+            printf 'clone:%s:%s:file://%s\n' 0 "$(git rev-parse HEAD)" "$PWD/$pkg" | tee -a "$results_file"
         fi
     else
         error '%s: %s: failed to clone repository' "$argv0" "$pkg"

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -6,19 +6,15 @@ AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 
-# default arguments
-pull_args=('--verbose')
-diff_args=('--patch' '--stat')
-
 # default options
-verbose=0 recurse=0 confirm_seen=0 results=0 sync=no log_fmt=diff
+verbose=0 recurse=0 results=0 sync=no log_fmt=diff
 
 usage() {
     cat <<! | base64 -d
 ICAgICAgICAgICAgIC4tLX5+LF9fCjotLi4uLiwtLS0tLS0tYH5+Jy5fLicKIGAtLCwsICAs
 XyAgICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
 !
-    plain >&2 'usage: %s [-L directory] [-Rrv] pkgname...' "$argv0"
+    plain >&2 'usage: %s [-L directory] [-RrSv] pkgname...' "$argv0"
     exit 1
 }
 
@@ -30,7 +26,7 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
 fi
 
 opt_short='rvL:S'
-opt_long=('recurse' 'verbose' 'write-log:' 'confirm-seen' 'sync:' 'results:' 'format:')
+opt_long=('recurse' 'verbose' 'write-log:' 'sync:' 'results:' 'format:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -67,8 +63,6 @@ while true; do
                     error '%s: invalid --format option: %s' "$argv0" "$1"
                     usage ;;
             esac ;;
-        --confirm-seen)
-            confirm_seen=1 ;;
         --results)
             shift; results_file=$1 ;;
         --dump-options)
@@ -81,7 +75,7 @@ while true; do
 done
 
 if [[ -v $log_dir ]] && [[ ! -d $log_dir ]]; then
-    error '%s: %s: Not a directory' "$argv0" "$log_dir"
+    error '%s: %s: not a directory' "$argv0" "$log_dir"
     exit 20
 fi
 
@@ -91,7 +85,7 @@ if [[ -v results_file ]]; then
 fi
 
 if ! (( $# )); then
-    error '%s: No pkgname given' "$argv0"
+    error '%s: no pkgname given' "$argv0"
     exit 1
 fi
 
@@ -101,10 +95,6 @@ orderfile=$XDG_CONFIG_HOME/aurutils/$argv0/orderfile
 
 if [[ ! -s $orderfile ]]; then
     printf 'PKGBUILD\n' > "$orderfile"
-fi
-
-if (( confirm_seen )); then
-    msg >&2 "Marking repositories as seen"
 fi
 
 if (( recurse )); then
@@ -119,15 +109,9 @@ fi | while read -r pkg; do
         # Avoid issues with filesystem boundaries. (#274)
         export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
 
-        if (( confirm_seen )); then
-            git update-ref AUR_SEEN HEAD
-
-            msg2 >&2 'Marked repository %s as seen' "$pkg"
-            continue # skip diff logic
-        fi
-
         git fetch --verbose >&2 || exit 1
 
+        prev_head=$(git rev-parse 'HEAD')
         case $sync in
             auto)
                 if [[ $(git config --get --bool aurutils.rebase) == "true" ]]; then
@@ -141,29 +125,24 @@ fi | while read -r pkg; do
         case $sync in
             rebase)
                 git reset --hard 'HEAD' >&2
-                git rebase "${pull_args[@]}" >&2 ;;
+                git rebase --verbose >&2 ;;
             reset)
                 git reset --hard 'HEAD@{upstream}' >&2 ;;
         esac || {
-            error '%s: %s: Failed to integrate changes' "$argv0" "$pkg"
+            error '%s: %s: failed to integrate changes' "$argv0" "$pkg"
             exit 1
         }
 
-        if ! seen=$(git rev-parse --quiet --verify AUR_SEEN); then
-            warning '%s: AUR_SEEN object not found for %s, assuming empty tree' "$pkg" "$argv0"
-            seen=$(git hash-object -t tree /dev/null)
-        fi
-
-        if [[ $seen != "$(git rev-parse HEAD)" ]]; then
-            range=${seen:+$seen..}HEAD
+        if [[ $prev_head != "$(git rev-parse HEAD)" ]]; then
+            range=$prev_head..HEAD
 
             # Contents have changed since last inspection; print differences.
             if (( verbose )); then
-                git --no-pager "$log_fmt" "${diff_args[@]}" "$range"
+                git --no-pager "$log_fmt" --patch --stat "$range"
             fi
 
             if [[ $log_dir ]]; then
-                git --no-pager "$log_fmt" "${diff_args[@]}" "$range" >"$log_dir/$pkg.$log_fmt"
+                git --no-pager "$log_fmt" --patch --stat "$range" >"$log_dir/$pkg.$log_fmt"
             fi
         fi
 
@@ -173,13 +152,7 @@ fi | while read -r pkg; do
 
     # Otherwise, try to clone anew
     elif git clone "$AUR_LOCATION/$pkg"; then
-        # Avoid issues with filesystem boundaries. (#274)
         export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
-
-        if (( confirm_seen )); then
-            git update-ref AUR_SEEN HEAD
-            msg2 'Marked new repository %s as seen' "$pkg"
-        fi
 
         # Show PKGBUILDs first. (#399)
         git config diff.orderFile "$orderfile"
@@ -188,7 +161,7 @@ fi | while read -r pkg; do
             printf 'clone:file://%s\n' "$PWD/$pkg" | tee -a "$results_file"
         fi
     else
-        error '%s: %s: Failed to clone repository' "$argv0" "$pkg"
+        error '%s: %s: failed to clone repository' "$argv0" "$pkg"
         exit 1
     fi
 done

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -123,10 +123,14 @@ fi | while read -r pkg; do
 
         case $sync in
             rebase)
-                git reset --hard 'HEAD' >&2
-                git rebase --verbose >&2 ;;
+                { git stash
+                  git reset --hard 'HEAD'
+                  git rebase --verbose
+                } >&2 ;;
             reset)
-                git reset --hard 'HEAD@{upstream}' >&2 ;;
+                { git stash
+                  git reset --hard 'HEAD@{upstream}'
+                } >&2 ;;
         esac || {
             error '%s: %s: failed to integrate changes' "$argv0" "$pkg"
             exit 1

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -119,15 +119,18 @@ fi | while read -r pkg; do
             printf 'fetch:%s:%s:file://%s\n' "$prev_head" "$fetch_head" "$PWD/$pkg" | tee -a "$results_file"
         fi
 
-        case $sync in
-            auto)
-                if [[ $(git config --get --type bool aurutils.rebase) == 'true' ]]; then
-                    plain >&2 'aurutils.rebase is set for %s' "$pkg"
+        if [[ $sync == 'auto' ]]; then
+            if [[ $(git config --get --type bool aurutils.rebase) == 'true' ]]; then
+                plain >&2 'aurutils.rebase is set for %s' "$pkg"
+
+                if ! git merge-base --is-ancestor 'HEAD@{upstream}' HEAD; then
                     sync=rebase
-                else
-                    sync=reset
-                fi ;;
-        esac
+                fi
+
+            elif [[ $prev_head != $(git rev-parse 'HEAD@{upstream}') ]]; then
+                sync=reset
+            fi # else sync = no
+        fi
 
         case $sync in
             rebase)

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -346,7 +346,6 @@ if (( view )); then
         error '%s: no viewer found, please install vifm or set AUR_PAGER' "$argv0"
         exit 1
     fi
-    xargs -a "$tmp/queue" aur fetch --confirm-seen
 fi
 
 if (( build )); then

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -1,4 +1,4 @@
-.TH AUR-FETCH 1 2018-03-17 AURUTILS
+.TH AUR-FETCH 1 2020-03-14 AURUTILS
 .SH NAME
 aur\-fetch \- download packages from the AUR
 .
@@ -6,24 +6,16 @@ aur\-fetch \- download packages from the AUR
 .SY "aur fetch"
 .OP \-L log_dir
 .OP \-r
-.OP \-R
+.OP \-S
 .OP \-v
-.IR package " [" package... ]
-.YS
-.SY "aur fetch"
-.OP \-\-confirm\-seen
 .IR package " [" package... ]
 .YS
 .
 .SH DESCRIPTION
 .B aur\-fetch
-downloads packages, specified on the command-line, from the AUR.
+downloads packages specified on the command-line from the AUR.
 .
 .SH OPTIONS
-.TP
-.BI \-L " DIRECTORY" "\fR,\fP \-\-write\-log=" DIRECTORY
-The location of where to store the diffs of previously unpacked
-archives.
 .
 .TP
 .BR \-r ", " \-\-recurse
@@ -31,58 +23,83 @@ Download packages and their dependencies with
 .BR aur\-depends (1).
 .
 .TP
-.BR \-v ", " \-\-verbose
-Print logs to
-.BR stdout .
-.
-.TP
-.BR \-\-format= [ diff | log ]
-Specifies the format logs are generated.
-.
-.TP
-.B \-\-reset
-Reset to the upstream commit, discarding local changes.
+.BI \-\-sync= MODE
+If
+.I MODE
+is set to
+.BR reset ,
+reset to the upstream commit for the git repository, discarding any
+local changes.
 .IP
-When neither
-.BR \-\-rebase " or " \-\-reset
-are specified, the default behaviour is
-.BR \-\-reset ,
-unless
-.BR aurutils.rebase " is set to " true
-in which case
-.B \-\-rebase
-will be used.
+If
+.I MODE
+is set to
+.BR rebase ,
+update with
+.BR "git pull \-\-rebase"
+instead of resetting to the upstream commit. This can be used to keep
+locally committed changes to PKGBUILDS, while discarding uncommitted
+changes.
 .IP
-If specified,
-.BR \-\-reset " takes precedence over " aurutils.rebase .
-.
-.TP
-.BR \-R ", " \-\-rebase
-Instead of resetting to the upstream commit, update with
-.BR "git pull \-\-rebase" .
-This can be used to keep locally committed changes to PKGBUILDS.
-Uncommitted changes are discarded. See
-.BR NOTES .
+If
+.I MODE
+is set to
+.BR auto ,
+the git configuration for each repository is checked for
+.BR aurutils.rebase .
+If set to
+.BR true ,
+and the
+.B HEAD
+commit is not an ancestor of the
+.BR HEAD@{upstream}
+commit, behave as if
+.I MODE
+was set to
+.B rebase
+for the given repository. If
+.B HEAD
+is already an ancestor, perform no action. If
+.BR aurutils.rebase
+is unset or set to any other value, and the
+.B HEAD
+commit differs from the
+.B HEAD@{upstream}
+commit, behave as if
+.I MODE
+was set to
+.BR reset .
 .IP
-This feature can be enabled on a per-repository basis by setting
-.BR aurutils.rebase " to " true
-in the git configuration.
+.RS
+.B Note:
+If a rebase does not apply cleanly, the user is expected to fix any
+issues occuring in the git repository before continuing. A rebase may
+also inadvertently keep malicious commits that Trusted Users have
+removed from the git history. The
+.B rebase
+or
+.B auto
+modes should thus be used with care.
+.RE
 .
 .TP
-.B \-\-confirm\-seen
-Marks the package's checked out commit as seen. See
-.BR NOTES .
+.B \-S
+Alias for
+.BR \-\-sync=auto .
 .
 .TP
-.BI \-\-results= file
-Writes
-.IB action :file:// path
-pairs to the specified
-.IR file .
+.BI \-\-results= FILE
+Write colon-delimited output in the following form to
+.IR FILE :
+.IP
+<action>:<head_from>:<head_to>:file://<path>
+.IP
 Possible values for
 .I action
 are
-.B clone
+.BR clone ,
+.BR rebase ,
+.BR reset ,
 and
 .BR fetch .
 .I path
@@ -91,37 +108,34 @@ is the absolute path to the processed package repository.
 Can be used by higher level tools to differentiate new clones from
 updates to existing repositories.
 .
-.
-.SH NOTES
-.
-.SS LOGS
-The logs shown by
+.SS Log options
+Logs shown by
 .BR aur\-fetch (1)
-show changes that happened since the commit referenced by the
-special reference
-.B AUR_SEEN
-stored inside the repository.
-.PP
-This reference can be created with with:
-.PP
-.EX
-    \fB$ aur fetch \-\-confirm\-seen \fI<package> \fR[\fP<package>...\fR]\fR
-.EE
-.PP
-which will mark the current commit as seen, signaling
-.BR aur\-fetch (1)
-that current changes should not be shown in future logs.
+show changes that happened since the commit referenced by the previous
+.B HEAD
+before
+.BR git\-reset (1)
+or
+.BR git\-rebase (1).
+See the
+.B \-\-sync
+option for more information.
+.TP
+.BI \-L " DIRECTORY" "\fR,\fP \-\-write\-log=" DIRECTORY
+The directory where logs between merged revisions are stored.
 .
+.TP
+.BR \-\-format= [ diff | log ]
+Use
+.BR git\-diff (1)
+or
+.BR git\-log (1)
+to generate logs, respectively.
 .
-.SS REBASE
-This option should be used with care. While it enables users
-to keep personalized changes to PKGBUILDS, it will cause failures if
-.BR git\-rebase (1)
-does not apply cleanly. The user is expected to fix those issues
-before continuing.
-.PP
-More importantly, it may inadvertently keep malicious commits that
-Trusted Users have removed from the git history.
+.TP
+.BR \-v ", " \-\-verbose
+Print logs to
+.BR stdout .
 .
 .SH SEE ALSO
 .ad l


### PR DESCRIPTION
A downside of `AUR_SEEN` is that removing the git repositories (e.g the `aur-sync` cache) also removes the reference to the "last seen" revision by the user. This PR removes `AUR_SEEN` from `aur-fetch`, and instead extends `--results` such that higher level tools like `aur-sync` can use their own diff mechanisms which do not rely on git repositories. (I will give the implementation for the latter in a later PR.) 

A side benefit is the reduced complexity in `aur-fetch`, such as absence of the seperate "mode" `--confirm-seen`. The log mechanism is otherwise kept for standalone use of `aur-fetch`.

Also extend `--sync=auto` to only make changes, i.e. run `git-rebase` or `git-reset`, if new upstream revisions are available. Otherwise, perform no action.