### PR TITLE
aur-sync: remove parallel

### DIFF
--- a/lib/aur-query
+++ b/lib/aur-query
@@ -87,12 +87,10 @@ EOF
 fi
 
 # pipeline
-jq -R -r '@uri' | uri | wget -o "$wget_log" -i - -O - -nv
-wget_err=${PIPESTATUS[2]}
-
-if (( wget_err )); then
-    cat "$wget_log" >&2
-    exit "$wget_err"
+if ! jq -R -r '@uri' | uri | wget -o "$wget_log" -i - -O - -nv; then
+    err=$?
+    cat >&2 "$wget_log"
+    exit "$err"
 fi
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -58,10 +58,6 @@ complement() {
     grep -Fxvf "$@" || return $(( $? - 1 ))
 }
 
-order() {
-    cut -f1,2 depends | tr_ver | tsort
-}
-
 trap_exit() {
     if [[ ! -v AUR_DEBUG ]]; then
         rm -rf -- "$tmp" "$tmp_view"
@@ -212,7 +208,9 @@ fi
 
 # Append contents of ignore file
 if [[ -f ${ignore_file=$XDG_CONFIG_HOME/aurutils/sync/ignore} ]]; then
-    while IFS="#" read -r i _; do [[ $i ]] && pkg_i+=("$i"); done < "$ignore_file"
+    while IFS='#' read -r i _; do
+        [[ $i ]] && pkg_i+=("$i")
+    done < "$ignore_file"
 fi
 
 if (( rotate )); then
@@ -257,7 +255,7 @@ fi
 if [[ -s argv ]]; then
     # shellcheck disable=SC2094
     # $1 pkgname $2 depends $3 pkgbase $4 pkgver
-    xargs --arg-file=argv aur depends --table >depends
+    xargs -a argv aur depends --table >depends
 else
     plain >&2 "there is nothing to do"
     exit
@@ -294,7 +292,7 @@ cut -f2 --complement depends | sort -u >pkginfo
 } >filter
 
 # pkgname queue (AUR + repos)
-if order depends >queue_0; then
+if cut -f1,2 depends | tr_ver | tsort >queue_0; then
     tac queue_0 | lib32 | complement filter >queue_1
 else
     # input contains a loop
@@ -321,9 +319,11 @@ fi
 # Link build files in the queue (absolute links)
 parallel -X ln -s "$(pwd -P)"/{} "$tmp_view" :::: "$tmp"/queue
 
-# Check if dependency graph is valid
 if (( graph )); then
-    aur graph "$tmp_view"/*/.SRCINFO >/dev/null
+    if ! aur graph "$tmp_view"/*/.SRCINFO >/dev/null; then
+        error '%s: failed to validate dependency graph' "$argv0"
+        exit 1
+    fi
 fi
 
 if (( view )); then
@@ -344,10 +344,10 @@ if (( view )); then
           find "$tmp_view" -maxdepth 1 -type f
 
           # Print build directories in dependency order
-          xargs -I{} -a "$tmp"/queue find -L "$tmp_view"/{} -maxdepth 1
+          xargs -a "$tmp"/queue -I{} find -L "$tmp_view"/{} -maxdepth 1
         } | viewer "$tmp_view"
     else
-        error '%s: no viewer found, please install vifm or define AUR_PAGER' "$argv0"
+        error '%s: no viewer found, please install vifm or set AUR_PAGER' "$argv0"
         exit 1
     fi
     xargs -a "$tmp/queue" aur fetch --confirm-seen

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -357,7 +357,9 @@ if (( build )); then
     aur build --arg-file "$tmp"/queue --database "$db_name" --root "$db_root" \
         "${build_args[@]}" -- "${build_extra_args[@]}"
 else
-    xargs -a "$tmp"/queue -I{} printf '%s\n' "$(pwd -P)"/{}
+    while read -r pkg; do
+        [[ $pkg ]] && printf '%s\n' "$(pwd -P)/$pkg"
+    done < "$tmp"/queue
 fi
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -255,7 +255,7 @@ fi
 if [[ -s argv ]]; then
     # shellcheck disable=SC2094
     # $1 pkgname $2 depends $3 pkgbase $4 pkgver
-    xargs -a argv aur depends --table >depends
+    xargs -a argv -d'\n' aur depends --table >depends
 else
     plain >&2 "there is nothing to do"
     exit
@@ -312,14 +312,16 @@ fi
 
 if (( download )); then
     msg >&2 "Retrieving package files"
-    parallel -Xj +3 --nice 10 --halt now,fail=1 --keep-order \
-        aur fetch -L "$tmp_view" -S :::: "$tmp"/queue
+    xargs -a "$tmp"/queue -d'\n' aur fetch -L "$tmp_view" -S
 fi
 
 # Link build files in the queue (absolute links)
-parallel -X ln -s "$(pwd -P)"/{} "$tmp_view" :::: "$tmp"/queue
+while read -r pkg; do
+    [[ $pkg ]] && printf '%s\0' "$(pwd -P)/$pkg"
+done < "$tmp"/queue | xargs -0 ln -t "$tmp_view" -s --
 
 if (( graph )); then
+    # Avoid exceeding ARG_MAX with printf as built-in command
     if ! printf '%s\0' "$tmp_view"/*/.SRCINFO | xargs -0 cat -- | aur_graph >/dev/null; then
         error '%s: failed to validate dependency graph' "$argv0"
         exit 1

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -320,7 +320,7 @@ fi
 parallel -X ln -s "$(pwd -P)"/{} "$tmp_view" :::: "$tmp"/queue
 
 if (( graph )); then
-    if ! aur graph "$tmp_view"/*/.SRCINFO >/dev/null; then
+    if ! printf '%s\0' "$tmp_view"/*/.SRCINFO | xargs -0 cat -- | aur_graph >/dev/null; then
         error '%s: failed to validate dependency graph' "$argv0"
         exit 1
     fi

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -11,7 +11,7 @@ changelog=aurutils.changelog
 sha256sums=('SKIP')
 conflicts=('aurutils')
 provides=("aurutils=${pkgver%%.r*}")
-depends=('git' 'jq' 'pacutils' 'parallel' 'wget')
+depends=('git' 'jq' 'pacutils' 'wget')
 makedepends=('git')
 optdepends=('bash-completion: bash completion'
             'devtools: aur-chroot'


### PR DESCRIPTION
This removes the dependency on `parallel` besides some other minor tweaks.

Fixes #582

