### PR TITLE
aur-sync: remove additional build arguments after --

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -10,7 +10,6 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
 build_args=(--clean --syncdeps)
-build_extra_args=()
 repo_args=()
 
 # default options (enabled)
@@ -201,11 +200,6 @@ tmp_view=$(mktemp -d --tmpdir "aurutils-$argv0-view.XXXXXXXX") || exit
 
 trap 'trap_exit' EXIT
 
-# Append remaining options to the aur-build command-line
-if (( $# )); then
-    build_extra_args+=("$@")
-fi
-
 # Append contents of ignore file
 if [[ -f ${ignore_file=$XDG_CONFIG_HOME/aurutils/sync/ignore} ]]; then
     while IFS='#' read -r i _; do
@@ -356,8 +350,7 @@ if (( view )); then
 fi
 
 if (( build )); then
-    aur build --arg-file "$tmp"/queue --database "$db_name" --root "$db_root" \
-        "${build_args[@]}" -- "${build_extra_args[@]}"
+    aur build -a "$tmp"/queue -d "$db_name" --root "$db_root" "${build_args[@]}"
 else
     while read -r pkg; do
         [[ $pkg ]] && printf '%s\n' "$(pwd -P)/$pkg"

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -121,20 +121,21 @@ value of the configured repository.
 .
 .SS Build options
 The default build command is
-.BR "makepkg \-\-clean \-\-syncdeps" .
-Additional options may be passed to
-.B aur\-build
-by placing them after
-.B --
-in the
-.B aur\-sync
-command-line. See
+.BR "aur-build \-\-clean \-\-syncdeps" .
+Specifying
 .BR aur\-build (1)
-for details.
+options such as
+.B \-\-chroot
+or
+.B \-\-force
+to
+.B aur\-sync
+will append these options to the build command.
 .
 .TP
 .BR \-c ", " \-\-chroot
-Build packages in a systemd\-nspawn container. (\fBaur build \-c\fR)
+Build packages in a systemd\-nspawn container.
+.RB ( "aur build \-c" )
 .
 .TP
 .BR \-f ", " \-\-force
@@ -196,7 +197,7 @@ in
 .BR vifm (1).
 See also
 .B AUR_CONFIRM_PAGER
-for adding a confirmation prompt if the viewer exited successfully.
+for adding a confirmation prompt after the viewer exited successfully.
 .PP
 To avoid downloading files again, the
 .B \-\-continue


### PR DESCRIPTION
This is problematic in `aur-sync` as both program names and option names (for `aur-build`) can be placed after `--`. 

See issue #678.