### PR TITLE
aur-build: pass on EOF options to makepkg

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -158,7 +158,13 @@ fi
 # Propagate pacman config to aur-repo and pacconf (#543)
 conf_args=()
 if [[ -v pacman_conf ]]; then
+    chroot_args+=(--pacman-conf "$pacman_conf")
     conf_args+=(--config "$pacman_conf")
+fi
+
+# Defaults to /usr/share/devtools/makepkg-<arch>.conf
+if [[ -v makepkg_conf ]]; then
+    chroot_args+=(--makepkg-conf "$makepkg_conf")
 fi
 
 # Assign environment variables (#443)
@@ -206,15 +212,6 @@ fi
 if (( chroot )); then
     # Defaults to /usr/share/devtools/pacman-aur.conf
     chroot_args+=(--prefix "$prefix")
-
-    if [[ -v pacman_conf ]]; then
-        chroot_args+=(--pacman-conf "$pacman_conf")
-    fi
-
-    # Defaults to /usr/share/devtools/makepkg-<arch>.conf
-    if [[ -v makepkg_conf ]]; then
-        chroot_args+=(--makepkg-conf "$makepkg_conf")
-    fi
 
     # Update pacman and makepkg configuration for the chroot build
     # queue. A full system upgrade is run on the /root container to

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -12,11 +12,9 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0 prefix=aur
 
 # default arguments
-chroot_args=()
+chroot_args=() conf_args=() makepkg_args=() makechrootpkg_makepkg_args=() repo_add_args=()
 gpg_args=(--detach-sign --no-armor --batch)
-makepkg_args=()
-makechrootpkg_args=(-cu)
-repo_add_args=()
+makechrootpkg_args=(-c -u)
 
 db_replaces() {
     bsdcat "$1" | awk '
@@ -57,12 +55,13 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
 fi
 
 ## option parsing
-opt_short='a:B:d:D:AcCfnrsvLNRST'
+opt_short='a:B:d:D:U:AcCfnrsvLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:'
           'remove' 'build-command:' 'pkgver' 'prefix:' 'rmdeps'
           'no-confirm' 'ignore-arch' 'log' 'new' 'makepkg-conf:'
-          'bind:' 'bind-rw:' 'prevent-downgrade' 'temp' 'syncdeps' 'clean')
+          'bind:' 'bind-rw:' 'prevent-downgrade' 'temp' 'syncdeps' 'clean'
+          'namcap' 'checkpkg' 'user:')
 opt_hidden=('dump-options' 'gpg-sign' 'ignorearch' 'noconfirm' 'nosync')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -88,7 +87,7 @@ while true; do
             shift; makepkg_conf=$1 ;;
         --pacman-conf)
             shift; pacman_conf=$1 ;;
-        -N|--nosync|--no-sync)
+        --nosync|--no-sync)
             no_sync=1 ;;
         --pkgver)
             run_pkgver=1
@@ -109,11 +108,18 @@ while true; do
             shift; makechrootpkg_args+=(-d"$1") ;;
         --prefix)
             shift; prefix=$1 ;;
+        -N|--namcap)
+            makechrootpkg_args+=(-n) ;;
+        --checkpkg) # XXX short option
+            makechrootpkg_args+=(-C) ;;
         -T|--temp)
             makechrootpkg_args+=(-T) ;;
+        -U|--user)
+            shift; makechrootpkg_args+=(-U "$1") ;;
         # makepkg options
         -A|--ignorearch|--ignore-arch)
-            makepkg_args+=(--ignorearch) ;;
+            makepkg_args+=(--ignorearch)
+            makechrootpkg_makepkg_args+=(--ignorearch) ;;
         -C|--clean)
             makepkg_args+=(--clean) ;;
         -L|--log)
@@ -151,12 +157,11 @@ trap 'exit' INT
 
 # Append remaining options to the makechrootpkg command-line
 if (( $# )); then
-    makechrootpkg_args+=("$@")
     makepkg_args+=("$@")
+    makechrootpkg_makepkg_args+=("$@")
 fi
 
 # Propagate pacman config to aur-repo and pacconf (#543)
-conf_args=()
 if [[ -v pacman_conf ]]; then
     chroot_args+=(--pacman-conf "$pacman_conf")
     conf_args+=(--config "$pacman_conf")
@@ -284,7 +289,7 @@ while IFS= read -ru "$fd" path; do
     elif (( chroot )); then
         printf '%s\n' >&2 "Running makechrootpkg ${makechrootpkg_args[*]}"
         env PKGDEST="$var_tmp" aur chroot "${chroot_args[@]}" --no-prepare \
-            -- "${makechrootpkg_args[@]}"
+            -- "${makechrootpkg_args[@]}" -- "${makechrootpkg_makepkg_args[@]}"
     else
         printf '%s\n' >&2 "Running makepkg ${makepkg_args[*]}"
         env PKGDEST="$var_tmp" makepkg "${makepkg_args[@]}"

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -13,12 +13,10 @@ chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0 prefix=aur
 
 # default arguments
 chroot_args=()
-conf_args=()
 gpg_args=(--detach-sign --no-armor --batch)
 makepkg_args=()
 makechrootpkg_args=(-cu)
 repo_add_args=()
-repo_args=()
 
 db_replaces() {
     bsdcat "$1" | awk '
@@ -72,7 +70,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset build_cmd db_name db_path db_root results_file queue
+unset build_cmd db_name db_path db_root makepkg_conf pacman_conf results_file queue
 while true; do
     case "$1" in
         # build options
@@ -87,11 +85,9 @@ while true; do
         -d|--database|--repo)
             shift; db_name=$1 ;;
         --makepkg-conf)
-            shift; chroot_args+=(--makepkg-conf "$1") ;;
+            shift; makepkg_conf=$1 ;;
         --pacman-conf)
-            shift; chroot_args+=(--pacman-conf "$1")
-            repo_args+=(--pacman-conf "$1")
-            conf_args+=(--config "$1") ;;
+            shift; pacman_conf=$1 ;;
         -N|--nosync|--no-sync)
             no_sync=1 ;;
         --pkgver)
@@ -159,6 +155,12 @@ if (( $# )); then
     makepkg_args+=("$@")
 fi
 
+# Propagate pacman config to aur-repo and pacconf (#543)
+conf_args=()
+if [[ -v pacman_conf ]]; then
+    conf_args+=(--config "$pacman_conf")
+fi
+
 # Assign environment variables (#443)
 : "${db_name=$AUR_REPO}"
 : "${db_root=$AUR_DBROOT}"
@@ -168,7 +170,7 @@ fi
 case $db_name in
     "")
         case $db_root in
-            "") db_path=$(aur repo "${repo_args[@]}" --path)
+            "") db_path=$(aur repo "${conf_args[@]}" --path)
                 db_name=$(basename "$db_path" .db)
                 db_root=$(dirname "$db_path")
                 ;;
@@ -177,7 +179,7 @@ case $db_name in
         esac ;;
     *)
         case $db_root in
-            "") db_path=$(aur repo "${repo_args[@]}" --path -d "$db_name")
+            "") db_path=$(aur repo "${conf_args[@]}" --path -d "$db_name")
                 db_root=$(dirname "$db_path")
                 ;;
              *) db_path=$(readlink -f -- "$db_root/$db_name".db)
@@ -189,6 +191,7 @@ esac
 if ! [[ -f $db_path ]]; then
     error '%s: %s: no such file or directory' "$argv0" "$db_path"
     exit 2
+
 elif ! [[ -w $db_path ]]; then
     error '%s: %s: permission denied' "$argv0" "$db_path"
     exit 13
@@ -203,6 +206,15 @@ fi
 if (( chroot )); then
     # Defaults to /usr/share/devtools/pacman-aur.conf
     chroot_args+=(--prefix "$prefix")
+
+    if [[ -v pacman_conf ]]; then
+        chroot_args+=(--pacman-conf "$pacman_conf")
+    fi
+
+    # Defaults to /usr/share/devtools/makepkg-<arch>.conf
+    if [[ -v makepkg_conf ]]; then
+        chroot_args+=(--makepkg-conf "$makepkg_conf")
+    fi
 
     # Update pacman and makepkg configuration for the chroot build
     # queue. A full system upgrade is run on the /root container to

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -64,7 +64,7 @@ while true; do
     shift
 done
 
-# Use remaining options for the makechrootpkg command-line
+# Reset makechrootpkg command-line if specified
 if (( $# )); then
     makechrootpkg_args=("$@")
 fi

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -66,9 +66,9 @@ source /usr/share/makepkg/util/parseopts.sh
 
 ## option parsing
 opt_short='c:d:r:alquS'
-opt_long=('database:' 'repo:' 'pacman-conf:' 'root:' 'path' 'all' 'list'
+opt_long=('database:' 'repo:' 'config:' 'root:' 'path' 'all' 'list'
           'repo-list' 'sync' 'upgrades' 'table' 'quiet')
-opt_hidden=('dump-options' 'status-file:')
+opt_hidden=('dump-options' 'status-file:' 'pacman-conf:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -82,7 +82,7 @@ while true; do
             shift; db_name=$1 ;;
         -r|--root)
             shift; db_root=$1 ;;
-        -c|--pacman-conf)
+        -c|--config|--pacman-conf)
             shift; pacman_conf=$1 ;;
         -l|--list)
             mode=packages ;;

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -93,7 +93,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:'
           'no-ver-argv' 'no-view' 'print' 'provides' 'rm-deps'
           'sign' 'temp' 'upgrades' 'pkgver' 'rebuild' 'rebuild-tree'
           'build-command:' 'ignore-file:' 'remove' 'provides-from:'
-          'new' 'prevent-downgrade' 'verify')
+          'new' 'prevent-downgrade' 'verify' 'results:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:'
             'noconfirm' 'nover' 'nograph' 'nover-argv' 'noview'
             'rebuildtree' 'rmdeps' 'gpg-sign')
@@ -156,6 +156,8 @@ while true; do
             repo_args+=(--pacman-conf "$1") ;;
         --pkgver)
             build_args+=(--pkgver) ;;
+        --results)
+            shift; build_args+=(--results "$1") ;;
         -S|--sign|--gpg-sign)
             build_args+=(--sign) ;;
         # build options (devtools)

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -1,4 +1,4 @@
-.TH AUR\-BUILD 1 2019-01-24 AURUTILS
+.TH AUR\-BUILD 1 2019-03-27 AURUTILS
 .SH NAME
 aur\-build \- build packages to a local repository
 .
@@ -87,7 +87,7 @@ The name of the pacman database.
 Continue the build process if a package with the same name is found.
 .
 .TP
-.BR \-N ", " \-\-no\-sync
+.BR \-\-no\-sync
 Do not sync the local repository after building.
 .
 .TP
@@ -145,21 +145,6 @@ To use another key than the default, the
 environment variable can be set to the appropriate key identifier.
 .
 .SS makechrootpkg options
-Additional options may be passed to
-.B makechrootpkg
-by placing them after
-.B --
-in the
-.B aur\-build
-command-line. For a list of available options, run
-.B "makechrootpkg \-h".
-.PP
-The default set of options used in
-.B archbuild
-is
-.BR "makechrootpkg \-c \-n \-C" ,
-and cannot be overridden.
-.
 .TP
 .BI \-D " DIR" "\fR,\fP \-\-directory=" DIR
 The base directory for containers. Defaults to
@@ -190,8 +175,16 @@ is set to
 .BR aur .
 .
 .TP
-.B \-\-recreate
-Recreate the chroot before building packages.
+.BR \-N ", " \-\-namcap
+Run
+.BR namcap (1)
+on the built package.
+.
+.TP
+.BR \-\-checkpkg
+Run
+.BR checkpkg (1)
+on the built package.
 .
 .TP
 .BR \-T ", " \-\-temp
@@ -199,6 +192,9 @@ Build in a temporary container. (\fBmakechrootpkg \-T\fR) Temporary
 means that the user container has a random name and is removed on
 build completion.
 .
+.TP
+.BI \-U " USER" "\fR,\fP \-\-user=" USER
+
 .SS makepkg options
 Additional options may be passed to
 .B makepkg
@@ -306,7 +302,6 @@ custom counterpart. Packages which define a
 .I replaces
 field are ignored if the target package is installed on the local system.
 .
-.
 .SS Using a dedicated build user
 While using a dedicated user for the build process does not increase
 security (beyond protecting against packaging errors that write to
@@ -382,96 +377,6 @@ You can use
 rebuild-detector
 .UE
 to detect which packages need to be rebuilt.
-.
-.SH CHROOT NOTES
-.SS Building with makechrootpkg
-Changes to the pacman database are
-.I not
-propagated from the container to the local system. Packages must be
-installed and updated separately, typically through
-.BI "pacman \-Syu " package_name\fR.
-.PP
-Package conflicts inside the container must be solved manually, as
-.B makechrootpkg
-uses
-.B "makepkg \-\-noconfirm \-s"
-internally. For example, to replace
-.I gcc
-with
-.IR gcc\-multilib ,
-run
-.B "arch\-nspawn /var/lib/archbuild/aur\-x86_64/root pacman \-S gcc\-multilib"
-as root.
-.PP
-To install packages from the local repository (for example, on
-dependency resolution with
-.BR "makepkg \-s" ,
-the container requires read access to the host directory where it is
-located. This is ensured through a
-.IR "bind mount" .
-.
-.SS Avoiding password prompts
-.BR makepkg (8)
-must be run as a regular user as of version 4.2, with privileged
-operations done via
-.BR sudo (8).
-It follows that
-.BR aur\-build (1)
-can not run directly as root. To avoid password prompts,
-.BR sudoers (5)
-can be used instead. For example, if
-.BR aur\-build (1)
-is run as the
-.I archie
-user, create the following sudoers policy:
-.PP
-.EX
-    archie ALL = (root) NOPASSWD: SETENV: /usr/bin/archbuild
-.EE
-.TP
-.B Note:
-Should the rule only apply to specific hosts, replace
-.B ALL
-with the respective
-.IR hostname .
-.
-.SS Using ccache and distcc
-As in the example above, install the required packages:
-.PP
-.EX
-    # arch\-nspawn /var/lib/archbuild/aur\-x86_64/root pacman \-S ccache distcc
-.EE
-.PP
-Ensure write access to
-.B ccache
-directories on the host:
-.PP
-.EX
-    # aur build \-\-chroot \-\- \-d /home/_ccache:/build/.ccache
-.EE
-.
-.SS Building for a different architecture
-To build packages for a different architecture, prepend
-.BI setarch " arch"
-to the
-.B aur\-build
-command line.
-.PP
-The target architecture must be supported both by the host (run
-.B "setarch \-\-list"
-for an approximation), and have a matching
-.BR makepkg.conf (5)
-file available in
-.B /usr/share/devtools
-(such as
-.I /usr/share/devtools/makepkg\-i686.conf
-for
-.IR i686 ).
-.TP
-.B Note:
-Building for other CPU architectures may be done through
-QEMU, for example with
-.BR proot (1).
 .
 .SH BUGS
 Databases are built with

--- a/man1/aur-chroot.1
+++ b/man1/aur-chroot.1
@@ -1,0 +1,194 @@
+.TH AUR-CHROOT 2020-03-27 AURUTILS
+.SH NAME
+aur\-chroot \- build packages with systemd-nspawn
+
+.SH SYNOPSIS
+.SY "aur chroot"
+.OP \-d database
+.OP \-D directory
+.OP \-M makepkg_conf
+.OP \-C pacman_conf
+.OP \-\-no\-build
+.OP \-\-no\-prepare
+.OP \-\-
+.RI [ "makechrootpkg args" ]
+.YS
+
+.SH DESCRIPTION
+Build packages in an nspawn container, adding the results to a local
+repository.
+
+.SH OPTIONS
+All arguments after \-\- are passed to \fBmakechrootpkg\fR.
+
+.TP
+.BI \-D " DIR" "\fR,\fP \-\-directory=" DIR
+The base directory for containers. This directory usually contains a
+.B /root
+subdirectory that serves as template for user containers (named after
+.I $SUDO_USER
+, or
+.B /copy
+if unset).
+
+.SY Note:
+If the
+.B \-T
+parameter is specified to
+.BR makechrootpkg ,
+the user container has a random name and is removed on build
+completion.
+
+.TP
+.BI \-C " FILE" "\fR,\fP \-\-pacman\-conf=" FILE
+The
+.BR pacman.conf (5)
+file used inside the container. Defaults to devtools'
+.IR pacman-extra.conf .
+This file is processed with
+.BR pacconf (1)
+to include necessary information from the host, such as mirrors. If a
+local repository name is specified with
+.BR \-d ,
+its configuration is appended to this file.
+
+.TP
+.BI \-M " FILE" "\fR,\fP \-\-makepkg\-conf=" FILE
+The
+.BR makepkg.conf (5)
+file used inside the container. Defaults to devtools'
+.IR makepkg\-<machine>.conf .
+
+.TP
+.B \-\-no\-build
+Update or create the
+.B /root
+copy of the container; do not build a package.
+
+.TP
+.B \-\-no\-prepare
+Build a package, do not update the container.
+
+.SH ENVIRONMENT
+Packages are placed in the directory specified in
+.BR PKGDEST .
+If unset, the current directory
+.RB ( $PWD )
+is used. See also
+.BR makepkg.conf (5).
+
+.SH NOTES
+.SS Building with makechrootpkg
+Changes to the pacman database are
+.I not
+propagated from the container to the local system. Packages must be
+installed and updated separately, typically through
+.BI "pacman \-Syu " package_name\fR.
+
+Package conflicts inside the container must be solved manually, as
+.B makechrootpkg
+uses
+.B "makepkg \-\-noconfirm \-s"
+internally. For example, to replace
+.I gcc
+with
+.I gcc\-multilib
+, run
+.B "arch\-nspawn /var/lib/aurbuild/root pacman \-S gcc\-multilib"
+as root.
+
+.SS Accessing the local repository
+To install packages from the local repository (for example, on
+dependency resolution with
+.BR "makepkg \-s" ,
+the container requires read access to the host directory where it is
+located. This is ensured through a
+.IR "bind mount" .
+
+.SS Avoiding password prompts
+.BR makepkg (8)
+must be run as a regular user as of version 4.2, with privileged
+operations done via
+.BR sudo (8).
+It follows that
+.BR aur\-chroot (1)
+and
+.BR aur\-build (1)
+can not run directly as root. To avoid password prompts,
+.BR sudoers (5) can
+be used instead. For example, if
+.BR aur\-chroot (1)
+is run as the
+.I archie
+user, create the following sudoers policy:
+.EX
+
+  archie ALL = (root) NOPASSWD: SETENV: /usr/bin/makechrootpkg
+  archie ALL = (root) NOPASSWD: /usr/bin/mkarchroot, /usr/bin/arch-nspawn
+
+.EE
+.SY Note:
+Should the rule only apply to specific hosts, replace
+.B ALL
+with the respective
+.IR hostname .
+
+.SS Using ccache and distcc
+As in the example above, install the required packages:
+.EX
+
+  # arch-nspawn /var/lib/aurbuild/root pacman \-S ccache distcc
+
+.EE
+Ensure write access to
+.B ccache
+directories on the host:
+.EX
+
+  # aur chroot -- -d /home/_ccache:/build/.ccache -cu
+
+.EE
+Necessary
+.BR makepkg (1)
+options may be set in a specified (\-M)
+.BR makepkg.conf (5)
+file. See GitHub issue #334 for details.
+
+.SS Building for a different architecture
+To build packages for a different architecture, prepend
+.BI setarch " arch"
+to the
+.B aur\-build
+command line.
+
+The target architecture must be supported both by the host (run
+.B "setarch \-\-list"
+for an approximation), and have a matching
+.BR makepkg.conf (5)
+file available in
+.B /usr/share/devtools
+(such as
+.I /usr/share/devtools/makepkg\-i686.conf
+for
+.IR i686 ).
+.TP
+.B Note:
+Building for other CPU architectures may be done through
+QEMU, for example with
+.BR proot (1).
+
+.SH SEE ALSO
+.BR aur (1),
+.BR aur\-build (1),
+.BR pacconf (1),
+.BR pacman (1),
+.BR makepkg.conf (5),
+.BR pacman.conf (5),
+.BR setarch (8)
+
+.SH AUTHORS
+.MT https://github.com/AladW
+Alad Wenter
+.ME
+
+.\" vim: set textwidth=72:

--- a/man1/aur-repo.1
+++ b/man1/aur-repo.1
@@ -14,7 +14,7 @@ aur\-repo \- manage local repositories
 .SH DESCRIPTION
 When run without arguments,
 .BR aur\-repo
-prints the path of a selected repository to standard output. For other
+prints the path of a file:// repository to standard output. For other
 modes, see the
 .B OPTIONS
 section.
@@ -41,7 +41,7 @@ when checking for updates. Implies
 .BR \-\-upgrades .
 .
 .TP
-.BR \-c ", " \-\-pacman\-conf
+.BR \-c ", " \-\-config ", " \-\-pacman\-conf
 .
 .
 .TP


### PR DESCRIPTION
The main change is this PR is pass on options after `--` to `makepkg` inside the container, instead of `makechrootpkg` on the host. Other changes include re-adding the missing `aur-chroot.1` man page and exposing `--results` to `aur-sync`.