### PR TITLE
scripts: switch to curl

### DIFF
--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -16,7 +16,7 @@ extract_date() {
 }
 
 list_update() {
-    if wget -O - -o last_transfer "$1" | gzip -d - > "$2"; then
+    if curl -f "$1" --stderr last_transfer | gzip -d - > "$2"; then
         extract_date "$2"
     else
         printf >&2 '%s: warning: failed to retrieve package list\n' "$argv0"
@@ -24,8 +24,8 @@ list_update() {
 }
 
 list_http_date() {
-    if wget -S --spider -o last_transfer "$1"; then
-        awk -F', ' '/Date:/ {print $2}' last_transfer
+    if curl -f "$1" -SsIo last_transfer; then
+        awk -F', ' '/^[Dd]ate:/ {print $2}' last_transfer
     else
         printf >&2 '%s: warning: failed to retrieve HTTP date\n' "$argv0"
     fi

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -31,7 +31,7 @@ uri_search() {
 }
 
 usage() {
-    printf 'usage: %s [-t [info|search] ] [-b by]' "$argv0" >&2
+    printf 'usage: %s [-t [info|search] ] [-b by]\n' "$argv0" >&2
     exit 1
 }
 
@@ -73,10 +73,6 @@ case $type in
          *) usage ;;
 esac
 
-# store output on error
-wget_log=$(mktemp --tmpdir aurutils-wget.XXXXXXXX) || exit
-trap 'rm -rf -- "$wget_log"' EXIT
-
 # check for interactive terminal
 if [[ -t 0 ]]; then
     cat >&2 <<EOF
@@ -87,10 +83,6 @@ EOF
 fi
 
 # pipeline
-if ! jq -R -r '@uri' | uri | wget -o "$wget_log" -i - -O - -nv; then
-    err=$?
-    cat >&2 "$wget_log"
-    exit "$err"
-fi
+jq -R -r '@uri' | uri | awk '{ printf "url %s\n", $0; }' | curl -K- -fgLsS
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -11,11 +11,12 @@ changelog=aurutils.changelog
 sha256sums=('SKIP')
 conflicts=('aurutils')
 provides=("aurutils=${pkgver%%.r*}")
-depends=('git' 'jq' 'pacutils' 'wget')
+depends=('git' 'jq' 'pacutils' 'curl')
 makedepends=('git')
 optdepends=('bash-completion: bash completion'
+            'zsh: zsh completion'
             'devtools: aur-chroot'
-            'vifm: build file interaction')
+            'vifm: default pager')
 
 pkgver() {
     cd aurutils

--- a/man1/aur-pkglist.1
+++ b/man1/aur-pkglist.1
@@ -66,9 +66,9 @@ has thus no benefit.
 .ad l
 .nh
 .BR aur (1),
+.BR curl (1),
 .BR gzip (1),
-.BR pcregrep (1),
-.BR wget (1)
+.BR pcregrep (1)
 .
 .SH AUTHORS
 .MT https://github.com/AladW

--- a/man1/aur-query.1
+++ b/man1/aur-query.1
@@ -36,8 +36,8 @@ arguments to avoid HTTP 414 errors (\fIFS#49089\fR).
 .SH SEE ALSO
 .ad l
 .nh
-.BR jq (1),
-.BR wget (1)
+.BR curl (1),
+.BR jq (1)
 .
 .SH AUTHORS
 .MT https://github.com/AladW


### PR DESCRIPTION
curl can take input from `stdin` through the `-K-` option. Removes the dependency on `wget`.

This affects pretty much all of `aurutils` so there should be no bugs here.