### PR TITLE
aur-sync: enable --provides by default

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -13,7 +13,7 @@ build_args=(--clean --syncdeps)
 repo_args=()
 
 # default options (enabled)
-build=1 chkver_depth=2 download=1 view=1 provides=0 graph=1
+build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1
 
 # default options (disabled)
 rotate=0 update=0
@@ -86,17 +86,17 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
     exit 1
 fi
 
-opt_short='B:d:D:AcfLnpPrRSTuv'
+opt_short='B:d:D:AcfLnprRSTuv'
 opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:'
           'root:' 'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue'
           'force' 'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph'
-          'no-ver-argv' 'no-view' 'print' 'provides' 'rm-deps'
+          'no-ver-argv' 'no-view' 'no-provides' 'print' 'rm-deps'
           'sign' 'temp' 'upgrades' 'pkgver' 'rebuild' 'rebuild-tree'
           'build-command:' 'ignore-file:' 'remove' 'provides-from:'
           'new' 'prevent-downgrade' 'verify' 'results:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:'
             'noconfirm' 'nover' 'nograph' 'nover-argv' 'noview'
-            'rebuildtree' 'rmdeps' 'gpg-sign')
+            'noprovides' 'rebuildtree' 'rmdeps' 'gpg-sign')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -124,8 +124,8 @@ while true; do
             chkver_depth=1 ;;
         --noview|--no-view)
             view=0 ;;
-        -P|--provides)
-            provides=1 ;;
+        --noprovides|--no-provides)
+            provides=0 ;;
         --provides-from)
             shift; IFS=, read -a repo -r <<< "$1"
             repo_p+=("${repo[@]}") ;;

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -67,7 +67,7 @@ trap_exit() {
 }
 
 usage() {
-    plain >&2 'usage: %s [-d repo] [--root path] [-cdfPpSu] [--] pkgname...' "$argv0"
+    plain >&2 'usage: %s [-d repo] [--root path] [-cdfpSu] [--] pkgname...' "$argv0"
     exit 1
 }
 
@@ -316,9 +316,11 @@ while read -r pkg; do
     [[ $pkg ]] && printf '%s\0' "$(pwd -P)/$pkg"
 done < "$tmp"/queue | xargs -0 ln -t "$tmp_view" -s --
 
+# Check AUR metadata for validity (#20)
 if (( graph )); then
-    # Avoid exceeding ARG_MAX with printf as built-in command
-    if ! printf '%s\0' "$tmp_view"/*/.SRCINFO | xargs -0 cat -- | aur graph >/dev/null; then
+    # Use find to avoid exceeding ARG_MAX
+    # See: https://www.in-ulm.de/~mascheck/various/argmax/
+    if ! find "$tmp_view" -name .SRCINFO -exec cat {} + | aur graph >/dev/null; then
         error '%s: failed to validate dependency graph' "$argv0"
         exit 1
     fi

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -71,22 +71,20 @@ Do not present build files for inspection.
 Print target packages and their paths instead of building them.
 .
 .TP
-.BR \-P ", " \-\-provides
-Take virtual dependencies
+.BR \-\-noprovides ", " \-\-no\-provides
+Do not take virtual dependencies
 .RB ( provides )
-in pacman sync repository into account. Version information is not
-considered. Packages specified on the command line or available
-upgrades are taken as target regardless of this setting.
+in pacman sync repository into account. Packages specified on the
+command line or available upgrades are taken as target regardless of
+this setting.
 .
 .TP
 .BI \-\-provides\-from= DIR1,...
-As
-.BR \-\-provides ,
-but only the specified (comma-separated) repositories are taken into
-account. If the same package is provided in multiple repositories,
-ordering is ignored (for example, \-\-provides\-from=a,b is equivalent
-to \-\-provides\-from=b,a) and dependencies are installed according to
-the order defined in
+Only take specified (comma-separated) repositories into acount for
+virtual dependencies. If the same package is provided in multiple
+repositories, ordering is ignored (for example, \-\-provides\-from=a,b
+is equivalent to \-\-provides\-from=b,a) and dependencies are
+installed according to the order defined in
 .BR pacman.conf (5).
 .
 .TP


### PR DESCRIPTION
Having `aur-sync` ignore providers by default has caused enough confusion over time, let's enable it by default.

Closes #695