### PR TITLE
aur-build: use --noextract for --pkgver build

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -91,7 +91,7 @@ while true; do
             no_sync=1 ;;
         --pkgver)
             run_pkgver=1
-            makepkg_args+=(--holdver) ;;
+            makepkg_args+=(--noextract) ;;
         --results)
             shift; results_file=$1 ;;
         --root)
@@ -262,7 +262,7 @@ while IFS= read -ru "$fd" path; do
     # Run pkgver before --packagelist (#500)
     if (( run_pkgver )); then
         # Ignore architecture in pkgver() function (#536)
-        makepkg --noprepare -od --ignorearch
+        makepkg -od --ignorearch
     fi
 
     if (( ! overwrite )); then

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -93,11 +93,11 @@ Do not sync the local repository after building.
 .TP
 .BR \-\-pkgver
 Run
-.B "makepkg \-\-noprepare \-od"
+.B "makepkg \-od \-\ignorearch"
 before checking existing packages (effectively running an existing
 .B pkgver()
 function). This option adds
-.B \-\-holdver
+.B \-\-noextract
 to the default
 .BR makepkg (8)
 options.


### PR DESCRIPTION
The `prepare` function is run before the `pkgver` function and may thus influence its output.

Remove `--noprepare` from the preparatory `makepkg` command and use `--noextract` for the main makepkg command instead.