### PR TITLE
aur-sync: store commits reviewed by the user

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -9,7 +9,7 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
-chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0
+chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0
 
 # default arguments (empty)
 chroot_args=() pacconf_args=() repo_add_args=() makepkg_args=() makechrootpkg_makepkg_args=() makepkg_common_args=()
@@ -199,7 +199,6 @@ fi
 # Write successfully built packages to file (#437)
 if [[ -v results_file ]]; then
     : >"$results_file" # truncate file
-    results=1
 fi
 
 # Defaults to /usr/share/devtools/pacman-<prefix>.conf
@@ -312,7 +311,7 @@ while IFS= read -ru "$fd" path; do
     cd_safe "$db_root"
     LANG=C repo-add "${repo_add_args[@]}" "$db_path" "${pkglist[@]}"
 
-    if (( results )); then
+    if [[ -v results_file ]]; then
         printf "build:file://${db_path%/*}/%s\n" "${pkglist[@]}" | tee -a "$results_file"
     fi
 

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -7,7 +7,7 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 
 # default options
-verbose=0 recurse=0 sync=no log_fmt=diff
+recurse=0 sync=no
 
 results() {
     local mode=$1 prev=$2 current=$3 path=$4 dest=$5
@@ -22,7 +22,7 @@ usage() {
 ICAgICAgICAgICAgIC4tLX5+LF9fCjotLi4uLiwtLS0tLS0tYH5+Jy5fLicKIGAtLCwsICAs
 XyAgICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
 !
-    plain >&2 'usage: %s [-L directory] [-rSv] pkgname...' "$argv0"
+    plain >&2 'usage: %s [-rS] [--] pkgname...' "$argv0"
     exit 1
 }
 
@@ -33,8 +33,8 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
     [[ -t 2 ]] && colorize
 fi
 
-opt_short='rvL:S'
-opt_long=('recurse' 'verbose' 'write-log:' 'sync:' 'results:' 'format:')
+opt_short='rS'
+opt_long=('recurse' 'sync:' 'results:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -42,15 +42,11 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset log_dir results_file
+unset results_file
 while true; do
     case "$1" in
-        -L|--write-log)
-            shift; log_dir=$1 ;;
         -r|--recurse)
             recurse=1 ;;
-        -v|--verbose)
-            verbose=1 ;;
         -S)
             sync=auto ;;
         --sync)
@@ -60,15 +56,6 @@ while true; do
                     sync=$1 ;;
                 *)
                     error '%s: invalid --sync option: %s' "$argv0" "$1"
-                    usage ;;
-            esac ;;
-        --format)
-            shift
-            case $1 in
-                diff|log)
-                    log_fmt=$1 ;;
-                *)
-                    error '%s: invalid --format option: %s' "$argv0" "$1"
                     usage ;;
             esac ;;
         --results)
@@ -82,26 +69,13 @@ while true; do
     shift
 done
 
-if [[ -v $log_dir ]] && [[ ! -d $log_dir ]]; then
-    error '%s: %s: not a directory' "$argv0" "$log_dir"
-    exit 20
-fi
-
-if [[ -v results_file ]]; then
-    : >"$results_file" || exit 1 # truncate file
-fi
-
 if ! (( $# )); then
     error '%s: no pkgname given' "$argv0"
     exit 1
 fi
 
-# Default to showing PKGBUILD first in patch. (#399)
-mkdir -p "$XDG_CONFIG_HOME/aurutils/$argv0"
-orderfile=$XDG_CONFIG_HOME/aurutils/$argv0/orderfile
-
-if [[ ! -s $orderfile ]]; then
-    printf 'PKGBUILD\n' > "$orderfile"
+if [[ -v results_file ]]; then
+    : >"$results_file" || exit 1 # truncate file
 fi
 
 if (( recurse )); then
@@ -112,7 +86,7 @@ fi | while read -r pkg; do
     unset -f git
 
     if [[ -d $pkg/.git ]]; then
-        # Avoid issues with filesystem boundaries. (#274)
+        # Avoid issues with filesystem boundaries (#274)
         git() { command git -C "$pkg" "$@"; }
 
         # Retrieve new upstream revisions
@@ -161,27 +135,12 @@ fi | while read -r pkg; do
             results "$sync" "$prev_head" "$head" "$PWD/$pkg" "$results_file"
         fi
 
-        if [[ $prev_head != "$head" ]]; then
-            range=$prev_head..HEAD
-
-            if (( verbose )); then
-                git --no-pager "$log_fmt" --patch --stat "$range"
-            fi
-
-            if [[ $log_dir ]]; then
-                git --no-pager "$log_fmt" --patch --stat "$range" >"$log_dir/$pkg.$log_fmt"
-            fi
-        fi
-
     # Otherwise, try to clone anew
     elif git clone "$AUR_LOCATION/$pkg"; then
-        git() { command git -C "$pkg" "$@"; }
-
-        # Show PKGBUILDs first. (#399)
-        git config diff.orderFile "$orderfile"
+        head=$(git -C "$pkg" rev-parse HEAD)
 
         if [[ -v results_file ]]; then
-            results 'clone' '0' "$(git rev-parse HEAD)" "$PWD/$pkg" "$results_file"
+            results 'clone' '0' "$head" "$PWD/$pkg" "$results_file"
         fi
     else
         error '%s: %s: failed to clone repository' "$argv0" "$pkg"

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -116,8 +116,11 @@ fi | while read -r pkg; do
         export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
 
         # Retrieve new upstream revisions
-        git fetch --verbose >&2 || exit
-        fetch_head=$(git rev-parse FETCH_HEAD)
+        if git fetch --verbose >&2; then
+            fetch_head=$(git rev-parse FETCH_HEAD)
+        else
+            exit 1
+        fi
 
         # HEAD before git rebase or git reset
         prev_head=$(git rev-parse HEAD)
@@ -141,12 +144,10 @@ fi | while read -r pkg; do
 
         case $sync in
             rebase)
-                git stash
                 git reset --hard HEAD
                 git rebase --verbose
                 ;;
             reset)
-                git stash
                 git reset --hard 'HEAD@{upstream}'
                 ;;
         esac >&2 || {

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -109,11 +109,11 @@ if (( recurse )); then
 else
    printf '%s\n' "$@"
 fi | while read -r pkg; do
-    unset GIT_DIR GIT_WORK_TREE
+    unset -f git
 
     if [[ -d $pkg/.git ]]; then
         # Avoid issues with filesystem boundaries. (#274)
-        export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
+        git() { command git -C "$pkg" "$@"; }
 
         # Retrieve new upstream revisions
         if git fetch --verbose >&2; then
@@ -175,7 +175,7 @@ fi | while read -r pkg; do
 
     # Otherwise, try to clone anew
     elif git clone "$AUR_LOCATION/$pkg"; then
-        export GIT_DIR=$pkg/.git GIT_WORK_TREE=$pkg
+        git() { command git -C "$pkg" "$@"; }
 
         # Show PKGBUILDs first. (#399)
         git config diff.orderFile "$orderfile"

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -7,7 +7,15 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 
 # default options
-verbose=0 recurse=0 results=0 sync=no log_fmt=diff
+verbose=0 recurse=0 sync=no log_fmt=diff
+
+results() {
+    local mode=$1 prev=$2 current=$3 path=$4 dest=$5
+
+    if [[ -w $dest ]]; then
+        printf '%s:%s:%s:file://%s\n' "$mode" "$prev" "$current" "$path" | tee -a "$dest"
+    fi
+}
 
 usage() {
     cat <<! | base64 -d
@@ -34,7 +42,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset log_dir
+unset log_dir results_file
 while true; do
     case "$1" in
         -L|--write-log)
@@ -80,8 +88,7 @@ if [[ -v $log_dir ]] && [[ ! -d $log_dir ]]; then
 fi
 
 if [[ -v results_file ]]; then
-    : >"$results_file" # truncate file
-    results=1
+    : >"$results_file" || exit 1 # truncate file
 fi
 
 if ! (( $# )); then
@@ -115,8 +122,8 @@ fi | while read -r pkg; do
         # HEAD before git rebase or git reset
         prev_head=$(git rev-parse HEAD)
 
-        if (( results )); then
-            printf 'fetch:%s:%s:file://%s\n' "$prev_head" "$fetch_head" "$PWD/$pkg" | tee -a "$results_file"
+        if [[ -v results_file ]]; then
+            results 'fetch' "$prev_head" "$fetch_head" "$PWD/$pkg" "$results_file"
         fi
 
         if [[ $sync == 'auto' ]]; then
@@ -149,13 +156,8 @@ fi | while read -r pkg; do
 
         head=$(git rev-parse HEAD)
 
-        if (( results )); then
-            case $sync in
-                rebase) printf 'rebase:%s:%s:file://%s\n' "$prev_head" "$head" "$PWD/$pkg"
-                        ;;
-                reset)  printf 'reset:%s:%s:file://%s\n' "$prev_head" "$head" "$PWD/$pkg"
-                        ;;
-            esac | tee -a "$results_file"
+        if [[ -v results_file ]] && [[ $sync != 'no' ]]; then
+            results "$sync" "$prev_head" "$head" "$PWD/$pkg" "$results_file"
         fi
 
         if [[ $prev_head != "$head" ]]; then
@@ -177,8 +179,8 @@ fi | while read -r pkg; do
         # Show PKGBUILDs first. (#399)
         git config diff.orderFile "$orderfile"
 
-        if (( results )); then
-            printf 'clone:%s:%s:file://%s\n' 0 "$(git rev-parse HEAD)" "$PWD/$pkg" | tee -a "$results_file"
+        if [[ -v results_file ]]; then
+            results 'clone' '0' "$(git rev-parse HEAD)" "$PWD/$pkg" "$results_file"
         fi
     else
         error '%s: %s: failed to clone repository' "$argv0" "$pkg"

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -11,6 +11,7 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 # default arguments
 build_args=(--clean --syncdeps)
 repo_args=()
+log_fmt='diff'
 
 # default options (enabled)
 build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1
@@ -93,7 +94,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'no-view' 'no-provides' 'no-build' 'rm-deps' 'sign' 'temp' 'upgrades'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
-          'results:' 'makepkg-args:')
+          'results:' 'makepkg-args:' 'format:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign' 'margs:')
@@ -111,6 +112,8 @@ while true; do
             rotate=1 ;;
         --continue)
             download=0 ;;
+        --format)
+            shift; log_fmt=$1 ;;
         --ignore)
             shift; IFS=, read -a pkg -r <<< "$1"
             pkg_i+=("${pkg[@]}") ;;
@@ -204,6 +207,18 @@ tmp_view=$(mktemp -d --tmpdir "aurutils-$argv0-view.XXXXXXXX") || exit
 
 trap 'trap_exit' EXIT
 
+# Directory for git checksums (revisions viewed by the user, #379)
+view_db=$XDG_DATA_HOME/aurutils/view
+mkdir -p "$view_db"
+
+# Default to showing PKGBUILD first in patch. (#399)
+orderfile=$XDG_CONFIG_HOME/aurutils/$argv0/orderfile
+mkdir -p "${orderfile%/*}"
+
+if [[ ! -s $orderfile ]]; then
+    printf 'PKGBUILD\n' > "$orderfile"
+fi
+
 # Append contents of ignore file
 if [[ -f ${ignore_file=$XDG_CONFIG_HOME/aurutils/sync/ignore} ]]; then
     while IFS='#' read -r i _; do
@@ -227,9 +242,10 @@ fi
 mkdir -p "$AURDEST"
 cd_safe "$tmp"
 
-# Retrieve path to local repo (#448)
+# db_info: $1 pkgname $2 pkgver
 aur repo "${repo_args[@]}" --list --status-file=db >db_info
 
+# Retrieve path to local repo (#448)
 { IFS= read -r db_name
   IFS= read -r db_root
 } <db
@@ -315,7 +331,19 @@ fi
 
 if (( download )); then
     msg >&2 "Retrieving package files"
-    xargs -a "$tmp"/queue -d'\n' aur fetch -L "$tmp_view" -S
+    xargs -a "$tmp"/queue -d'\n' aur fetch -S --results "$tmp"/fetch_results
+
+    # shellcheck disable=SC2034
+    while IFS=: read -r mode rev_old rev path; do
+        path=${path#file://} name=${path##*/}
+
+        case $mode in
+            clone)
+                git -C "$path" config diff.orderFile "$orderfile" ;;
+            fetch|rebase|reset)
+                ;;
+        esac
+    done < "$tmp"/fetch_results
 fi
 
 # Link build files in the queue (absolute links)
@@ -324,16 +352,40 @@ while read -r pkg; do
 done < "$tmp"/queue | xargs -0 ln -t "$tmp_view" -s --
 
 # Check AUR metadata for validity (#20)
-if (( graph )); then
-    # Use find to avoid exceeding ARG_MAX
-    # See: https://www.in-ulm.de/~mascheck/various/argmax/
-    if ! find "$tmp_view" -name .SRCINFO -exec cat {} + | aur graph >/dev/null; then
-        error '%s: failed to validate dependency graph' "$argv0"
-        exit 1
-    fi
+if (( graph )) && ! find "$tmp_view" -name .SRCINFO -exec cat {} + | aur graph >/dev/null; then
+    error '%s: failed to verify dependency graph' "$argv0"
+    exit 1
 fi
 
 if (( view )); then
+    declare -A heads
+
+    while read -r pkg; do
+        git() { command git -C "$pkg" "$@"; }
+
+        # Ensure every directory is a git repository (--continue)
+        if head=$(git rev-parse HEAD); then
+            heads[$pkg]=$head
+        else
+            error '%s: %s: not a git repository' "$argv0" "$pkg"
+            exit 22
+        fi
+
+        if read -r view < "$view_db/$pkg"; then
+            # Check if hash points to a valid object
+            if ! git cat-file -e "$view"; then
+                error '%s: %s: invalid revision' "$argv0" "$pkg"
+                exit 22
+            fi
+
+            if [[ $view != "$head" ]]; then
+                git --no-pager "$log_fmt" --patch --stat \
+                    "$view..$head" > "$tmp_view/$pkg.$log_fmt"
+            fi
+        fi
+    done < "$tmp"/queue
+    unset -f git
+
     if [[ -v AUR_PAGER ]]; then
         # shellcheck disable=SC2086
         command -- $AUR_PAGER "$tmp_view"
@@ -357,6 +409,11 @@ if (( view )); then
         error '%s: no viewer found, please install vifm or set AUR_PAGER' "$argv0"
         exit 1
     fi
+
+    # Update gitsums (viewer exited successfully)
+    while read -r pkg; do
+        printf '%s\n' "${heads[$pkg]}" > "$view_db/$pkg"
+    done < "$tmp"/queue
 fi
 
 if (( build )); then

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -5,6 +5,7 @@ set -o errexit
 argv0=sync
 XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
 AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -372,7 +372,7 @@ if (( view )); then
             exit 22
         fi
 
-        if read -r view < "$view_db/$pkg"; then
+        if [[ -f $view_db/$pkg ]] && read -r view < "$view_db/$pkg"; then
             # Check if hash points to a valid object
             if ! git cat-file -e "$view"; then
                 error '%s: %s: invalid revision' "$argv0" "$pkg"
@@ -383,6 +383,10 @@ if (( view )); then
                 git --no-pager "$log_fmt" --patch --stat \
                     "$view..$head" > "$tmp_view/$pkg.$log_fmt"
             fi
+
+        elif [[ -f $view_db/$pkg ]]; then
+            error '%s: %s: failed to read revision' "$argv0" "$pkg"
+            exit 1
         fi
     done < "$tmp"/queue
     unset -f git

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -4,23 +4,25 @@ aur\-fetch \- download packages from the AUR
 .
 .SH SYNOPSIS
 .SY "aur fetch"
-.OP \-L log_dir
 .OP \-r
 .OP \-S
-.OP \-v
-.IR package " [" package... ]
+.IR pkgbase " [" pkgbase... ]
 .YS
 .
 .SH DESCRIPTION
 .B aur\-fetch
-downloads packages specified on the command-line from the AUR.
+downloads packages specified on the command-line from the AUR using
+.BR git (1).
 .
 .SH OPTIONS
-.
 .TP
 .BR \-r ", " \-\-recurse
 Download packages and their dependencies with
 .BR aur\-depends (1).
+If this option is specified, arguments must be supplied by
+.B pkgname
+instead of by
+.BR pkgbase .
 .
 .TP
 .BI \-\-sync= MODE
@@ -107,35 +109,6 @@ is the absolute path to the processed package repository.
 .IP
 Can be used by higher level tools to differentiate new clones from
 updates to existing repositories.
-.
-.SS Log options
-Logs shown by
-.BR aur\-fetch (1)
-show changes that happened since the commit referenced by the previous
-.B HEAD
-before
-.BR git\-reset (1)
-or
-.BR git\-rebase (1).
-See the
-.B \-\-sync
-option for more information.
-.TP
-.BI \-L " DIRECTORY" "\fR,\fP \-\-write\-log=" DIRECTORY
-The directory where logs between merged revisions are stored.
-.
-.TP
-.BR \-\-format= [ diff | log ]
-Use
-.BR git\-diff (1)
-or
-.BR git\-log (1)
-to generate logs, respectively.
-.
-.TP
-.BR \-v ", " \-\-verbose
-Print logs to
-.BR stdout .
 .
 .SH SEE ALSO
 .ad l


### PR DESCRIPTION
Store "seen" git commit hashes (git `HEAD` after `vifm` or `$AUR_PAGER` exited successfully) in the following directory structure:

```
$XDG_DATA_HOME/aurutils/view
|- pkgname1 # <sha_hash1>
|- pkgname2 # <sha_hash2>
|- ...
```
Compared to `AUR_SEEN` (#552) these hashes are stored even if `$AURDEST` is deleted. (#691)

This approach uses `aur fetch --results` to handle all diff functionality in `aur-sync`, instead of relying on `aur-fetch` to generate patches.

Diffs are only displayed if `HEAD` differs from an existing hash. On first run, hashes should be generated for packages in the local repository (#652), for example with:
```
$ aur sync $(aur repo --list | cut -f1) --print
<inspect files and exit with :q when satisfied>
```
----
Possible improvements:
* [x] Add `--rebuild-all` flag to simplify above command line (#712);
* [ ] Add subdirectories for "new" repositories (#379);