### PR TITLE
aur-sync: add --rebuild-all

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -67,7 +67,7 @@ trap_exit() {
 }
 
 usage() {
-    plain >&2 'usage: %s [-d repo] [--root path] [-cdfpSu] [--] pkgname...' "$argv0"
+    plain >&2 'usage: %s [-d repo] [--root path] [-cdfSu] [--] pkgname...' "$argv0"
     exit 1
 }
 
@@ -86,17 +86,17 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
     exit 1
 fi
 
-opt_short='B:d:D:AcfLnprRSTuv'
+opt_short='B:d:D:AcfLnrRSTuv'
 opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue' 'force'
           'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph' 'no-ver-argv'
-          'no-view' 'no-provides' 'print' 'rm-deps' 'sign' 'temp' 'upgrades'
+          'no-view' 'no-provides' 'no-build' 'rm-deps' 'sign' 'temp' 'upgrades'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'build-command:'
           'ignore-file:' 'remove' 'provides-from:' 'new' 'prevent-downgrade'
           'verify' 'results:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
-            'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'rebuildall'
-            'rebuildtree' 'rmdeps' 'gpg-sign')
+            'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
+            'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -116,6 +116,8 @@ while true; do
             pkg_i+=("${pkg[@]}") ;;
         --ignorefile|--ignore-file)
             shift; ignore_file=$1 ;;
+        --nobuild|--no-build)
+            build=0 ;;
         --nograph|--no-graph)
             graph=0 ;;
         --nover|--no-ver)
@@ -129,8 +131,6 @@ while true; do
         --provides-from)
             shift; IFS=, read -a repo -r <<< "$1"
             repo_p+=("${repo[@]}") ;;
-        -p|--print)
-            build=0 ;;
         --rebuild)
             build_args+=(-f); chkver_depth=1 ;;
         --rebuildtree|--rebuild-tree)

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -67,7 +67,7 @@ trap_exit() {
 }
 
 usage() {
-    plain >&2 'usage: %s [-d repo] [--root path] [-cdfSu] [--] pkgname...' "$argv0"
+    plain >&2 'usage: %s [-d repo] [--root path] [-cdfoSu] [--] pkgname...' "$argv0"
     exit 1
 }
 
@@ -86,7 +86,7 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
     exit 1
 fi
 
-opt_short='B:d:D:AcfLnrRSTuv'
+opt_short='B:d:D:AcfLnorRSTuv'
 opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue' 'force'
           'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph' 'no-ver-argv'
@@ -116,7 +116,7 @@ while true; do
             pkg_i+=("${pkg[@]}") ;;
         --ignorefile|--ignore-file)
             shift; ignore_file=$1 ;;
-        --nobuild|--no-build)
+        -o|--nobuild|--no-build)
             build=0 ;;
         --nograph|--no-graph)
             graph=0 ;;

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -16,7 +16,7 @@ repo_args=()
 build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1
 
 # default options (disabled)
-rotate=0 update=0
+rotate=0 update=0 repo_targets=0
 
 lib32() {
     awk -v arch="$(uname -m)" '{
@@ -87,16 +87,16 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
 fi
 
 opt_short='B:d:D:AcfLnprRSTuv'
-opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:'
-          'root:' 'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue'
-          'force' 'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph'
-          'no-ver-argv' 'no-view' 'no-provides' 'print' 'rm-deps'
-          'sign' 'temp' 'upgrades' 'pkgver' 'rebuild' 'rebuild-tree'
-          'build-command:' 'ignore-file:' 'remove' 'provides-from:'
-          'new' 'prevent-downgrade' 'verify' 'results:')
-opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:'
-            'noconfirm' 'nover' 'nograph' 'nover-argv' 'noview'
-            'noprovides' 'rebuildtree' 'rmdeps' 'gpg-sign')
+opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
+          'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue' 'force'
+          'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph' 'no-ver-argv'
+          'no-view' 'no-provides' 'print' 'rm-deps' 'sign' 'temp' 'upgrades'
+          'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'build-command:'
+          'ignore-file:' 'remove' 'provides-from:' 'new' 'prevent-downgrade'
+          'verify' 'results:')
+opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
+            'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'rebuildall'
+            'rebuildtree' 'rmdeps' 'gpg-sign')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -135,6 +135,8 @@ while true; do
             build_args+=(-f); chkver_depth=1 ;;
         --rebuildtree|--rebuild-tree)
             build_args+=(-f); chkver_depth=0 ;;
+        --rebuildall|--rebuild-all)
+            build_args+=(-f); chkver_depth=0; repo_targets=1 ;;
         -u|--upgrades)
             update=1 ;;
         # database options
@@ -217,7 +219,7 @@ if (( rotate )); then
     fi
 fi
 
-if ! (( $# + update )); then
+if ! (( $# + update + repo_targets )); then
     error '%s: no targets specified' "$argv0"
     exit 1
 fi
@@ -243,21 +245,26 @@ fi
       printf '%s\n' "$@"
   fi
 
-  if (( update )); then
+  # append repository packages (all)
+  if (( repo_targets )); then
+      cut -f1 <db_info
+
+  # append repository packages (updated)
+  elif (( update )); then
       aur vercmp --quiet <db_info
   fi
 } >argv
 
 if [[ -s argv ]]; then
     # shellcheck disable=SC2094
-    # $1 pkgname $2 depends $3 pkgbase $4 pkgver
+    # depends: $1 pkgname $2 depends $3 pkgbase $4 pkgver
     xargs -a argv -d'\n' aur depends --table >depends
 else
     plain >&2 "there is nothing to do"
     exit
 fi
 
-# $1 pkgname $2 pkgbase $3 pkgver
+# pkginfo: $1 pkgname $2 pkgbase $3 pkgver
 cut -f2 --complement depends | sort -u >pkginfo
 
 { if (( ${#pkg_i[@]} )); then

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -158,6 +158,17 @@ Alias for
 .BR "\-f \-\-nover" .
 .
 .TP
+.BR \-\-rebuildall ", " \-\-rebuild\-all
+As
+.BR \-\-rebuild\-tree ,
+but append all packages in the repository (see
+.BR \-d )
+as targets. May be used in conjunction with
+.B \-\-print
+to repopulate source directories in
+.BR $AURDEST .
+.
+.TP
 .BR \-S ", " \-\-sign ", " \-\-gpg-sign
 Sign built packages with
 .BR gpg (1).

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -47,6 +47,10 @@ be specified after a number sign. Defaults to
 .BR $XDG_CONFIG_HOME/aurutils/sync/ignore .
 .
 .TP
+.BR \-\-nobuild ", " \-\-no\-build
+Print target packages and their paths instead of building them.
+.
+.TP
 .BR \-\-nograph ", " \-\-no\-graph
 Do not verify the AUR dependency graph with
 .BR aur\-graph (1).
@@ -65,10 +69,6 @@ Version checks for package dependencies remain enabled.
 .TP
 .BR \-\-noview ", " \-\-no\-view
 Do not present build files for inspection.
-.
-.TP
-.BR \-p ", " \-\-print
-Print target packages and their paths instead of building them.
 .
 .TP
 .BR \-\-noprovides ", " \-\-no\-provides

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -4,7 +4,7 @@ aur\-sync \- download and build AUR packages automatically
 .
 .SH SYNOPSIS
 .SY "aur sync"
-.OP \-AcfgkLPstTuh
+.OP \-AcfgkLostTu
 .OP \-\-
 .IR pkgname ...
 .YS
@@ -47,7 +47,7 @@ be specified after a number sign. Defaults to
 .BR $XDG_CONFIG_HOME/aurutils/sync/ignore .
 .
 .TP
-.BR \-\-nobuild ", " \-\-no\-build
+.BR \-o ", " \-\-nobuild ", " \-\-no\-build
 Print target packages and their paths instead of building them.
 .
 .TP


### PR DESCRIPTION
Flag to rebuild a local repository in full or repopulate `AURDEST` in conjunction with `--print`.

Provisions for `--provides` are not required, because `aur-repo-filter` has no output on empty input.