### PR TITLE
aur-build: add --margs

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -1,6 +1,6 @@
 Andrew Gregory <https://github.com/andrewgregory>
 Assaf Gordon <http://savannah.gnu.org/users/agn>
-Robin Broda <https://github.com/coderobe>
+bartoszek <https://github.com/bartoszek>
 Damien Robert <https://github.com/DamienRobert>
 Dave Reisner <https://github.com/falconindy>
 e36freak <https://github.com/e36freak>
@@ -16,6 +16,7 @@ Patrick Burroughs <https://github.com/Celti>
 Peter van den Hurk <https://github.com/runical>
 rafasc <https://github.com/rafasc>
 Remy Marquis <https://github.com/rmarquis>
+Robin Broda <https://github.com/coderobe
 Sam Stuewe <https://github.com/halosghost>
 Simon Gomizelj <https://github.com/vodik>
 Tatsuhiro Tsujikawa <https://github.com/tatsuhiro-t>
@@ -32,4 +33,3 @@ pacaur (aur-sync)
 git (general design)
 pacutils (general design)
 repose (local repository)
-yaourt (--build-command)

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -37,7 +37,7 @@ trap_exit() {
 }
 
 usage() {
-    plain >&2 'usage: %s [-acfBNS] [-d repo] [--root path] [--] <makepkg args>' "$argv0"
+    plain >&2 'usage: %s [-acfNS] [-d repo] [--root path] [--margs makepkg_arg...]' "$argv0"
     exit 1
 }
 
@@ -57,28 +57,25 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
 fi
 
 ## option parsing
-opt_short='a:B:d:D:U:AcCfnrsvLNRST'
+opt_short='a:d:D:U:AcCfnrsvLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
-          'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:'
-          'remove' 'build-command:' 'pkgver' 'prefix:' 'rmdeps'
-          'no-confirm' 'ignore-arch' 'log' 'new' 'makepkg-conf:'
-          'bind:' 'bind-rw:' 'prevent-downgrade' 'temp' 'syncdeps' 'clean'
-          'namcap' 'checkpkg' 'user:')
-opt_hidden=('dump-options' 'gpg-sign' 'ignorearch' 'noconfirm' 'nosync')
+          'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:' 'remove'
+          'pkgver' 'prefix:' 'rmdeps' 'no-confirm' 'ignore-arch' 'log' 'new'
+          'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
+          'syncdeps' 'clean' 'namcap' 'checkpkg' 'user:' 'makepkg-args:')
+opt_hidden=('dump-options' 'gpg-sign' 'ignorearch' 'noconfirm' 'nosync' 'margs:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
 
-unset build_cmd db_name db_path db_root makepkg_conf pacman_conf results_file queue
+unset db_name db_path db_root makepkg_conf pacman_conf results_file queue
 while true; do
     case "$1" in
         # build options
         -a|--arg-file)
             shift; queue=$1 ;;
-        -B|--build-command)
-            shift; build_cmd+=("$1") ;;
         -f|--force)
             overwrite=1 ;;
         -c|--chroot)
@@ -118,7 +115,7 @@ while true; do
             makechrootpkg_args+=(-T) ;;
         -U|--user)
             shift; makechrootpkg_args+=(-U "$1") ;;
-        # makepkg options
+        # makepkg options (common)
         -A|--ignorearch|--ignore-arch)
             makepkg_args+=(--ignorearch)
             makechrootpkg_makepkg_args+=(--ignorearch) ;;
@@ -132,6 +129,11 @@ while true; do
             makepkg_args+=(--rmdeps) ;;
         -s|--syncdeps)
             makepkg_args+=(--syncdeps) ;;
+        # makepkg options
+        --makepkg-args|--margs)
+            shift; IFS=, read -a arg -r <<< "$1"
+            makepkg_args+=("${arg[@]}")
+            makechrootpkg_makepkg_args+=("${arg[@]}") ;;
         # repo-add options
         -v|--verify)
             repo_add_args+=(-v) ;;
@@ -156,12 +158,6 @@ var_tmp=$(mktemp -d --tmpdir="${TMPDIR:-/var/tmp/}" "aurutils-$argv0.XXXXXXXX") 
 
 trap 'trap_exit' EXIT
 trap 'exit' INT
-
-# Append remaining options to the makechrootpkg command-line
-if (( $# )); then
-    makepkg_args+=("$@")
-    makechrootpkg_makepkg_args+=("$@")
-fi
 
 # Propagate pacman config to aur-repo and pacconf (#543)
 if [[ -v pacman_conf ]]; then
@@ -230,7 +226,6 @@ if (( chroot )); then
     aur chroot "${chroot_args[@]}" --no-build
 else
     # Configuration for host builds.
-    # XXX move to aur-repo
     { printf '[options]\n'
       pacconf "${conf_args[@]}" --raw --options
 
@@ -267,7 +262,7 @@ while IFS= read -ru "$fd" path; do
 
     # Run pkgver before --packagelist (#500)
     if (( run_pkgver )); then
-        # Ignore architecture in pkgver() function (#536)
+        # Ignore architecture inside pkgver() function (#536)
         makepkg -od --ignorearch
     fi
 
@@ -289,10 +284,7 @@ while IFS= read -ru "$fd" path; do
         fi
     fi
 
-    if [[ -v build_cmd ]]; then
-        printf '%s\n' >&2 "Running custom command: ${build_cmd[*]}"
-        env PKGDEST="$var_tmp" AUR_REPO="$db_name" AUR_DBROOT="$db_root" "${build_cmd[@]}"
-    elif (( chroot )); then
+    if (( chroot )); then
         printf '%s\n' >&2 "Running makechrootpkg ${makechrootpkg_args[*]}"
         env PKGDEST="$var_tmp" aur chroot "${chroot_args[@]}" --no-prepare \
             -- "${makechrootpkg_args[@]}" -- "${makechrootpkg_makepkg_args[@]}"

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -168,6 +168,7 @@ fi
 # Defaults to /usr/share/devtools/makepkg-<arch>.conf
 if [[ -v makepkg_conf ]]; then
     chroot_args+=(--makepkg-conf "$makepkg_conf")
+    makepkg_args+=(--config "$makepkg_conf")
 fi
 
 # Assign environment variables (#443)

--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -5,6 +5,9 @@ argv0=repo-filter
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 arch_repo=(core extra testing community{,-testing} multilib{,-testing})
 
+# default options
+sync_repo=0
+
 # The command line will hit ARG_MAX on approximately 70k packages;
 # spread arguments with xargs (and printf, as a shell built-in).
 satisfies() {
@@ -36,7 +39,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset argv_repo sync_repo sift_args
+unset argv_repo sift_args
 while true; do
     case "$1" in
         -a|--all|--sync)
@@ -73,7 +76,7 @@ fi
 
 # associative array for input package names
 declare -A pkgset
-unset strset
+strset=()
 
 while IFS= read -r str; do
     # store unversioned string as key

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -86,17 +86,17 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
     exit 1
 fi
 
-opt_short='B:d:D:AcfLnorRSTuv'
+opt_short='d:D:AcfLnorRSTuv'
 opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue' 'force'
           'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph' 'no-ver-argv'
           'no-view' 'no-provides' 'no-build' 'rm-deps' 'sign' 'temp' 'upgrades'
-          'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'build-command:'
-          'ignore-file:' 'remove' 'provides-from:' 'new' 'prevent-downgrade'
-          'verify' 'results:')
+          'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
+          'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
+          'results:' 'makepkg-args:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
-            'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign')
+            'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign' 'margs:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -145,12 +145,12 @@ while true; do
         --root)
             shift; repo_args+=(-r "$1") ;;
         # build options
-        -B|--build-command)
-            shift; build_args+=(--build-command "$1") ;;
         -c|--chroot)
             build_args+=(--chroot) ;;
         -f|--force)
             build_args+=(--force) ;;
+        --makepkg-args|--margs)
+            shift; build_args+=(--margs "$1") ;;
         --makepkg-conf)
             shift; build_args+=(--makepkg-conf "$1") ;;
         --pacman-conf)

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -8,8 +8,8 @@ aur\-build \- build packages to a local repository
 .OP \-cfNRsv
 .OP \-a queue
 .OP \-B string
-.OP \-\-
-.RI [ "makepkg args" ]
+.OP \-\-margs
+.RI [ makepkg_args... ]
 .YS
 .
 .SH DESCRIPTION
@@ -25,27 +25,6 @@ prefix in
 .BI \-a " FILE" "\fR,\fP \-\-arg\-file=" FILE
 A text file describing directories that contain a PKGBUILD, relative to
 the current directory. If unspecified, the current directory is assumed.
-.
-.TP
-.BI \-B " STRING" "\fR,\fP \-\-build\-command=" STRING
-A string used as build command
-(instead of
-.B makepkg
-or
-.BR makechrootpkg ).
-The command has
-.BR PKGDEST ,
-.BR AUR_REPO ", and"
-.BR AUR_DBROOT
-set in the user environment. (These variables should be unset where
-appropriate.)
-.IP
-To split the command on whitespace, repeat the
-.B \-B
-option for each substring. For example,
-.BI "\-B " "makepkg " "\-B " \-sri
-would set the build command to
-.BR "makepkg \-sri" .
 .
 .TP
 .BR \-c ", " \-\-chroot
@@ -199,10 +178,7 @@ build completion.
 Additional options may be passed to
 .B makepkg
 by placing them after
-.B --
-in the
-.B aur\-build
-command-line.
+.BR \-\-m\-args .
 .
 .TP
 .BR \-A ", " \-\-ignorearch

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -162,8 +162,8 @@ As
 .BR \-\-rebuild\-tree ,
 but append all packages in the repository (see
 .BR \-d )
-as targets. May be used in conjunction with
-.B \-\-print
+as targets. May be used together with
+.B \-o
 to repopulate source directories in
 .BR $AURDEST .
 .


### PR DESCRIPTION
Replace `--build-command` by the following:

1. Add options to the `makepkg` command-line (both on the host and on the container, depending if -c is specified) with the `--margs` option. Arguments are comma-separated and may be specified multiple times. 
  To avoid quoting issues with `makepkg --config` through `--margs`, `--makepkg-conf` now sets the makepkg configuration used with `makepkg` for host (non-container) builds.
2. Support the `MAKEPKG` and `PACMAN` environment variables, to set the commands for `pacman` and `makepkg` operations.

Revisit of #678 (@bartoszek) and #709. A test case should include `aur sync --margs -h`.