### PR TITLE
aur-build: strip extension after last .db occurence

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -11,8 +11,10 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 # default options
 chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0 prefix=aur
 
-# default arguments
+# default arguments (empty)
 chroot_args=() conf_args=() makepkg_args=() makechrootpkg_makepkg_args=() repo_add_args=()
+
+# default arguments
 gpg_args=(--detach-sign --no-armor --batch)
 makechrootpkg_args=(-c -u)
 
@@ -182,12 +184,16 @@ case $db_name in
     "")
         case $db_root in
             "") db_path=$(aur repo "${conf_args[@]}" --path)
-                db_name=$(basename "$db_path" .db)
                 db_root=$(dirname "$db_path")
                 ;;
              *) error '%s: root specified without database name' "$argv0"
                 exit 1 ;;
-        esac ;;
+        esac
+
+        # Strip archive file extension (tar.gz, #714)
+        db_name=$(basename "$db_path")
+        db_name=${db_name%.db*}
+        ;;
     *)
         case $db_root in
             "") db_path=$(aur repo "${conf_args[@]}" --path -d "$db_name")

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -25,6 +25,7 @@ tr_ver() {
     sed -r 's/[<>=].*$//g'
 }
 
+# shellcheck disable=SC2086
 chain() {
     local a num sub
 

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -120,7 +120,7 @@ if cd "$tmp" && mkdir json tsv; then
     case $rings in
         1) true # no dependencies
            ;;
-        $max_request)
+        "$max_request")
             printf >&2 '%s: total requests: %d (out of range)\n' "$argv0" $(( max_request + 1 ))
             exit 34 ;;
     esac

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -131,7 +131,7 @@ while read -r key _ value; do
             conf_file_repo+=("$section")
 
             case $section in
-                $db_name)
+                "$db_name")
                     if ! [[ $db_root ]]; then
                         db_root=$server
                     elif [[ $db_root != "$server" ]]; then
@@ -141,7 +141,7 @@ while read -r key _ value; do
             ;;
         Server=*://*)
             case $section in
-                $db_name)
+                "$db_name")
                     if ! [[ $db_root ]]; then
                         db_root=$value
                     fi ;;

--- a/test/issue-187
+++ b/test/issue-187
@@ -1,8 +1,10 @@
 #!/bin/bash
-aur search .invalid
+out=$(aur search .invalid)
+err=$?
 
-# expected: [empty], exit 1
-case $? in
-    1) exit 0 ;;
-    *) exit 1 ;;
-esac
+# expected: empty output, exit 1
+if [[ ! $out ]] && (( err == 1 )); then
+    exit 0
+else
+    exit 1
+fi

--- a/test/issue-187
+++ b/test/issue-187
@@ -3,8 +3,4 @@ out=$(aur search .invalid)
 err=$?
 
 # expected: empty output, exit 1
-if [[ ! $out ]] && (( err == 1 )); then
-    exit 0
-else
-    exit 1
-fi
+[[ ! $out ]] && (( err == 1 ))

--- a/test/issue-257
+++ b/test/issue-257
@@ -1,8 +1,10 @@
 #!/bin/bash
-aur search python
+out=$(aur search python)
+err=$?
 
 # expected: "Too many package results", exit 2
-case $? in
-    2) exit 0 ;;
-    *) exit 1 ;;
-esac
+if (( err == 2 )); then
+    exit 0
+else
+    exit 1
+fi

--- a/test/issue-257
+++ b/test/issue-257
@@ -3,8 +3,4 @@ out=$(aur search python)
 err=$?
 
 # expected: "Too many package results", exit 2
-if (( err == 2 )); then
-    exit 0
-else
-    exit 1
-fi
+(( err == 2 ))

--- a/test/issue-403
+++ b/test/issue-403
@@ -1,8 +1,10 @@
 #!/bin/bash
-aur search aurutils
+out=$(aur search aurutils)
+err=$?
 
 # expected: valid results, exit 0
-case $? in
-    0) exit 0 ;;
-    *) exit 1 ;;
-esac
+if [[ $out ]] && (( err == 0 )); then
+    exit 0
+else
+    exit 1
+fi

--- a/test/issue-403
+++ b/test/issue-403
@@ -3,8 +3,4 @@ out=$(aur search aurutils)
 err=$?
 
 # expected: valid results, exit 0
-if [[ $out ]] && (( err == 0 )); then
-    exit 0
-else
-    exit 1
-fi
+[[ $out ]] && (( err == 0 ))

--- a/test/issue-513
+++ b/test/issue-513
@@ -1,6 +1,9 @@
-#!/bin/bash -e
-tmp=$(mktemp -d)
-trap 'rm -rf -- "$tmp"' EXIT
+#!/bin/bash
+if tmp=$(mktemp -d); then
+    trap 'rm -rf -- "$tmp"' EXIT
+else
+    exit 1
+fi
 
 cat >"$tmp"/pacman.conf <<EOF
 [options]
@@ -30,8 +33,7 @@ package() {
 EOF
 
 # create local repository
-repo-add "$tmp"/custom.db.tar
+repo-add "$tmp"/custom.db.tar || exit
 
 # issue 513: PKGDEST (environment) should be ignored
-cd "$tmp"
-PKGDEST=/does/not/exist aur build -d custom --pacman-conf "$tmp"/pacman.conf
+env -C "$tmp" PKGDEST=/does/not/exist aur build -d custom --pacman-conf "$tmp"/pacman.conf

--- a/test/issue-513
+++ b/test/issue-513
@@ -1,9 +1,8 @@
 #!/bin/bash -e
-tmp_server=$(mktemp -d)
-trap 'rm -rf -- "$tmp_server"' EXIT
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
 
-pacman_config() {
-    cat <<EOF
+cat >"$tmp"/pacman.conf <<EOF
 [options]
 HoldPkg = pacman-git glibc
 Architecture = auto
@@ -16,13 +15,23 @@ Include = /etc/pacman.d/mirrorlist
 Include = /etc/pacman.d/mirrorlist
 [custom]
 SigLevel = Optional TrustAll
-Server = file://$tmp_server
+Server = file://$tmp
 EOF
+
+cat >"$tmp"/PKGBUILD <<EOF
+pkgname=foo
+pkgver=1
+pkgrel=1
+arch=('any')
+
+package() {
+    true
 }
+EOF
 
 # create local repository
-repo-add "$tmp_server"/custom.db.tar
+repo-add "$tmp"/custom.db.tar
 
 # issue 513: PKGDEST (environment) should be ignored
-cd ../makepkg
-PKGDEST=/does/not/exist aur build -d custom -C <(pacman_config) -f
+cd "$tmp"
+PKGDEST=/does/not/exist aur build -d custom --pacman-conf "$tmp"/pacman.conf

--- a/test/issue-513
+++ b/test/issue-513
@@ -1,9 +1,6 @@
 #!/bin/bash
-if tmp=$(mktemp -d); then
-    trap 'rm -rf -- "$tmp"' EXIT
-else
-    exit 1
-fi
+tmp=$(mktemp -d) || exit
+trap 'rm -rf -- "$tmp"' EXIT
 
 cat >"$tmp"/pacman.conf <<EOF
 [options]

--- a/test/issue-636
+++ b/test/issue-636
@@ -1,14 +1,16 @@
 #!/bin/bash
+if tmp=$(mktemp -d); then
+    trap 'rm -rf -- "$tmp"' EXIT
+else
+    exit 1
+fi
 
-argv0=issue-636
-tmp="$(mktemp -d --tmpdir "aurutils-$argv0.XXXXXXXX")"
+out=$(env -C "$tmp" aur fetch aurutils aurutils-git)
+err=$?
 
-trap_exit() {
-    rm -rf -- "$tmp"
-}
-
-trap 'trap_exit' EXIT
-
-cd "$tmp" || exit
-
-aur fetch aurutils aurutils-git
+# expected: cloned repositories (x2), exit 0
+if (( err == 0 )) && [[ -d $tmp/aurutils/.git ]] && [[ -d $tmp/aurutils-git/.git ]]; then
+    exit 0
+else
+    exit 1
+fi

--- a/test/issue-636
+++ b/test/issue-636
@@ -1,16 +1,9 @@
 #!/bin/bash
-if tmp=$(mktemp -d); then
-    trap 'rm -rf -- "$tmp"' EXIT
-else
-    exit 1
-fi
+tmp=$(mktemp -d) || exit
+trap 'rm -rf -- "$tmp"' EXIT
 
 out=$(env -C "$tmp" aur fetch aurutils aurutils-git)
 err=$?
 
 # expected: cloned repositories (x2), exit 0
-if (( err == 0 )) && [[ -d $tmp/aurutils/.git ]] && [[ -d $tmp/aurutils-git/.git ]]; then
-    exit 0
-else
-    exit 1
-fi
+(( err == 0 )) && [[ -d $tmp/aurutils/.git ]] && [[ -d $tmp/aurutils-git/.git ]]

--- a/test/issue-706
+++ b/test/issue-706
@@ -1,2 +1,10 @@
 #!/bin/bash
-aur query -t info </dev/null
+out=$(aur query -t info </dev/null)
+err=$?
+
+# expected: empty output, exit 0
+if [[ ! $out ]] && (( err == 0 )); then
+    exit 0
+else
+    exit 1
+fi

--- a/test/issue-706
+++ b/test/issue-706
@@ -3,8 +3,4 @@ out=$(aur query -t info </dev/null)
 err=$?
 
 # expected: empty output, exit 0
-if [[ ! $out ]] && (( err == 0 )); then
-    exit 0
-else
-    exit 1
-fi
+[[ ! $out ]] && (( err == 0 ))

--- a/test/issue-714
+++ b/test/issue-714
@@ -1,6 +1,9 @@
-#!/bin/bash -e
-tmp=$(mktemp -d)
-trap 'rm -rf -- "$tmp"' EXIT
+#!/bin/bash
+if tmp=$(mktemp -d); then
+    trap 'rm -rf -- "$tmp"' EXIT
+else
+    exit 1
+fi
 
 cat >"$tmp"/pacman.conf <<EOF
 [options]
@@ -30,8 +33,7 @@ package() {
 EOF
 
 # create local repository
-repo-add "$tmp"/custom.db.tar
+repo-add "$tmp"/custom.db.tar || exit
 
 # issue 714: select repository without -d or --root
-cd "$tmp"
-aur build --pacman-conf "$tmp"/pacman.conf
+env -C "$tmp" aur build --pacman-conf "$tmp"/pacman.conf

--- a/test/issue-714
+++ b/test/issue-714
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+
+cat >"$tmp"/pacman.conf <<EOF
+[options]
+HoldPkg = pacman-git glibc
+Architecture = auto
+CheckSpace
+[core]
+Include = /etc/pacman.d/mirrorlist
+[extra]
+Include = /etc/pacman.d/mirrorlist
+[community]
+Include = /etc/pacman.d/mirrorlist
+[custom]
+SigLevel = Optional TrustAll
+Server = file://$tmp
+EOF
+
+cat >"$tmp"/PKGBUILD <<EOF
+pkgname=foo
+pkgver=1
+pkgrel=1
+arch=('any')
+
+package() {
+    true
+}
+EOF
+
+# create local repository
+repo-add "$tmp"/custom.db.tar
+
+# issue 714: select repository without -d or --root
+cd "$tmp"
+aur build --pacman-conf "$tmp"/pacman.conf

--- a/test/issue-714
+++ b/test/issue-714
@@ -1,9 +1,6 @@
 #!/bin/bash
-if tmp=$(mktemp -d); then
-    trap 'rm -rf -- "$tmp"' EXIT
-else
-    exit 1
-fi
+tmp=$(mktemp -d) || exit
+trap 'rm -rf -- "$tmp"' EXIT
 
 cat >"$tmp"/pacman.conf <<EOF
 [options]


### PR DESCRIPTION
aur-repo prints the absolute path to the database as of commit 44ea281d848ef4393a420477c7857531dacde1ee. Strip the extension accordingly if both `$db_name` and `$db_root` are unspecified.

Fixes #714