### PR TITLE
completion: fix broken completion for aur repo

### DIFF
--- a/completions/bash/aurutils.in
+++ b/completions/bash/aurutils.in
@@ -30,7 +30,7 @@ cat <<'EOF'
     # Fallback to default (files) completion in such cases.
 
     opts=(${default_cmds[${words[1]}]})
-    if [[ ${opts[*]} != *$prev:* ]]; then
+    if [[ ${opts[*]} != *$prev:* ]] || [[ $cword -eq 2 ]]; then
         COMPREPLY=($(compgen -W "${opts[*]%:}" -- "$cur"));
     fi
 }

--- a/completions/zsh/aurutils.in
+++ b/completions/zsh/aurutils.in
@@ -17,6 +17,8 @@ cat <<'EOF'
 
     _arguments -C \
         '1: :(${(k)default_cmds})' \
+        '2: :(${(@s/ /)default_cmds[${words[2]}]})' \
+
         '*: :->options'
 
     case $state in


### PR DESCRIPTION
When we attempt to generate a completion we check if the previous 'word'
matches 'word:' because options which require arguments are marked with
an ':' suffix in the array.

If we find a match, we complete with files by default,
otherwise we show all available options for the subcommand being used.

This worked until aur-repo learned '--repo:'.  Making aur repo <tab>
complete with files, as the subcommand itself matched one of its
options with required arguments.

To prevent that, always complete with options if we are on the second
word.