### PR TITLE
bash completion: provide repo completions

### DIFF
--- a/completions/bash/aurutils.in
+++ b/completions/bash/aurutils.in
@@ -20,7 +20,7 @@ cat <<'EOF'
     fi
 
     # If there's an override for subcommand, use it
-    if declare -F "_aurutils_${words[1]}" >/dev/null ; then
+    if declare -F "_aurutils_${words[1]/-/_/}" >/dev/null ; then
         "_aurutils_${words[1]}"
         return
     fi
@@ -29,12 +29,52 @@ cat <<'EOF'
     # is stored with an : suffix, because the option requires an argument.
     # Fallback to default (files) completion in such cases.
 
+    _fallback_completion
+}
+
+_fallback_completion(){
     opts=(${default_cmds[${words[1]}]})
     if [[ ${opts[*]} != *$prev:* ]] || [[ $cword -eq 2 ]]; then
         COMPREPLY=($(compgen -W "${opts[*]%:}" -- "$cur"));
     fi
 }
 
+_complete_with_repos() {
+    opts=($(aur repo --repo-list))
+    COMPREPLY=($(compgen -W "${opts[*]}" -- "$cur"))
+}
+
+_aurutils_build() {
+    case $prev in
+        -d|--database|--repo)
+            _complete_with_repos ;;
+        *) _fallback_completion ;;
+    esac
+}
+
+_aurutils_repo() {
+    case $prev in
+        -d|--database|--repo)
+            _complete_with_repos ;;
+        *) _fallback_completion ;;
+    esac
+}
+
+_aurutils_repo_filter() {
+    case $prev in
+        -d|--database|--repo)
+            _complete_with_repos ;;
+        *) _fallback_completion ;;
+    esac
+}
+
+_aurutils_sync() {
+    case $prev in
+        -d|--database|--repo)
+            _complete_with_repos ;;
+        *) _fallback_completion ;;
+    esac
+}
 
 complete -o bashdefault -o default -o nosort -F _aur_completion aur
 EOF


### PR DESCRIPTION
Specifying a repository is one of the most commonly used options for
anyone who uses multiple repositories.

Let's provide completions for it.

---

Would be nice to keep the zsh completion feature par, but this one is for bash only.