### PR TITLE
Use makepkg config when updating pkgver

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -263,8 +263,12 @@ while IFS= read -ru "$fd" path; do
 
     # Run pkgver before --packagelist (#500)
     if (( run_pkgver )); then
-        # Ignore architecture inside pkgver() function (#536)
-        makepkg -od --ignorearch
+        # Use the given config, if any
+        if (( makepkg_conf )); then
+            makepkg -od --ignorearch --config "$makepkg_conf"
+        else
+            makepkg -od --ignorearch
+        fi
     fi
 
     if (( ! overwrite )); then


### PR DESCRIPTION
Sometimes packages check the compiler and its options. It can fail
during the pkgver update if the default makepkg.conf (/etc/makepkg.conf)
has been modified.
This commit forces makepkg to use the given makepkg_conf instead.

Example: package checking that the compiler is gcc and default makepkg
uses clang.