### PR TITLE
Add option for incrementing pkgrel

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -9,7 +9,7 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
-chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 results=0
+chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 bump_pkgrel=0 results=0
 
 # default arguments (empty)
 chroot_args=() pacconf_args=() repo_add_args=() makepkg_args=() makechrootpkg_makepkg_args=() makepkg_common_args=()
@@ -61,7 +61,7 @@ fi
 opt_short='a:d:D:U:AcCfnrsvLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:' 'remove'
-          'pkgver' 'prefix:' 'rmdeps' 'no-confirm' 'ignore-arch' 'log' 'new'
+          'pkgver' 'pkgrel' 'prefix:' 'rmdeps' 'no-confirm' 'ignore-arch' 'log' 'new'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
           'syncdeps' 'clean' 'namcap' 'checkpkg' 'user:' 'makepkg-args:')
 opt_hidden=('dump-options' 'gpg-sign' 'ignorearch' 'noconfirm' 'nosync' 'margs:')
@@ -87,6 +87,8 @@ while true; do
             no_sync=1 ;;
         --pkgver)
             run_pkgver=1; makepkg_args+=(--noextract) ;;
+        --pkgrel)
+            bump_pkgrel=1; makepkg_args+=(--noextract) ;;
         --results)
             shift; results_file=$1 ;;
         --root)
@@ -251,6 +253,13 @@ fi
 
 while IFS= read -ru "$fd" path; do
     cd_safe "$startdir/$path"
+
+    # Update pkgrel on rebuild
+    if (( bump_pkgrel )) ; then
+        mv PKGBUILD PKGBUILD.old
+        awk -F"=" '{ OFS="=" } {if ($1 == "pkgrel") print($1,$2+1); else print $0;}' PKGBUILD.old > PKGBUILD
+        rm PKGBUILD.old
+    fi
 
     # Run pkgver before --packagelist (#500)
     if (( run_pkgver )); then

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -91,7 +91,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue' 'force'
           'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph' 'no-ver-argv'
           'no-view' 'no-provides' 'no-build' 'rm-deps' 'sign' 'temp' 'upgrades'
-          'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
+          'pkgver' 'pkgrel' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
           'results:' 'makepkg-args:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
@@ -158,6 +158,8 @@ while true; do
             repo_args+=(--pacman-conf "$1") ;;
         --pkgver)
             build_args+=(--pkgver) ;;
+        --pkgrel)
+            build_args+=(--pkgrel) ;;
         --results)
             shift; build_args+=(--results "$1") ;;
         -S|--sign|--gpg-sign)

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -75,7 +75,7 @@ Run
 .B "makepkg \-od
 before checking existing packages (effectively running an existing
 .B pkgver()
-function). Th
+function). The
 .BR \-\-noconfirm
 option is added to the default
 .BR makepkg (8)
@@ -83,7 +83,6 @@ options.
 .
 .B Note:
 The
-.RE
 .BR \-r ,
 .BR \-s ,
 and
@@ -92,6 +91,13 @@ options are passed on to the above command. Other
 .BR makepkg (8)
 options are ignored.
 .RE
+.
+.TP
+.BR \-\-pkgrel
+Increments the 
+.B pkgrel
+variable in the PKGBUILD before checking existing packages. This ensures
+that rebuilt packages will be detected as updates by \fBpacman \-Syu\fR.
 .
 .TP
 .BI \-\-results= file

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -147,6 +147,13 @@ before the build process.
 .RB ( "aur\-build \-\-pkgver" )
 .
 .TP
+.BR \-\-pkgrel
+Update the 
+.B pkgrel
+variable before the build process.
+.RB ( "aur\-build \-\-pkgrel" )
+.
+.TP
 .BR \-\-rebuild
 Alias for
 .BR "\-f \-\-nover\-argv" .


### PR DESCRIPTION
This allows packages to be rebuilt and detected as upgrades by `pacman -Syu`. It updates the `pkgrel` variable using an awk script.

I'm not sure whether a check for `pkgver` as a conflicting option should also be added, as it seems that running `makepkg --nobuild --nodeps` resets the `pkgrel` back to 1 if the version changes. To play it safe, these modifications update the `pkgrel` first.