### PR TITLE
Make sure db_table exits successfully on empty db

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -56,6 +56,7 @@ db_table() {
     END {
         print_previous()
     }'
+    return 0
 }
 
 usage() {

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -9,7 +9,9 @@ modifier=local table_format=0
 
 db_table() {
     # do not extract an empty database (#727)
-    (( $(bsdtar -tf "$2" | wc -l) )) && bsdtar -Oxf "$2" '*/desc' | awk -v table="$1" '
+    (( $(bsdtar -tf "$2" | wc -l) )) || return 0
+    
+    bsdtar -Oxf "$2" '*/desc' | awk -v table="$1" '
     function print_previous() {
         table ? format = "%s\t%s\t%s\t%s\n" : format = "%1$s\t%4$s\n"
 
@@ -56,7 +58,6 @@ db_table() {
     END {
         print_previous()
     }'
-    return 0
 }
 
 usage() {


### PR DESCRIPTION
Follow-up to #729, seems like on an empty DB even though it is not being extracted, the function still doesn't return successfully, and so you cannot build your first package. Having `return 0` is a simple way to ensure the function always succeeds.