### PR TITLE
man: add missing --remove option from aur sync

### DIFF
--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -147,6 +147,12 @@ before the build process.
 .RB ( "aur\-build \-\-pkgver" )
 .
 .TP
+.BR \-R ", " \-\-remove
+Remove old package files from disk when updating their entry in the
+database.
+.RB ( "aur build \-R" )
+.
+.TP
 .BR \-\-rebuild
 Alias for
 .BR "\-f \-\-nover\-argv" .


### PR DESCRIPTION
I wouldn't add a new repo-add section to the man page like in the aur-build man page, since aur-sync forwards it to aur-build, but it's an repo-add option, so I also could add a new section in the man page. 