### PR TITLE
Docker: /home/archie/.local/ is owned by root

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,8 @@ RUN ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 
 # unprivileged user
 ARG USERNAME=archie
-RUN useradd -m -s /bin/bash $USERNAME && \
+RUN useradd -m -s /bin/bash $USERNAME
+RUN install -o $USERNAME -dm755 /home/$USERNAME/.local && \
     install -o $USERNAME -dm755 /home/$USERNAME/.local/bin
 ENV PATH "/home/${USERNAME}/.local/bin:$PATH"
 


### PR DESCRIPTION
https://github.com/AladW/aurutils/pull/728/commits/bd261f7ba966854a8b9e0c27dde83300223c4545 changed the Dockerfile to use a single `install` call. 

This prevents using some `aurutils` operations with the unprivileged `archie` user, as `install` seems to only change the ownership of the last path component. 

As a result,  commands like `aur sync aurutils` would fail with:

```
+(/usr/lib/aurutils/aur-sync:213): mkdir -p /home/archie/.local/share/aurutils/view
mkdir: cannot create directory ‘/home/archie/.local/share’: Permission denied
```