### PR TITLE
aur-build: extend --user to local builds

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -71,7 +71,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset db_name db_path db_root makepkg_conf results_file queue
+unset db_name db_path db_root makepkg_conf makepkg_user results_file queue
 while true; do
     case "$1" in
         # build options
@@ -109,7 +109,8 @@ while true; do
         -T|--temp)
             makechrootpkg_args+=(-T) ;;
         -U|--user)
-            shift; makechrootpkg_args+=(-U "$1") ;;
+            shift; makechrootpkg_args+=(-U "$1")
+            makepkg_user=$1 ;;
         # makepkg options (common)
         -A|--ignorearch|--ignore-arch)
             makepkg_common_args+=(--ignorearch)
@@ -199,6 +200,14 @@ fi
 # Write successfully built packages to file (#437)
 if [[ -v results_file ]]; then
     : >"$results_file" # truncate file
+fi
+
+if [[ -v makepkg_user ]]; then
+    id -- "$makepkg_user" >/dev/null
+
+    makepkg() {
+        command sudo -u "$makepkg_user" makepkg "$@"
+    }
 fi
 
 # Defaults to /usr/share/devtools/pacman-<prefix>.conf

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -88,14 +88,14 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
     exit 1
 fi
 
-opt_short='d:D:AcfLnorRSTuv'
+opt_short='d:D:U:AcfLnorRSTuv'
 opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue' 'force'
           'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph' 'no-ver-argv'
           'no-view' 'no-provides' 'no-build' 'rm-deps' 'sign' 'temp' 'upgrades'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
-          'results:' 'makepkg-args:' 'format:')
+          'results:' 'makepkg-args:' 'format:' 'user:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign' 'margs:')
@@ -175,6 +175,8 @@ while true; do
             shift; build_args+=(--bind-rw "$1") ;;
         -T|--temp)
             build_args+=(-T) ;;
+        -U|--user)
+            shift; build_args+=(--user "$1") ;;
         # build options (makepkg)
         -A|--ignorearch|--ignore-arch)
             build_args+=(--ignorearch) ;;


### PR DESCRIPTION
This allows in particular to build packages with one user, and GPG sign them with another. This takes advantage of `aur-build` signing packages separately from `makepkg` in `/var/tmp`. `gpg` and other commands such as `repo-add` are unaffected by this flag and run as the local user.

To use `--syncdeps` with the build user, an appropriate sudoers rule should be added. This is similar to the existing `sudo -u build` approach documented in `aur-build`. If desired, `--syncdeps` can be implemented separately by the user, e.g. to allow an `sudo aur-build` invocation with dependency resolution.