### PR TITLE
aur-fetch: do not print results to stdout

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -13,7 +13,7 @@ results() {
     local mode=$1 prev=$2 current=$3 path=$4 dest=$5
 
     if [[ -w $dest ]]; then
-        printf '%s:%s:%s:file://%s\n' "$mode" "$prev" "$current" "$path" | tee -a "$dest"
+        printf >> "$dest" '%s:%s:%s:file://%s\n' "$mode" "$prev" "$current" "$path"
     fi
 }
 


### PR DESCRIPTION
This was a side-effect of printing the --results output to a file with `tee -a`.