### PR TITLE
aur-fetch: do not reset if rebase.autoStash is set

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -118,7 +118,9 @@ fi | while read -r pkg; do
 
         case $sync in
             rebase)
-                git reset --hard HEAD
+                if [[ $(git config --get --type bool rebase.autoStash) != 'true' ]]; then
+                    git reset --hard 'HEAD'
+                fi
                 git rebase --verbose
                 ;;
             reset)


### PR DESCRIPTION
https://github.com/AladW/aurutils/commit/d5ec2ddeb1c3a8718adcd0771adce997b8033c57 promised to respect `rebase.autoStash`, however `git reset` would still be run. Read the configuration and only run `git rest` if this option is not set to `true`.