### PR TITLE
aur-build: propagate --pacman-conf to makepkg for local builds

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -4,6 +4,7 @@
 set -o errexit
 shopt -s extglob
 argv0=build
+runtime_dir=${XDG_RUNTIME_DIR:-/run/user/$UID}/aurutils
 startdir=$PWD
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
@@ -60,7 +61,7 @@ fi
 ## option parsing
 opt_short='a:d:D:U:AcCfnrsvLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
-          'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:' 'remove'
+          'verify' 'directory:' 'no-sync' 'config:' 'pacman-conf:' 'results:' 'remove'
           'pkgver' 'prefix:' 'rmdeps' 'no-confirm' 'ignore-arch' 'log' 'new'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
           'syncdeps' 'clean' 'namcap' 'checkpkg' 'user:' 'makepkg-args:')
@@ -71,7 +72,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset db_name db_path db_root makepkg_conf results_file queue
+unset db_name db_path db_root makepkg_conf pacman_conf results_file queue
 while true; do
     case "$1" in
         # build options
@@ -143,8 +144,10 @@ while true; do
         --prevent-downgrade)
             repo_add_args+=(-p) ;;
         # other options
+        --config)
+            shift; pacconf_args+=(--config "$1") ;;
         --pacman-conf)
-            shift; pacconf_args+=(--config "$1")
+            shift; pacman_conf=$1
             chroot_args+=(--pacman-conf "$1") ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
@@ -222,11 +225,24 @@ if (( chroot )); then
     printf 'Running aur-chroot %s\n' >&2 "${args[*]}"
     aur chroot "${args[@]}"
 else
+    # makepkg -s does not support setting pacman.conf
+    if [[ -v pacman_conf ]]; then
+        mkdir -p "$runtime_dir"
+
+        { printf '#!/bin/sh --\n'
+          printf 'pacman --config "%s" "$@"\n' "$pacman_conf"
+        } > "$runtime_dir"/pacman_cfg
+
+        chmod +x "$runtime_dir"/pacman_cfg
+        PACMAN=$runtime_dir/pacman_cfg
+    fi
+    PACMAN=${PACMAN:-pacman}
+
     packagelist() {
         local args=("--packagelist" "${makepkg_conf[@]}")
 
         printf 'Running makepkg %s\n' >&2 "${args[*]}"
-        makepkg "${args[@]}"
+        PACMAN="$PACMAN" makepkg "${args[@]}"
     }
 
     # Configuration for host builds.
@@ -269,7 +285,7 @@ while IFS= read -ru "$fd" path; do
         args=("-od" "${makepkg_common_args[@]}" "${makepkg_conf[@]}")
 
         printf 'Running makepkg %s\n' >&2 "${args[*]}"
-        makepkg "${args[@]}"
+        PACMAN="$PACMAN" makepkg "${args[@]}"
     fi
 
     if (( ! overwrite )); then
@@ -303,7 +319,7 @@ while IFS= read -ru "$fd" path; do
               "${makepkg_conf[@]}")
 
         printf 'Running makepkg %s\n' >&2 "${args[*]}"
-        PKGDEST="$var_tmp" makepkg "${args[@]}"
+        PKGDEST="$var_tmp" PACMAN="$PACMAN" makepkg "${args[@]}"
     fi
 
     cd_safe "$var_tmp"

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -95,7 +95,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'no-view' 'no-provides' 'no-build' 'rm-deps' 'sign' 'temp' 'upgrades'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
-          'results:' 'makepkg-args:' 'format:')
+          'results:' 'makepkg-args:' 'format:' 'config:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign' 'margs:')
@@ -153,6 +153,8 @@ while true; do
             build_args+=(--chroot) ;;
         -f|--force)
             build_args+=(--force) ;;
+        --config)
+            shift; build_args+=(--config "$1") ;;
         --makepkg-args|--margs)
             shift; build_args+=(--margs "$1") ;;
         --makepkg-conf)

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -83,6 +83,16 @@ builds, this reflects the
 command.
 .
 .TP
+.BI \-\-config= FILE
+The
+.BR pacman.conf (5)
+file to use for syncing and retrieving local repositories. This option
+does not affect
+.BR makepkg (8)
+calls. (See also
+.BR \-\-pacman\-conf .)
+.
+.TP
 .BR \-\-no\-sync
 Do not sync the local repository after building.
 .
@@ -186,6 +196,18 @@ Run
 on the built package.
 .
 .TP
+.BI \-\-makepkg\-conf= FILE
+The
+.BR makepkg.conf (5)
+file used inside the container. (\fBaur\-chroot \-\-makepkg\-conf\fR)
+.
+.TP
+.BI \-\-pacman\-conf= FILE
+The
+.BR pacman.conf (5)
+file used inside the container. (\fBaur\-chroot \-\-pacman\-conf\fR)
+.
+.TP
 .BI \-\-prefix= PREFIX
 The path component
 .B <prefix>
@@ -234,6 +256,27 @@ Enable logging to a text file in the build directory.
 .BR \-\-clean
 Clean up leftover work files and directories after a successful build.
 .RB ( makepkg " " \-c )
+.
+.TP
+.BI \-\-pacman\-conf= FILE
+The
+.BR pacman.conf (5)
+file used for
+.BR makepkg (8)
+invocations.
+.IP
+.B Note:
+This option invalidates the use of the
+.B PACMAN
+environment variable.
+.
+.TP
+.BI \-\-makepkg\-conf= FILE
+The
+.BR makepkg.conf (5)
+file used for
+.BR makepkg (8)
+invocations.
 .
 .SS repo\-add options
 .TP

--- a/man1/aur-chroot.1
+++ b/man1/aur-chroot.1
@@ -4,12 +4,13 @@ aur\-chroot \- build packages with systemd-nspawn
 .
 .SH SYNOPSIS
 .SY "aur chroot"
-.OP \-d database
 .OP \-D directory
-.OP \-M makepkg_conf
 .OP \-C pacman_conf
+.OP \-M makepkg_conf
 .OP \-\-no\-build
 .OP \-\-no\-prepare
+.OP \-\-packagelist
+.OP \-\-prefix
 .OP \-\-
 .RI [ "makechrootpkg args" ]
 .YS
@@ -50,11 +51,10 @@ file used inside the container. Defaults to
 .IR /usr/share/devtools/pacman\-extra.conf .
 .IP
 This file is processed with
-.BR pacconf (1)
-to include necessary information from the host, such as mirrors. If a
-local repository name is specified with
-.BR \-d ,
-its configuration is appended to this file.
+.B pacman\-conf
+to bind-mount listed
+.B file://
+repositories.
 .
 .TP
 .BI \-M " FILE" "\fR,\fP \-\-makepkg\-conf=" FILE
@@ -65,9 +65,11 @@ file used inside the container. Defaults to devtools'
 .
 .TP
 .B \-\-bind
+Bind a directory read-only to the container. (\fBmakechrootpkg \-D\fR)
 .
 .TP
 .B \-\-bind\-rw
+Bind a directory read-write to the container. (\fBmakechrootpkg \-d\fR)
 .
 .TP
 .B \-\-no\-build
@@ -81,9 +83,23 @@ Build a package, do not update the container.
 .
 .TP
 .B \-\-packagelist
+List the package filenames that would be produced without
+building.
+.RB ( "makepkg \-\-packagelist" )
+using the
+.BR makepkg.conf (5)
+file specified with the
+.B \-\-makepkg\-conf
+option.
 .
 .TP
 .B \-\-prefix
+The path component
+.B <prefix>
+in the pacman configuration
+.BR /usr/share/devtools/pacman\-<prefix>.conf .
+Defaults to
+.BR extra .
 .
 .SH ENVIRONMENT
 Packages are placed in the directory specified in
@@ -100,16 +116,16 @@ Changes to the pacman database are
 propagated from the container to the local system. Packages must be
 installed and updated separately, typically through
 .BI "pacman \-Syu " package_name\fR.
-.
-Package conflicts inside the container must be solved manually, as
+.PP
+Package conflicts inside the container must be resolved manually, as
 .B makechrootpkg
 uses
 .B "makepkg \-\-noconfirm \-s"
 internally. For example, to replace
 .I gcc
 with
-.I gcc\-multilib
-, run
+.IR gcc\-multilib ,
+run
 .B "arch\-nspawn /var/lib/aurbuild/root pacman \-S gcc\-multilib"
 as root.
 .

--- a/test/package-tests
+++ b/test/package-tests
@@ -7,6 +7,8 @@ cat >"$var_tmp"/pacman.conf <<EOF
 HoldPkg = pacman-git glibc
 Architecture = auto
 CheckSpace
+CacheDir = $var_tmp
+CacheDir = /var/cache/pacman/pkg
 [core]
 Include = /etc/pacman.d/mirrorlist
 [extra]
@@ -21,24 +23,34 @@ EOF
 # create local repository
 repo-add "$var_tmp"/custom.db.tar || exit
 
-test_packages=(
+test_package=(
     'python-pyalsaaudio' # split packages - independent
     'fasm-linux-git' 'hnwatch' # split packages - pkgbase does not match pkgname
     'ros-build-tools' # empty make/depends
     'curr' # dependency order (#414)
-    'mingw-w64-gcc-base' # cyclic dependencies - required removal of makedeps
     'gimp-plugin-separate+' # Special characters
 )
 
-test_packages_big=(
+test_package_big=(
     'clion' # split package - multiple packages from same package base
     'libc++' 'libc++-abi' # split package - depends on package from same package base
     'openrct2-git' # make/depends_arch
+    'mingw-w64-gcc-base' # cyclic dependencies - required removal of makedeps
+)
+
+test_package_huge=(
     'plasma-git-meta' # 100+ depends
     'ros-lunar-desktop' # 250+ depends 
 )
 
-for p in "${test_packages[@]}"; do
-    { aur sync --rmdeps --no-confirm --no-view --repo=custom --margs --skippgpcheck --pacman-conf "$var_tmp"/pacman.conf "$p" && \
-	    pacman -Si --config "$var_tmp"/pacman.conf custom/"$p"; } || exit
+sync_args=(
+    --rmdeps --no-confirm --no-view --repo=custom
+    --margs --skippgpcheck
+    --config "$var_tmp"/pacman.conf
+    --pacman-conf "$var_tmp"/pacman.conf    
+)
+for p in "${test_package[@]}"; do
+    { AURDEST="$var_tmp" aur sync "${sync_args[@]}" "$p" && \
+        pacman --config "$var_tmp"/pacman.conf -Si custom/"$p"
+    } || exit
 done


### PR DESCRIPTION
Noticed this as my package tests would not use their custom set cache directory: `makepkg -s` runs `pacman` with a few hardcoded arguments; in particular, `--config` is not supported. The only way around this is either use a chroot, or set `PACMAN` to a `pacman --config` wrapper. As former is already possible, this PR implements latter.