### PR TITLE
aur-build: use libmakepkg for packagelist

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -47,9 +47,12 @@ usage() {
     exit 1
 }
 
-source /usr/share/makepkg/util/util.sh
+source /usr/share/makepkg/util/config.sh
 source /usr/share/makepkg/util/message.sh
+source /usr/share/makepkg/util/option.sh
 source /usr/share/makepkg/util/parseopts.sh
+source /usr/share/makepkg/util/pkgbuild.sh
+source /usr/share/makepkg/util/util.sh
 
 if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
     [[ -t 2 ]] && colorize
@@ -130,8 +133,9 @@ while true; do
         -s|--syncdeps)
             makepkg_common_args+=(--syncdeps) ;;
         --makepkg-conf)
-            shift; makepkg_conf+=(--config "$1")
-            chroot_args+=(--makepkg-conf "$1") ;;
+            shift; chroot_args+=(--makepkg-conf "$1")
+            makepkg_conf=$1
+            makepkg_common_args+=(--config "$1") ;;
         # makepkg options
         -C|--clean)
             makepkg_args+=(--clean) ;;
@@ -230,9 +234,13 @@ if (( chroot )); then
     # avoid lenghty upgrades for makechrootpkg -u.
     run_msg aur chroot --update "${chroot_args[@]}"
 else
-    packagelist() {
-        run_msg makepkg --packagelist "${makepkg_conf[@]}"
-    }
+    # XXX: ignores makepkg -p option (--margs)
+    packagelist() (
+        load_makepkg_config "${makepkg_conf-}"
+        source_safe PKGBUILD
+
+        PKGDEST="${PKGDEST:-$startdir}" print_all_package_names
+    )
 
     # Configuration for host builds.
     { printf '[options]\n'
@@ -271,7 +279,7 @@ while IFS= read -ru "$fd" path; do
 
     # Run pkgver before --packagelist (#500)
     if (( run_pkgver )); then
-        run_msg makepkg -od "${makepkg_common_args[@]}" "${makepkg_conf[@]}"
+        run_msg makepkg -od "${makepkg_common_args[@]}"
     fi
 
     if (( ! overwrite )); then
@@ -297,8 +305,8 @@ while IFS= read -ru "$fd" path; do
                -- "${makechrootpkg_args[@]}" \
                -- "${makechrootpkg_makepkg_args[@]}"
     else
-        PKGDEST="$var_tmp" run_msg makepkg "${makepkg_common_args[@]}" \
-               "${makepkg_args[@]}" "${makepkg_conf[@]}"
+        PKGDEST="$var_tmp" run_msg makepkg \
+               "${makepkg_common_args[@]}" "${makepkg_args[@]}"
     fi
 
     cd_safe "$var_tmp"

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -67,11 +67,13 @@ fi
 
 ## option parsing
 opt_short='a:d:D:U:AcCfnrsvLNRST'
-opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
-          'verify' 'directory:' 'no-sync' 'config:' 'pacman-conf:' 'results:' 'remove'
-          'pkgver' 'prefix:' 'rmdeps' 'no-confirm' 'ignore-arch' 'log' 'new'
-          'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
-          'syncdeps' 'clean' 'namcap' 'checkpkg' 'user:' 'makepkg-args:')
+opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:'
+          'sign' 'verify' 'directory:' 'no-sync' 'config:'
+          'pacman-conf:' 'results:' 'remove' 'pkgver' 'prefix:'
+          'rmdeps' 'no-confirm' 'ignore-arch' 'log' 'new'
+          'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade'
+          'temp' 'syncdeps' 'clean' 'namcap' 'checkpkg' 'user:'
+          'makepkg-args:' 'buildscript:')
 opt_hidden=('dump-options' 'gpg-sign' 'ignorearch' 'noconfirm' 'nosync' 'margs:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -79,7 +81,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset db_name db_path db_root makepkg_conf pacman_conf results_file queue
+unset buildscript db_name db_path db_root makepkg_conf pacman_conf results_file queue
 while true; do
     case "$1" in
         # build options
@@ -93,6 +95,9 @@ while true; do
             shift; db_name=$1 ;;
         --config)
             shift; pacconf_args+=(--config "$1") ;;
+        --buildscript)
+            shift; buildscript=$1
+            makepkg_common_args+=(-p "$1") ;;
         --nosync|--no-sync)
             no_sync=1 ;;
         --pkgver)
@@ -223,8 +228,9 @@ if (( chroot )); then
         chroot_args+=(--prefix "$prefix")
     fi
 
-    # makepkg --packagelist includes the package extension, but makechrootpkg
-    # ignores PKGEXT set on the host. Retrieve it seperately.
+    # makepkg --packagelist includes the package extension, but
+    # makechrootpkg ignores PKGEXT set on the host. Retrieve it
+    # seperately.
     packagelist() {
         run_msg aur chroot --packagelist "${chroot_args[@]}"
     }
@@ -234,10 +240,11 @@ if (( chroot )); then
     # avoid lenghty upgrades for makechrootpkg -u.
     run_msg aur chroot --update "${chroot_args[@]}"
 else
-    # XXX: ignores makepkg -p option (--margs)
+    # Use libmakepkg to avoid a performance hit from linting the
+    # PKGBUILD twice (in both makepkg and makepkg --packagelist)
     packagelist() (
         load_makepkg_config "${makepkg_conf-}"
-        source_safe PKGBUILD
+        source_safe "${buildscript-PKGBUILD}"
 
         PKGDEST="${PKGDEST:-$startdir}" print_all_package_names
     )
@@ -293,6 +300,8 @@ while IFS= read -ru "$fd" path; do
         wait $!
 
         if [[ ${exists[*]} ]]; then
+            # XXX: use lint_pkgbuild in this case as no lint from a
+            # makepkg invocation may take place
             warning '%s: skipping existing package (use -f to overwrite)' "$argv0"
 
             printf '%q\n' >&2 "${exists[@]}"

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -6,6 +6,7 @@ argv0=chroot
 PATH=/bin:/usr/bin
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 machine=$(uname -m)
+startdir=$(pwd -P)
 
 # default arguments
 directory=/var/lib/aurbuild/$machine
@@ -21,6 +22,9 @@ usage() {
     exit 1
 }
 
+source /usr/share/makepkg/util/config.sh
+source /usr/share/makepkg/util/option.sh
+source /usr/share/makepkg/util/pkgbuild.sh
 source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='C:D:M:BU'
@@ -97,7 +101,11 @@ while read -r key _ value; do
 done < <(pacman-conf --config "$pacman_conf")
 
 if (( packagelist )); then
-    makepkg --config "$makepkg_conf" --packagelist
+    ( load_makepkg_config "$makepkg_conf"
+      source_safe PKGBUILD
+
+      PKGDEST="${PKGDEST:-$startdir}" print_all_package_names
+    )
     exit $?
 fi
 

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -29,7 +29,7 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='C:D:M:BU'
 opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'build' 'update'
-          'prefix:' 'bind:' 'bind-rw:' 'packagelist')
+          'prefix:' 'bind:' 'bind-rw:' 'packagelist' 'buildscript:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -37,13 +37,15 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset bindmounts_ro bindmounts_rw pacman_conf
+unset bindmounts_ro bindmounts_rw buildscript pacman_conf
 while true; do
     case "$1" in
         -B|--build)
             build=1 ;;
         -U|--update)
             update=1 ;;
+        --buildscript)
+            shift; buildscript=$1 ;;
         --packagelist)
             packagelist=1 ;;
         --prefix)
@@ -102,7 +104,7 @@ done < <(pacman-conf --config "$pacman_conf")
 
 if (( packagelist )); then
     ( load_makepkg_config "$makepkg_conf"
-      source_safe PKGBUILD
+      source_safe "${buildscript-PKGBUILD}"
 
       PKGDEST="${PKGDEST:-$startdir}" print_all_package_names
     )

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -78,7 +78,6 @@ database.
 .TP
 .BR \-f ", " \-\-force
 Continue the build process if a package with the same name is found.
-.RB ( "makepkg \-\-packagelist" )
 .
 .TP
 .BR \-S ", " \-\-sign ", " \-\-gpg\-sign

--- a/man1/aur-chroot.1
+++ b/man1/aur-chroot.1
@@ -87,13 +87,10 @@ Bind a directory read-write to the container.
 .TP
 .B \-\-packagelist
 List the package filenames that would be produced without
-building.
-.RB ( "makepkg \-\-packagelist" )
-using the
+building using the
 .BR makepkg.conf (5)
-file specified with the
-.B \-\-makepkg\-conf
-option.
+file specified with
+.BR \-\-makepkg\-conf .
 .
 .TP
 .B \-\-prefix


### PR DESCRIPTION
Basic performance comparison on a low-performance VM:
```
[archie@vbox makepkg]$ time makepkg --packagelist
/home/archie/projects/aurutils/makepkg/aurutils-git-3.0.0rc.r7.gc91de35-1-any.pkg.tar.zst
    
real    0m2.412s
user    0m1.766s
sys     0m0.580s

[archie@vbox makepkg]$ time ../makepkg-fast --packagelist
/home/archie/projects/aurutils/makepkg/aurutils-git-3.0.0rc.r7.gc91de35-1-any.pkg.tar.zst
    
real    0m0.064s
user    0m0.051s
sys     0m0.008s
```

Where `makepkg-fast` is a script using libmakepkg/util/pkgbuild.sh print_all_package_names() directly if called with --packagelist.

---

A possible issue is that the PKGBUILD is not linted if the build is skipped due to matching version in the local repository. In this specific case, `lint_pkgbuild` could be called (which apparently is a cause for the slow-down above).