### PR TITLE
aur-chroot: use --update/--build

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -225,7 +225,7 @@ if (( chroot )); then
     # Update pacman and makepkg configuration for the chroot build
     # queue. A full system upgrade is run on the /root container to
     # avoid lenghty upgrades for makechrootpkg -u.
-    run_msg aur chroot --no-build "${chroot_args[@]}"
+    run_msg aur chroot --update "${chroot_args[@]}"
 else
     # makepkg -s does not support setting pacman.conf
     if [[ -v pacman_conf ]]; then
@@ -304,7 +304,7 @@ while IFS= read -ru "$fd" path; do
     fi
 
     if (( chroot )); then
-        PKGDEST="$var_tmp" run_msg aur chroot --no-prepare "${chroot_args[@]}" \
+        PKGDEST="$var_tmp" run_msg aur chroot --build "${chroot_args[@]}" \
                -- "${makechrootpkg_args[@]}" \
                -- "${makechrootpkg_makepkg_args[@]}"
     else

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -14,19 +14,19 @@ makepkg_conf=/usr/share/devtools/makepkg-$machine.conf
 prefix=extra
 
 # default options
-prepare=1 build=1 packagelist=0
+update=0 build=0 packagelist=0
 
 usage() {
-    printf >&2 'usage: %s [-CDM path] -- <makechrootpkg args>\n' "$argv0"
+    printf >&2 'usage: %s [-BU] [-CDM path] -- <makechrootpkg args>\n' "$argv0"
     exit 1
 }
 
 source /usr/share/makepkg/util/parseopts.sh
 
-opt_short='C:D:M:'
-opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'no-build' 'no-prepare'
+opt_short='C:D:M:BU'
+opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'build' 'update'
           'prefix:' 'bind:' 'bind-rw:' 'packagelist')
-opt_hidden=('dump-options' 'nobuild' 'noprepare')
+opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -36,10 +36,10 @@ set -- "${OPTRET[@]}"
 unset bindmounts_ro bindmounts_rw pacman_conf
 while true; do
     case "$1" in
-        --no-build|--nobuild)
-            build=0 ;;
-        --no-prepare|--noprepare)
-            prepare=0 ;;
+        -B|--build)
+            build=1 ;;
+        -U|--update)
+            update=1 ;;
         --packagelist)
             packagelist=1 ;;
         --prefix)
@@ -101,7 +101,7 @@ if (( packagelist )); then
     exit $?
 fi
 
-if (( prepare )); then
+if (( update )); then
     # parent path is not created by mkarchroot (#371)
     if [[ ! -d $directory ]]; then
         sudo install -d "$directory" -m 755 -v

--- a/man1/aur-chroot.1
+++ b/man1/aur-chroot.1
@@ -1,4 +1,4 @@
-.TH AUR-CHROOT 2020-10-02 AURUTILS
+.TH AUR-CHROOT 2020-10-12 AURUTILS
 .SH NAME
 aur\-chroot \- build packages with systemd-nspawn
 .
@@ -7,8 +7,8 @@ aur\-chroot \- build packages with systemd-nspawn
 .OP \-D directory
 .OP \-C pacman_conf
 .OP \-M makepkg_conf
-.OP \-\-no\-build
-.OP \-\-no\-prepare
+.OP \-\-build
+.OP \-\-update
 .OP \-\-packagelist
 .OP \-\-prefix
 .OP \-\-
@@ -24,6 +24,16 @@ container.
 All arguments after
 .B \-\-
 are passed to \fBmakechrootpkg\fR.
+.
+.TP
+.BR \-B ", " \-\-build
+Build a package inside the container.
+.
+.TP
+.BR \-U ", " \-\-update
+Update or create the
+.B /root
+copy of the container.
 .
 .TP
 .BI \-D " DIR" "\fR,\fP \-\-directory=" DIR
@@ -70,16 +80,6 @@ Bind a directory read-only to the container. (\fBmakechrootpkg \-D\fR)
 .TP
 .B \-\-bind\-rw
 Bind a directory read-write to the container. (\fBmakechrootpkg \-d\fR)
-.
-.TP
-.B \-\-no\-build
-Update or create the
-.B /root
-copy of the container; do not build a package.
-.
-.TP
-.B \-\-no\-prepare
-Build a package, do not update the container.
 .
 .TP
 .B \-\-packagelist


### PR DESCRIPTION
Enable functionality with `--update`/`-U` (create or update chroot) and `--build`/`-B` (build package inside chroot), instead of disable it with `--no-prepare` and `--no-build`, respectively.

---
I always found the selective disabling of functionality in `aur-chroot` awkward, and the full program can be enabled by golfing `-UB`.