### PR TITLE
aur-build, aur-chroot: rename --prefix to --suffix

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -17,7 +17,7 @@ chroot_args=() pacconf_args=() repo_add_args=() makepkg_args=() makechrootpkg_ma
 # default arguments
 gpg_args=(--detach-sign --no-armor --batch)
 makechrootpkg_args=(-c -u)
-prefix=aur
+suffix=aur
 
 db_replaces() {
     bsdcat "$1" | awk '
@@ -69,7 +69,7 @@ fi
 opt_short='a:d:D:U:AcCfnrsvLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:'
           'sign' 'verify' 'directory:' 'no-sync' 'config:'
-          'pacman-conf:' 'results:' 'remove' 'pkgver' 'prefix:'
+          'pacman-conf:' 'results:' 'remove' 'pkgver' 'suffix:'
           'rmdeps' 'no-confirm' 'ignore-arch' 'log' 'new'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade'
           'temp' 'syncdeps' 'clean' 'namcap' 'checkpkg' 'user:'
@@ -117,8 +117,8 @@ while true; do
             shift; makechrootpkg_args+=(-d"$1") ;;
         --pacman-conf)
             shift; pacman_conf=$1 ;;
-        --prefix)
-            shift; prefix=$1 ;;
+        --suffix)
+            shift; suffix=$1 ;;
         -N|--namcap)
             makechrootpkg_args+=(-n) ;;
         --checkpkg)
@@ -224,8 +224,8 @@ if (( chroot )); then
     if [[ -v pacman_conf ]]; then
         chroot_args+=(--pacman-conf "$pacman_conf")
     else
-        # Defaults to /usr/share/devtools/pacman-<prefix>.conf
-        chroot_args+=(--prefix "$prefix")
+        # Defaults to /usr/share/devtools/pacman-<suffix>.conf
+        chroot_args+=(--suffix "$suffix")
     fi
 
     # makepkg --packagelist includes the package extension, but

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -65,7 +65,7 @@ configuration for the container is placed in
 A different location can be chosen with the
 .BR \-\-pacman\-conf
 or
-.BR \-\-prefix
+.BR \-\-suffix
 options.
 .RE
 .
@@ -162,7 +162,7 @@ sync operations regardless of this setting. See also
 .TP
 .BI \-D " DIR" "\fR,\fP \-\-directory=" DIR
 The base directory for containers. Defaults to
-.BI /var/lib/archbuild/ <chroot\-prefix> \- <arch> \fR.
+.BI /var/lib/archbuild/ <chroot\-suffix> \- <arch> \fR.
 .IP
 .RS
 .B Note:
@@ -222,12 +222,12 @@ file used inside the container.
 .RB ( aur\-chroot " " \-\-pacman\-conf )
 .
 .TP
-.BI \-\-prefix= PREFIX
+.BI \-\-suffix= SUFFIX
 The path component
-.B <prefix>
+.B <suffix>
 in the pacman configuration
-.BR /usr/share/devtools/pacman\-<prefix>.conf .
-.RB ( aur\-chroot " " \-\-prefix )
+.BR /usr/share/devtools/pacman\-<suffix>.conf .
+.RB ( aur\-chroot " " \-\-suffix )
 Defaults to
 .BR aur .
 .

--- a/man1/aur-chroot.1
+++ b/man1/aur-chroot.1
@@ -10,7 +10,7 @@ aur\-chroot \- build packages with systemd-nspawn
 .OP \-\-build
 .OP \-\-update
 .OP \-\-packagelist
-.OP \-\-prefix
+.OP \-\-suffix
 .OP \-\-
 .RI [ "makechrootpkg args" ]
 .YS
@@ -93,11 +93,11 @@ file specified with
 .BR \-\-makepkg\-conf .
 .
 .TP
-.B \-\-prefix
+.B \-\-suffix
 The path component
-.B <prefix>
+.B <suffix>
 in the pacman configuration
-.BR /usr/share/devtools/pacman\-<prefix>.conf .
+.BR /usr/share/devtools/pacman\-<suffix>.conf .
 Defaults to
 .BR extra .
 .


### PR DESCRIPTION
This option affects the suffix `extra` in `pacman-extra.conf`, and should thus be called `--suffix`.