### PR TITLE
aur-sync: use XDG_RUNTIME_DIR for view directory

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -6,6 +6,7 @@ argv0=sync
 XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
+XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$UID}
 AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
@@ -205,9 +206,11 @@ while true; do
     shift
 done
 
-tmp=$(mktemp -d --tmpdir "aurutils-$argv0.XXXXXXXX") || exit
-tmp_view=$(mktemp -d --tmpdir "aurutils-$argv0-view.XXXXXXXX") || exit
+# Directory for package symlinks
+mkdir -p "$XDG_RUNTIME_DIR"/aurutils
 
+tmp=$(mktemp -d --tmpdir "aurutils-$argv0.XXXXXXXX") || exit
+tmp_view=$(mktemp -d "$XDG_RUNTIME_DIR/aurutils/view.XXXXXXXX") || exit
 trap 'trap_exit' EXIT
 
 # Directory for git checksums (revisions viewed by the user, #379)


### PR DESCRIPTION
With miller column file managers (in particular, ranger), saving the directory with symlinked build files in `TMPDIR` caused a lot of irrelevant files to appear in the left-most column. Using `XDG_DATA_HOME` allows to use this left-most column to switch to viewed revisions in `XDG_DATA_HOME/aurutils/view`.

To avoid conflicts, the parent process ID is suffixed to the directory name.

Later commits may move this directory (and possibly additional symlinks to directories in `XDG_DATA_HOME/aurutils/view`) to the more suitable `XDG_RUNTIME_DIR`.

Before:
![Before](https://imgur.com/RmpSnU7.png)

After:
![After](https://imgur.com/ugghxTf.png)