### PR TITLE
aur-sync: actually use all provides

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -12,7 +12,7 @@ startdir=$(pwd -P)
 directory=/var/lib/aurbuild/$machine
 makechrootpkg_args=(-c) # sync /root container to /$USER copy
 makepkg_conf=/usr/share/devtools/makepkg-$machine.conf
-prefix=extra
+suffix=extra
 
 # default options
 update=0 build=0 packagelist=0
@@ -29,7 +29,7 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='C:D:M:BU'
 opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'build' 'update'
-          'prefix:' 'bind:' 'bind-rw:' 'packagelist' 'buildscript:')
+          'suffix:' 'bind:' 'bind-rw:' 'packagelist' 'buildscript:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -48,8 +48,8 @@ while true; do
             shift; buildscript=$1 ;;
         --packagelist)
             packagelist=1 ;;
-        --prefix)
-            shift; prefix=$1 ;;
+        --suffix)
+            shift; suffix=$1 ;;
         # arch-nspawn options
         -C|--pacman-conf)
             shift; pacman_conf=$1 ;;
@@ -78,13 +78,13 @@ if (( $# )); then
 fi
 
 # base container configuration
-case $prefix in
+case $suffix in
     multilib*)
         base_packages=('multilib-devel') ;;
     *)
         base_packages=('base-devel') ;;
 esac
-pacman_conf=${pacman_conf:-/usr/share/devtools/pacman-$prefix.conf}
+pacman_conf=${pacman_conf:-/usr/share/devtools/pacman-$suffix.conf}
 
 if [[ ! -r $pacman_conf ]]; then
     printf >&2 '%s: config file %q could not be read\n' "$argv0" "$pacman_conf"

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -309,7 +309,7 @@ cut -f2 --complement depends | sort -u >pkginfo
   if (( ${#repo_p[@]} )); then
       cut -f1 pkginfo | complement argv | aur-repo-filter "${repo_p[@]/#/--database=}"
   elif (( provides )); then
-      cut -f1 pkginfo | complement argv | aur repo-filter
+      cut -f1 pkginfo | complement argv | aur repo-filter --sync
   fi
 } >filter
 

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,4 +1,4 @@
-## 3.0.0
+## 3.0.0 - 2020-10-26
 
 * `aur`
   + add `AUR_EXEC_PATH` environment variable
@@ -16,6 +16,7 @@
     - specify common `makepkg` options as `aur-build` arguments (`--syncdeps`, `--rmdeps`, `--ignorearch`, `--log`, `--noconfirm`)
     - pass `--syncdeps`, `--rmdeps` to `--pkgver` makepkg command (#716)
     - make `-r` an alias for `--rmdeps` (was: alias for `--root`)
+    - make `-S` an alias for `--sign` (was: `-s`)
   + use `--margs` to set makepkg options instead of EOF seperator (`--`)
   + `--makepkg-conf` now sets the makepkg configuration for host builds (avoid quoting issues with setting `--config` in `--margs`)
   + use `makepkg --noextract` if `--pkgver` is specified (#708)
@@ -46,7 +47,7 @@
   + exit `1` if `git clone` or `git fetch` failed
   + remove support for `tar` archives
   + remove diff output (`--log-dir`, `--verbose`, `--format`)
-    - diffs can be generated from the extended --results output (done in `aur-sync`)      
+    - diffs can be generated from the extended --results output (done in `aur-sync`)
   + remove setting `orderfile` (done in `aur-sync`)
   + use `git -C` for `git` calls
 
@@ -93,7 +94,7 @@
   + add `--jobs`
   + do not use `makepkg --log`
   + remove `parallel` dependency
-  
+
 * `aur-sync`
   + add `AUR_DEBUG`, `NO_COLOR`, `AUR_CONFIRM_PAGER` environment variables
     - use confirmation prompt after package review if `AUR_CONFIRM_PAGER` is set
@@ -115,9 +116,21 @@
 
 * `aur-vercmp`
   + add `AUR_DEBUG`, `NO_COLOR` environment variables
-  
+
 * `Makefile`
   + allow overriding `AUR_LIB_DIR` at build time
+
+## 2.3.7
+
+## 2.3.6
+
+## 2.3.5
+
+## 2.3.4
+
+## 2.3.3
+
+## 2.3.2
 
 ## 2.3.1 - 2019-02-21
 
@@ -149,7 +162,7 @@
 * `completions`
   + group options by type (#520)
   + complete `aur-depends` options (#526)
-  
+
 ## 2.2.1 - 2019-01-25
 
 * `aur-build`

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -80,7 +80,7 @@ Do not present build files for inspection.
 .BR \-\-noprovides ", " \-\-no\-provides
 Do not take virtual dependencies
 .RB ( provides )
-in pacman sync repository into account. Packages specified on the
+in pacman sync repositories into account. Packages specified on the
 command line or available upgrades are taken as target regardless of
 this setting.
 .


### PR DESCRIPTION
* `aur repo-filter` was run without arguments, limiting the output to the official repositories. Add `--sync` to address this issue.
* `aur chroot` was still using `--prefix`.