### PR TITLE
Fix broken zsh completion due to unwanted newline

### DIFF
--- a/completions/zsh/aurutils.in
+++ b/completions/zsh/aurutils.in
@@ -18,7 +18,6 @@ cat <<'EOF'
     _arguments -C \
         '1: :(${(k)default_cmds})' \
         '2: :(${(@s/ /)default_cmds[${words[2]}]})' \
-
         '*: :->options'
 
     case $state in


### PR DESCRIPTION
The fix for aur repo completion done in
63641ea (completion: fix broken completion for aur repo, 2020-05-08)
introduced an extraneous newline in the zsh version,
effectively breaking it.

Remove the unwanted newline.

Closes #776