### PR TITLE
aur-chroot: add --create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PREFIX ?= /usr
 SHRDIR ?= $(PREFIX)/share
 BINDIR ?= $(PREFIX)/bin
 LIBDIR ?= $(PREFIX)/lib
+ETCDIR ?= /etc
 AURUTILS_LIB_DIR ?= $(LIBDIR)/$(PROGNM)
 
 .PHONY: shellcheck install build completion aur
@@ -26,4 +27,5 @@ install: install-aur
 	@install -Dm644 man1/*    -t '$(DESTDIR)$(SHRDIR)/man/man1'
 	@install -Dm644 man7/*    -t '$(DESTDIR)$(SHRDIR)/man/man7'
 	@install -Dm644 LICENSE   -t '$(DESTDIR)$(SHRDIR)/licenses/$(PROGNM)'
+	@install -dm755 aurutils '$(DESTDIR)$(ETCDIR)/$(PROGNM)'
 	@$(MAKE) -C completions DESTDIR='$(DESTDIR)' install-bash install-zsh

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -17,7 +17,6 @@ chroot_args=() pacconf_args=() repo_add_args=() makepkg_args=() makechrootpkg_ma
 # default arguments
 gpg_args=(--detach-sign --no-armor --batch)
 makechrootpkg_args=(-c -u)
-suffix=aur
 
 db_replaces() {
     bsdcat "$1" | awk '
@@ -69,11 +68,11 @@ fi
 opt_short='a:d:D:U:AcCfnrsvLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:'
           'sign' 'verify' 'directory:' 'no-sync' 'config:'
-          'pacman-conf:' 'results:' 'remove' 'pkgver' 'suffix:'
-          'rmdeps' 'no-confirm' 'ignore-arch' 'log' 'new'
-          'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade'
-          'temp' 'syncdeps' 'clean' 'namcap' 'checkpkg' 'user:'
-          'makepkg-args:' 'buildscript:')
+          'pacman-conf:' 'results:' 'remove' 'pkgver' 'rmdeps'
+          'no-confirm' 'ignore-arch' 'log' 'new' 'makepkg-conf:'
+          'bind:' 'bind-rw:' 'prevent-downgrade' 'temp' 'syncdeps'
+          'clean' 'namcap' 'checkpkg' 'user:' 'makepkg-args:'
+          'buildscript:')
 opt_hidden=('dump-options' 'gpg-sign' 'ignorearch' 'noconfirm' 'nosync' 'margs:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -117,8 +116,6 @@ while true; do
             shift; makechrootpkg_args+=(-d"$1") ;;
         --pacman-conf)
             shift; pacman_conf=$1 ;;
-        --suffix)
-            shift; suffix=$1 ;;
         -N|--namcap)
             makechrootpkg_args+=(-n) ;;
         --checkpkg)
@@ -230,8 +227,7 @@ if (( chroot )); then
     if [[ -v pacman_conf ]]; then
         chroot_args+=(--pacman-conf "$pacman_conf")
     else
-        # Defaults to /usr/share/devtools/pacman-<suffix>.conf
-        chroot_args+=(--suffix "$suffix")
+        chroot_args+=(--pacman-conf "/etc/aurutils/pacman-$db_name.conf")
     fi
 
     # makepkg --packagelist includes the package extension, but

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -240,6 +240,7 @@ if (( chroot )); then
     # Update pacman and makepkg configuration for the chroot build
     # queue. A full system upgrade is run on the /root container to
     # avoid lenghty upgrades for makechrootpkg -u.
+    run_msg aur chroot --create "${chroot_args[@]}"
     run_msg aur chroot --update "${chroot_args[@]}"
 else
     # Use libmakepkg to avoid a performance hit from linting the

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -10,15 +10,18 @@ startdir=$(pwd -P)
 
 # default arguments
 directory=/var/lib/aurbuild/$machine
-makechrootpkg_args=(-c) # sync /root container to /$USER copy
-makepkg_conf=/usr/share/devtools/makepkg-$machine.conf
 suffix=extra
 
 # default options
-update=0 build=0 packagelist=0
+update=0 build=0 packagelist=0 create=0
 
 usage() {
-    printf >&2 'usage: %s [-BU] [-CDM path] -- <makechrootpkg args>\n' "$argv0"
+    cat <<EOF
+Usage:
+  $argv0 [-BU] [-CDM path] -- <makechrootpkg args>
+  $argv0 --create [-CDM path] [package...]
+  $argv0 --packagelist [-D path]
+EOF
     exit 1
 }
 
@@ -27,9 +30,10 @@ source /usr/share/makepkg/util/option.sh
 source /usr/share/makepkg/util/pkgbuild.sh
 source /usr/share/makepkg/util/parseopts.sh
 
-opt_short='C:D:M:BU'
+opt_short='C:D:M:x:BU'
 opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'build' 'update'
-          'suffix:' 'bind:' 'bind-rw:' 'packagelist' 'buildscript:')
+          'create' 'suffix:' 'bind:' 'bind-rw:' 'packagelist'
+          'buildscript:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -37,7 +41,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset bindmounts_ro bindmounts_rw buildscript pacman_conf
+unset bindmounts_ro bindmounts_rw buildscript makepkg_conf pacman_conf
 while true; do
     case "$1" in
         -B|--build)
@@ -48,16 +52,17 @@ while true; do
             shift; buildscript=$1 ;;
         --packagelist)
             packagelist=1 ;;
-        --suffix)
+        --create)
+            create=1 ;;
+        -x|--suffix)
             shift; suffix=$1 ;;
-        # arch-nspawn options
+        # devtools options
         -C|--pacman-conf)
             shift; pacman_conf=$1 ;;
         -D|--directory)
             shift; directory=$1 ;;
         -M|--makepkg-conf)
             shift; makepkg_conf=$1 ;;
-        # makechrootpkg options
         --bind)
             shift; bindmounts_ro+=("$1") ;;
         --bind-rw)
@@ -72,46 +77,54 @@ while true; do
     shift
 done
 
-# Reset makechrootpkg command-line if specified
-if (( $# )); then
-    makechrootpkg_args=("$@")
+# required for chroot creation and update
+makepkg_conf=${makepkg_conf:-/usr/share/devtools/makepkg-$machine.conf}
+
+if [[ ! -f $makepkg_conf ]]; then
+    printf >&2 '%s: %q is not a file\n' "$argv0" "$makepkg_conf"
+    exit 2
+elif [[ ! -r $makepkg_conf ]]; then
+    printf >&2 '%s: %q could not be read\n' "$argv0" "$makepkg_conf"
+    exit 1
 fi
 
-# base container configuration
-case $suffix in
-    multilib*)
-        base_packages=('multilib-devel') ;;
-    *)
-        base_packages=('base-devel') ;;
-esac
+# required for chroot creation and update
 pacman_conf=${pacman_conf:-/usr/share/devtools/pacman-$suffix.conf}
 
-if [[ ! -r $pacman_conf ]]; then
-    printf >&2 '%s: config file %q could not be read\n' "$argv0" "$pacman_conf"
-    exit 1
-elif [[ ! -r $makepkg_conf ]]; then
-    printf >&2 '%s: config file %q could not be read\n' "$argv0" "$makepkg_conf"
+if [[ ! -f $pacman_conf ]]; then
+    printf >&2 '%s: %q is not a file\n' "$argv0" "$pacman_conf"
+    exit 2
+elif [[ ! -r $pacman_conf ]]; then
+    printf >&2 '%s: %q could not be read\n' "$argv0" "$pacman_conf"
     exit 1
 fi
 
 # bind mount file:// paths to container (#461)
+# required for update/build steps
 while read -r key _ value; do
     case $key=$value in
         Server=file://*)
             bindmounts_rw+=("${value#file://}") ;;
     esac
 done < <(pacman-conf --config "$pacman_conf")
+wait $!
 
-if (( packagelist )); then
-    ( load_makepkg_config "$makepkg_conf"
-      source_safe "${buildscript-PKGBUILD}"
+# create new container, required for packagelist/update/build steps
+if (( create )); then
+    # default to base-devel or multilib-devel, unless packages are
+    # specified on the command-line.
+    # available packages depend on the configured pacman configuration
+    if (( $# )); then
+        base_packages=("$@")
 
-      PKGDEST="${PKGDEST:-$startdir}" print_all_package_names
-    )
-    exit $?
-fi
+    # XXX: use pacini to not process Include directives in pacman.conf
+    # (not supported by devtools)
+    elif [[ $(pacini --section=multilib "$pacman_conf") ]] && [[ $machine == "x86_64" ]]; then
+        base_packages=('multilib-devel')
+    else
+        base_packages=('base-devel')
+    fi
 
-if (( update )); then
     # parent path is not created by mkarchroot (#371)
     if [[ ! -d $directory ]]; then
         sudo install -d "$directory" -m 755 -v
@@ -121,6 +134,32 @@ if (( update )); then
         sudo mkarchroot -C "$pacman_conf" -M "$makepkg_conf" \
              "$directory"/root "${base_packages[@]}"
     fi
+    exit $?
+fi
+
+# use libmakepkg to print full package names
+if (( packagelist )); then
+    if [[ ! -r $directory/root/etc/makepkg.conf ]]; then
+        printf >&2 '%s --packagelist: %q: could not be read\n' "$argv0" "$directory"/root/etc/makepkg.conf
+        exit 1
+    fi
+
+    ( load_makepkg_config "$directory"/root/etc/makepkg.conf
+      source_safe "${buildscript-PKGBUILD}"
+
+      PKGDEST="${PKGDEST:-$startdir}" print_all_package_names
+    )
+    exit $?
+fi
+
+if (( update )); then
+    # arch-nspawn makes no distinction between a missing working directory
+    # and one which does not exist
+    if [[ ! -d $directory/root ]]; then
+        printf >&2 '%s: %q is not a directory\n' "$argv0" "$directory"/root
+        printf >&2 '%s: did you run aur chroot --create?\n' "$argv0"
+        exit 20
+    fi    
 
     # locking is done by systemd-nspawn
     sudo arch-nspawn -C "$pacman_conf" -M "$makepkg_conf" "$directory"/root \
@@ -129,9 +168,11 @@ if (( update )); then
 fi
 
 if (( build )); then
+    # use makechrootpkg -c as default build command (sync /root container)
+    # arguments after -- (if present) are used as makechrootpkg arguments
     sudo --preserve-env=GNUPGHOME,PKGDEST makechrootpkg -r "$directory" \
          "${bindmounts_ro[@]/#/-D}" \
-         "${bindmounts_rw[@]/#/-d}" "${makechrootpkg_args[@]}"
+         "${bindmounts_rw[@]/#/-d}" "${@:--c}"
 fi
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -96,7 +96,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'no-view' 'no-provides' 'no-build' 'rm-deps' 'sign' 'temp' 'upgrades'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
-          'results:' 'makepkg-args:' 'format:' 'config:' 'suffix:')
+          'results:' 'makepkg-args:' 'format:' 'config:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign' 'margs:')
@@ -169,8 +169,6 @@ while true; do
             shift; build_args+=(--results "$1") ;;
         -S|--sign|--gpg-sign)
             build_args+=(--sign) ;;
-        --suffix)
-            shift; build_args+=(--suffix "$1") ;;
         # build options (devtools)
         -D|--directory)
             shift; build_args+=(--directory "$1") ;;

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -61,12 +61,12 @@ The prerequisites for this option are that the
 package is installed, and the a
 .BR pacman (8)
 configuration for the container is placed in
-.BI /usr/share/devtools/pacman \-aur.conf \fR.
+.BI /etc/aurutils/pacman-<database>.conf \fR
+where <database> is specified with
+.BR \-\-database .
 A different location can be chosen with the
 .BR \-\-pacman\-conf
-or
-.BR \-\-suffix
-options.
+option.
 .RE
 .
 .TP
@@ -220,16 +220,6 @@ The
 .BR pacman.conf (5)
 file used inside the container.
 .RB ( aur\-chroot " " \-\-pacman\-conf )
-.
-.TP
-.BI \-\-suffix= SUFFIX
-The path component
-.B <suffix>
-in the pacman configuration
-.BR /usr/share/devtools/pacman\-<suffix>.conf .
-.RB ( aur\-chroot " " \-\-suffix )
-Defaults to
-.BR aur .
 .
 .SS makepkg options
 Additional options may be passed to

--- a/man1/aur-chroot.1
+++ b/man1/aur-chroot.1
@@ -1,41 +1,81 @@
-.TH AUR-CHROOT 2020-10-12 AURUTILS
+.TH AUR-CHROOT 2020-11-01 AURUTILS
 .SH NAME
-aur\-chroot \- build packages with systemd-nspawn
+aur\-chroot \- build pacman packages with systemd-nspawn
 .
 .SH SYNOPSIS
 .SY "aur chroot"
+.OP \-\-build
+.OP \-\-update
 .OP \-D directory
 .OP \-C pacman_conf
 .OP \-M makepkg_conf
-.OP \-\-build
-.OP \-\-update
-.OP \-\-packagelist
-.OP \-\-suffix
 .OP \-\-
 .RI [ "makechrootpkg args" ]
+.
+.SY "aur chroot"
+.OP \-\-create
+.OP \-D directory
+.OP \-C pacman_conf
+.OP \-M makepkg_conf
+.RI [ "package..." ]
+.
+.SY "aur chroot"
+.OP \-\-packagelist
+.OP \-D directory
 .YS
 .
 .SH DESCRIPTION
-Build packages inside a
+Build
+.BR pacman (8)
+packages inside a
 .BR systemd\-nspawn (1)
 container.
 .
-.SH OPTIONS
-All arguments after
+.SH OPERATIONS
+.TP
+.BR \-B ", " \-\-build
+Build a package inside the container. Arguments after
 .B \-\-
 are passed to
 .BR makechrootpkg .
-.
-.TP
-.BR \-B ", " \-\-build
-Build a package inside the container.
+If none are specified,
+.B makechrootpkg \-c
+is run.
 .
 .TP
 .BR \-U ", " \-\-update
 Update or create the
 .B /root
-copy of the container.
+copy of the container with
+.BR arch\-nspawn .
 .
+.TP
+.BR \-\-create
+Create a new container with
+.BR mkarchroot .
+.IP
+By default,
+.B base\-devel
+or
+.B multilib\-devel
+are installed to the container, depending if the host architecture is
+.B x86_64
+and
+.B [multilib]
+is set in the pacman configuration. (see
+.BR \-\-pacman\-conf )
+If packages or package groups are listed on the command-line, these
+are installed instead.
+.
+.TP
+.B \-\-packagelist
+List the package filenames that would be produced without
+building using the
+.BR makepkg.conf (5)
+file inside the container. (see
+.BR \-\-makepkg\-conf )
+.
+.SH OPTIONS
 .TP
 .BI \-D " DIR" "\fR,\fP \-\-directory=" DIR
 The base directory for containers. This directory usually contains a
@@ -61,11 +101,12 @@ The
 file used inside the container. Defaults to
 .IR /usr/share/devtools/pacman\-extra.conf .
 .IP
-This file is processed with
+This file is read with
 .B pacman\-conf
-to bind-mount listed
+to retrieve listed
 .B file://
-repositories.
+repositories for bind mounting. (see
+.BR "Accessing a local repository")
 .
 .TP
 .BI \-M " FILE" "\fR,\fP \-\-makepkg\-conf=" FILE
@@ -73,6 +114,17 @@ The
 .BR makepkg.conf (5)
 file used inside the container. Defaults to devtools'
 .IR makepkg\-<machine>.conf .
+.
+.TP
+.BR \-x ", " \-\-suffix
+The path component
+.B <suffix>
+in the pacman configuration
+.BR /usr/share/devtools/pacman\-<suffix>.conf .
+Defaults to
+.BR extra .
+A full path may be specified with
+.BR \-\-pacman\-conf .
 .
 .TP
 .B \-\-bind
@@ -84,30 +136,15 @@ Bind a directory read-only to the container.
 Bind a directory read-write to the container.
 .RB ( makechrootpkg " " \-d )
 .
-.TP
-.B \-\-packagelist
-List the package filenames that would be produced without
-building using the
-.BR makepkg.conf (5)
-file specified with
-.BR \-\-makepkg\-conf .
-.
-.TP
-.B \-\-suffix
-The path component
-.B <suffix>
-in the pacman configuration
-.BR /usr/share/devtools/pacman\-<suffix>.conf .
-Defaults to
-.BR extra .
-.
 .SH ENVIRONMENT
-Packages are placed in the directory specified in
+Packages are placed in the directory set in
 .BR PKGDEST .
 If unset, the current directory
 .RB ( $PWD )
 is used. See also
-.BR makepkg.conf (5).
+.BR makepkg.conf (5)
+and
+.BR "makechrootpkg \-h" .
 .
 .SH NOTES
 .SS Building with makechrootpkg
@@ -134,8 +171,20 @@ To install packages from the local repository (for example, on
 dependency resolution with
 .BR "makepkg \-s" ,
 the container requires read access to the host directory where it is
-located. This is ensured through a
+located. This is ensured through a (read-write)
 .IR "bind mount" .
+In particular, paths to
+.B file://
+repositories are passed to
+.B arch\-nspawn
+and
+.B makechrootpkg
+with
+.BR \-\-bind
+and
+.BR \-d ,
+respectively.
+.PP
 .
 .SS Avoiding password prompts
 .BR makepkg (8)
@@ -159,14 +208,15 @@ user, create the following sudoers policy:
   archie ALL = (root) NOPASSWD: /usr/bin/mkarchroot, /usr/bin/arch-nspawn
 
 .EE
-.SY Note:
 Should the rule only apply to specific hosts, replace
 .B ALL
 with the respective
 .IR hostname .
-
+.
 .SS Using ccache and distcc
-As in the example above, install the required packages:
+As in
+.BR "Building with makechrootpkg" ,
+install the required packages:
 .EX
 
   # arch-nspawn /var/lib/aurbuild/root pacman \-S ccache distcc
@@ -192,7 +242,7 @@ To build packages for a different architecture, prepend
 to the
 .B aur\-build
 command line.
-.
+.PP
 The target architecture must be supported both by the host (run
 .B "setarch \-\-list"
 for an approximation), and have a matching
@@ -203,11 +253,12 @@ file available in
 .I /usr/share/devtools/makepkg\-i686.conf
 for
 .IR i686 ).
-.TP
-.B Note:
+.PP
 Building for other CPU architectures may be done through
-QEMU, for example with
-.BR proot (1).
+QEMU user mode. See
+.UR https://www.qemu.org/docs/master/user/index.html
+.UE
+for details.
 .
 .SH SEE ALSO
 .BR aur (1),


### PR DESCRIPTION
Yet another rewrite of `aur-chroot`... 

* Set the default `pacman.conf` for `aur-build --chroot` to `/etc/aurutils/pacman-<db>.conf`. To accommodate this, the `Makefile` creates `$(PREFIX)/etc/aurutils`. Users will no longer have to write their config in `/usr/share` and can use a `pacman.conf` per local repository with no additional effort (apart from specifying the repository with `-d` or `AUR_REPO`).

* Create containers with `aur chroot --create`, and allow to specify the target packages on the command-line. This way all required packages can be specified in one step, e.g. to include `ccache` in the container. This additional step is only required when using `aur chroot` directly, or if other packages than `base-devel` or `multilib-devel` are required; `aur build` runs `aur chroot --create` on each `--chroot` build. (This is possible because `aur-chroot` only runs `mkarchroot` if there is no existing container in the target path, which still defaults to `/var/lib/aurbuild/<arch>`.)