### PR TITLE
aur-chroot: add base-devel to multilib container

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -120,7 +120,7 @@ if (( create )); then
     # XXX: use pacini to not process Include directives in pacman.conf
     # (not supported by devtools)
     elif [[ $(pacini --section=multilib "$pacman_conf") ]] && [[ $machine == "x86_64" ]]; then
-        base_packages=('multilib-devel')
+        base_packages=('base-devel' 'multilib-devel')
     else
         base_packages=('base-devel')
     fi


### PR DESCRIPTION
[`multilib-devel`](https://www.archlinux.org/groups/x86_64/multilib-devel/) group is pretty small and does not constitute a usable container. It is intended to be installed on top of regular `base-devel`. Relevant devtools code: https://github.com/archlinux/devtools/blob/20200407/archbuild.in#L7-L14