### PR TITLE
aur-sync: add --provides-deep

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -6,7 +6,6 @@ argv0=sync
 XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
-XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$UID}
 AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
@@ -19,7 +18,7 @@ log_fmt='diff'
 build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1
 
 # default options (disabled)
-rotate=0 update=0 repo_targets=0
+rotate=0 update=0 repo_targets=0 provides_deep=0
 
 lib32() {
     awk -v arch="$(uname -m)" '{
@@ -96,7 +95,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'no-view' 'no-provides' 'no-build' 'rm-deps' 'sign' 'temp' 'upgrades'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
-          'results:' 'makepkg-args:' 'format:' 'config:')
+          'results:' 'makepkg-args:' 'format:' 'config:' 'provides-deep')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign' 'margs:')
@@ -135,7 +134,11 @@ while true; do
             provides=0 ;;
         --provides-from)
             shift; IFS=, read -a repo -r <<< "$1"
-            repo_p+=("${repo[@]}") ;;
+            repo_p+=("${repo[@]}")
+            provides=1 ;;
+        --provides-deep)
+            provides_deep=1
+            provides=1 ;;
         --rebuild)
             build_args+=(-f); chkver_depth=1 ;;
         --rebuildtree|--rebuild-tree)
@@ -307,11 +310,27 @@ cut -f2 --complement depends | sort -u >pkginfo
       esac
   fi
 
-  # Note: this uses pacman's copy of the repo (as used by makepkg -s)
-  if (( ${#repo_p[@]} )); then
-      cut -f1 pkginfo | complement argv | aur-repo-filter "${repo_p[@]/#/--database=}"
-  elif (( provides )); then
-      cut -f1 pkginfo | complement argv | aur repo-filter --sync
+  if (( provides )); then
+      # Note: this uses pacman's copy of the repo (as used by makepkg -s)
+      provs() {
+          cut -f1 pkginfo | aur repo-filter "$@"
+      }
+
+      if (( ${#repo_p[@]} )); then
+          sift_args=("${repo_p[@]/#/--repo=}")
+      else
+          sift_args=(--sync)
+      fi
+
+      # Filter transitive dependencies (#592)
+      if (( provides_deep )); then
+          provs "${sift_args[@]}" | while IFS= read -r virt; do
+              awk -v v="^$virt$" '$1 ~ v { print $2 }' depends
+          done | grep -Fxf <(cut -f1 depends)
+      else
+          provs "${sift_args[@]}"
+      fi | complement argv # cmd arguments may appear anywhere in the
+                           # dependency graph; take complement lastly
   fi
 } >filter
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -18,7 +18,7 @@ log_fmt='diff'
 build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1
 
 # default options (disabled)
-rotate=0 update=0 repo_targets=0 provides_deep=0
+rotate=0 update=0 repo_targets=0
 
 lib32() {
     awk -v arch="$(uname -m)" '{
@@ -121,7 +121,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'no-view' 'no-provides' 'no-build' 'rm-deps' 'sign' 'temp' 'upgrades'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
-          'results:' 'makepkg-args:' 'format:' 'config:' 'provides-deep')
+          'results:' 'makepkg-args:' 'format:' 'config:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign' 'margs:')
@@ -161,9 +161,6 @@ while true; do
         --provides-from)
             shift; IFS=, read -a repo -r <<< "$1"
             repo_p+=("${repo[@]}")
-            provides=1 ;;
-        --provides-deep)
-            provides_deep=1
             provides=1 ;;
         --rebuild)
             build_args+=(-f); chkver_depth=1 ;;
@@ -341,22 +338,16 @@ cut -f2 --complement depends | sort -u >pkginfo
       provs() {
           cut -f1 pkginfo | aur repo-filter "$@"
       }
-
       if (( ${#repo_p[@]} )); then
-          sift_args=("${repo_p[@]/#/--repo=}")
+          provs_args=("${repo_p[@]/#/--repo=}")
       else
-          sift_args=(--sync)
+          provs_args=(--sync)
       fi
 
       # Filter transitive dependencies (#592)
-      if (( provides_deep )); then
-          provs "${sift_args[@]}" | while IFS= read -r virt; do
-              select_transitive_deps "$virt" depends
-          done
-      else
-          provs "${sift_args[@]}"
-      fi | complement argv # cmd arguments may appear anywhere in the
-                           # dependency graph; take complement lastly
+      provs "${provs_args[@]}" | while IFS= read -r virt; do
+          select_transitive_deps "$virt" depends
+      done | complement argv
   fi
 } >filter
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -49,6 +49,32 @@ select_pkgbase() {
     }' "$@"
 }
 
+# files: $2 pkgname\tdepends
+select_transitive_deps() {
+    awk -v pat="^$1$" -v virt="$1" '
+        $1 {
+            ++pkg_counts[$1]
+        }
+        $1 ~ pat {
+            pkg_deps[$1, ++dep_counts[$1]] = $2
+        }
+        END {
+            for (d = 1; d <= dep_counts[virt]; d++) {
+                p = pkg_deps[virt, d]
+
+                if (p in pkg_counts && p != virt) {
+                    printf("%s transitive dependency of %s\n",
+                           pkg_deps[virt, d], virt) > "/dev/stderr"
+                    printf("%s\n", pkg_deps[virt, d])
+                } else if (p in pkg_counts) {
+                    printf("%s\n", pkg_deps[virt, d])
+                }
+            }
+            close("/dev/stderr")
+        }
+    ' "$2"
+}
+
 # fields: $1 pkgname, $2 depends[<>=]
 tr_ver() {
     awk -F'[<>=]' '{print $1}'
@@ -325,8 +351,8 @@ cut -f2 --complement depends | sort -u >pkginfo
       # Filter transitive dependencies (#592)
       if (( provides_deep )); then
           provs "${sift_args[@]}" | while IFS= read -r virt; do
-              awk -v v="^$virt$" '$1 ~ v { print $2 }' depends
-          done | grep -Fxf <(cut -f1 depends)
+              select_transitive_deps "$virt" depends
+          done
       else
           provs "${sift_args[@]}"
       fi | complement argv # cmd arguments may appear anywhere in the

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -242,7 +242,7 @@ if (( rotate )); then
     fi
 fi
 
-if ! (( $# + update + repo_targets )); then
+if (( $# + update + repo_targets == 0 )); then
     error '%s: no targets specified' "$argv0"
     exit 1
 fi

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,8 @@
+## 3.2.0
+
+* `aur-sync`
+  + Take transitive dependencies into account (#592)
+
 ## 3.1.2 - 2020-11-09
 
 This releases fixes a regression in 3.1.1 where `AUR_LIB_DIR` was not

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -101,25 +101,16 @@ as targets. May be used together with
 to repopulate source directories in
 .BR $AURDEST .
 .
-.SS Dependency options
-By default, virtual dependencies
+.TP
+.BR \-\-noprovides ", " \-\-no\-provides
+Do not take virtual dependencies
 .RB ( provides )
 in pacman
 .I sync
-repositories are taken into account when resolving
-package dependencies. If packages are specified on the command-line or
-available as an upgrade
+repositories into account to resolve package dependencies.  Packages
+specified on the command-line or available as an upgrade
 .RB ( "aur\-sync \-u" ),
-they are taken as target regardless of the settings below.
-.
-.TP
-.BR \-\-noprovides ", " \-\-no\-provides
-Disable checking of virtual dependencies.
-.
-.TP
-.B \-\-provides\-deep
-Include transitive dependencies when checking virtual
-dependencies.
+are taken as targets regardless of this setting.
 .
 .TP
 .BI \-\-provides\-from= DIR1,...
@@ -133,6 +124,9 @@ is equivalent to
 .IR \-\-provides\-from=b,a )
 and dependencies are installed according to the order defined in
 .BR pacman.conf (5).
+Packages specified on the command-line or available as an upgrade
+.B ( "aur\-sync \-u" ),
+are taken as targets regardless of this setting.
 .
 .SS Database options
 Values for the following options are automatically selected, if a

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -77,23 +77,6 @@ Version checks for package dependencies remain enabled.
 Do not present build files for inspection.
 .
 .TP
-.BR \-\-noprovides ", " \-\-no\-provides
-Do not take virtual dependencies
-.RB ( provides )
-in pacman sync repositories into account. Packages specified on the
-command line or available upgrades are taken as target regardless of
-this setting.
-.
-.TP
-.BI \-\-provides\-from= DIR1,...
-Only take specified (comma-separated) repositories into acount for
-virtual dependencies. If the same package is provided in multiple
-repositories, ordering is ignored (for example, \-\-provides\-from=a,b
-is equivalent to \-\-provides\-from=b,a) and dependencies are
-installed according to the order defined in
-.BR pacman.conf (5).
-.
-.TP
 .BR \-u ", " \-\-upgrades
 Update all obsolete AUR packages in a local repository.
 .
@@ -117,6 +100,39 @@ as targets. May be used together with
 .B \-o
 to repopulate source directories in
 .BR $AURDEST .
+.
+.SS Dependency options
+By default, virtual dependencies
+.RB ( provides )
+in pacman
+.I sync
+repositories are taken into account when resolving
+package dependencies. If packages are specified on the command-line or
+available as an upgrade
+.RB ( "aur\-sync \-u" ),
+they are taken as target regardless of the settings below.
+.
+.TP
+.BR \-\-noprovides ", " \-\-no\-provides
+Disable checking of virtual dependencies.
+.
+.TP
+.B \-\-provides\-deep
+Include transitive dependencies when checking virtual
+dependencies.
+.
+.TP
+.BI \-\-provides\-from= DIR1,...
+Only take specified (comma-separated)
+.BR pacman (8)
+repositories into account when checking virtual dependencies. If the
+same package is provided in multiple repositories, ordering is ignored
+(for example,
+.I \-\-provides\-from=a,b
+is equivalent to
+.IR \-\-provides\-from=b,a )
+and dependencies are installed according to the order defined in
+.BR pacman.conf (5).
 .
 .SS Database options
 Values for the following options are automatically selected, if a


### PR DESCRIPTION
Allows to take transitive dependencies into account.

Fixes #592