### PR TITLE
aur-repo: set repository extension with AUR_DBEXT

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -12,7 +12,7 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0
 
 # default arguments (empty)
-chroot_args=() pacconf_args=() repo_add_args=() makepkg_args=() makechrootpkg_makepkg_args=() makepkg_common_args=()
+chroot_args=() pacconf_args=() repo_add_args=() repo_args=() makepkg_args=() makechrootpkg_makepkg_args=() makepkg_common_args=()
 
 # default arguments
 gpg_args=(--detach-sign --no-armor --batch)
@@ -91,12 +91,13 @@ while true; do
         -c|--chroot)
             chroot=1 ;;
         -d|--database|--repo)
-            shift; db_name=$1 ;;
-        --config)
-            shift; pacconf_args+=(--config "$1") ;;
+            shift; db_name=$1
+            repo_args+=(--repo "$1") ;;
         --buildscript)
             shift; buildscript=$1
             makepkg_common_args+=(-p "$1") ;;
+        --config)
+            shift; pacconf_args+=(--config "$1") ;;
         --nosync|--no-sync)
             no_sync=1 ;;
         --pkgver)
@@ -104,7 +105,8 @@ while true; do
         --results)
             shift; results_file=$1 ;;
         --root)
-            shift; db_root=$1 ;;
+            shift; db_root=$1
+            repo_args+=(--root "$1") ;;
         -S|--sign|--gpg-sign)
             sign_pkg=1; repo_add_args+=(-s) ;;
         # chroot options
@@ -175,36 +177,27 @@ var_tmp=$(mktemp -d --tmpdir="${TMPDIR:-/var/tmp/}" "aurutils-$UID/$argv0.XXXXXX
 trap 'trap_exit' EXIT
 trap 'exit' INT
 
-# Automatically choose repository root and name based on pacman
-# configuration and user environment.
-case ${db_name=$AUR_REPO} in
-    "")
-        case ${db_root=$AUR_DBROOT} in
-            "") db_path=$(aur repo "${pacconf_args[@]}" --path)
-                db_root=$(dirname "$db_path")
-                ;;
-             *) error '%s: root specified without database name' "$argv0"
-                exit 1 ;;
-        esac
+# assign environment variables
+: "${db_ext=$AUR_DBEXT}" "${db_root=$AUR_DBROOT}" "${db_repo=$AUR_REPO}"
 
-        # Strip archive file extension (tar.gz, #714)
-        db_name=$(basename "$db_path")
-        db_name=${db_name%.db*}
-        ;;
-    *)
-        case ${db_root=$AUR_DBROOT} in
-            "") db_path=$(aur repo "${pacconf_args[@]}" --path -d "$db_name")
-                db_root=$(dirname "$db_path")
-                ;;
-             *) db_path=$(readlink -f -- "$db_root/$db_name".db)
-                ;;
-        esac ;;
-esac
+if [[ $db_name ]] && [[ $db_root ]]; then
+    db_path=$db_name/$db_root.${db_ext:-db}
+    db_path=$(realpath -- "$db_path")
+else
+    # Automatically choose repository root and name based on pacman
+    # configuration and user environment.
+    { IFS=: read -r _ db_name
+      IFS=: read -r _ db_root
+      IFS=: read -r _ db_path
+    } < <(aur repo --status "${repo_args[@]}" "${pacconf_args[@]}")
+    wait $!
+fi
 
 # Resolve symbolic link to database.
 if ! [[ -f $db_path ]]; then
     error '%s: %s: no such file or directory' "$argv0" "$db_path"
     exit 2
+
 elif ! [[ -w $db_path ]]; then
     error '%s: %s: permission denied' "$argv0" "$db_path"
     exit 13

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -217,6 +217,7 @@ fi
 
 # Write successfully built packages to file (#437)
 if [[ -v results_file ]]; then
+    results_file=$(realpath -- "$results_file")
     : >"$results_file" # truncate file
 fi
 

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -75,6 +75,7 @@ if ! (( $# )); then
 fi
 
 if [[ -v results_file ]]; then
+    results_file=$(realpath -- "$results_file")
     : >"$results_file" || exit 1 # truncate file
 fi
 

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -207,6 +207,7 @@ case $db_query in
             exit 20
         fi
         db_path=$db_root/$db_name.${db_ext:-db}
+        db_path=$(realpath -- "$db_path") # resolve repo-add symlink
         ;;
     sync)
         db_path=$pacman_dbpath/sync/$db_name.${db_ext:-db}

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -5,7 +5,7 @@ argv0=repo
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
-db_query=local table_format=0 list_path=0
+db_query=local table_format=0
 
 # default arguments
 conf_args=()
@@ -81,7 +81,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset mode db_name db_root status_file pacman_conf vercmp_args
+unset mode list db_name db_root status_file pacman_conf vercmp_args
 while true; do
     case $1 in
         -d|--database|--repo)
@@ -91,7 +91,7 @@ while true; do
         -c|--config)
             shift; pacman_conf=$1 ;;
         -l|--list)
-            mode=packages ;;
+            mode=packages; table_format=0 ;;
         -t|--table)
             mode=packages; table_format=1 ;;
         -a|--all)
@@ -100,10 +100,10 @@ while true; do
             mode=upgrades; vercmp_args+=(-q) ;;
         -u|--upgrades)
             mode=upgrades ;;
-        --repo-list)
-            mode=repo_list ;;
         --path-list)
-            mode=repo_list; list_path=1 ;;
+            list=path ;;
+        --repo-list)
+            list=repo ;;
         --status)
             mode=status; status_file=/dev/fd/1 ;;
         --status-file)
@@ -137,8 +137,9 @@ while read -r key _ value; do
             ;;
         Server=file://*)
             server=${value#file://}
-            conf_file_serv+=("$server")
             conf_file_repo+=("$section")
+            conf_file_serv+=("$server")
+            conf_file_path+=("$server/$section.${db_ext:-db}")
 
             if [[ $section == "$db_name" ]]; then
                 if ! [[ $db_root ]]; then
@@ -156,29 +157,26 @@ while read -r key _ value; do
     esac
 done < <(pacman-conf "${conf_args[@]}")
 
-# exclusive modes
-case $mode in
-    repo_list)
+# list information on available local repositories
+case $list in
+    path|repo)
         if ! [[ ${conf_file_repo[*]} ]]; then
             printf >&2 '%s: no file:// repository configured\n' "$argv0"
             exit 2
         fi
-
-        if (( list_path )); then
-            paths=()
-            for i in "${!conf_file_repo[@]}"; do
-                paths+=("${conf_file_serv[$i]}/${conf_file_repo[$i]}.${db_ext:-db}")
-            done
-
-            readlink -f -- "${paths[@]}"
-        else
-            printf '%q\n' "${conf_file_repo[@]}"
-        fi
-
-        exit 0 ;;
+        ;;&
+    path)
+        realpath -- "${conf_file_path[@]}" # resolve repo-add symlink
+        exit 0
+        ;;
+    repo)
+        printf '%s\n' "${conf_file_repo[@]}"
+        exit 0
+        ;;
 esac
 
-# other modes
+# select local repository from pacman configuration, if no repository
+# was specified on the command-line
 if ! [[ $db_name ]]; then
     case ${#conf_file_repo[@]} in
         1) db_root=${conf_file_serv[0]}
@@ -189,8 +187,8 @@ if ! [[ $db_name ]]; then
            ;;
         *) printf >&2 '%s: repository choice is ambiguous (use -d to specify)\n' "$argv0"
            for i in "${!conf_file_repo[@]}"; do
-               printf '%q\t%q\n' "${conf_file_repo[$i]}" "${conf_file_serv[$i]}"
-           done | column -t >&2
+               printf '%q\t%q\n' "${conf_file_repo[$i]}" "${conf_file_path[$i]}"
+           done | column -d $'\t' -t >&2
            exit 1
            ;;
     esac

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -179,8 +179,7 @@ esac
 # was specified on the command-line
 if ! [[ $db_name ]]; then
     case ${#conf_file_repo[@]} in
-        1) db_root=${conf_file_serv[0]}
-           db_name=${conf_file_repo[0]}
+        1) db_name=${conf_file_repo[0]}
            ;;
         0) printf >&2 '%s: no file:// repository configured\n' "$argv0"
            exit 2

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -224,7 +224,7 @@ fi
 
 case $mode in
     upgrades)
-        db_table "$table_format" "$db_path" | aur vercmp "${vercmp_args[@]}"
+        db_table '0' "$db_path" | aur vercmp "${vercmp_args[@]}"
         ;;
     packages)
         db_table "$table_format" "$db_path"

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -124,11 +124,9 @@ if [[ -v pacman_conf ]]; then
 fi
 
 # assign environment variables
-: "${db_name=$AUR_REPO}"
-: "${db_root=$AUR_DBROOT}"
+: "${db_ext=$AUR_DBEXT}" "${db_name=$AUR_REPO}" "${db_root=$AUR_DBROOT}"
 
 unset conf_file_repo conf_file_serv server
-
 while read -r key _ value; do
     case $key=$value in
         \[*\]*)
@@ -169,7 +167,7 @@ case $mode in
         if (( list_path )); then
             paths=()
             for i in "${!conf_file_repo[@]}"; do
-                paths+=("${conf_file_serv[$i]}/${conf_file_repo[$i]}".db)
+                paths+=("${conf_file_serv[$i]}/${conf_file_repo[$i]}.${db_ext:-db}")
             done
 
             readlink -f -- "${paths[@]}"
@@ -198,13 +196,6 @@ if ! [[ $db_name ]]; then
     esac
 fi
 
-if [[ -v status_file ]]; then
-    { printf 'repo:%s\n' "$db_name"
-      printf 'root:%s\n' "$db_root"
-      printf 'conf:%s\n' "$pacman_conf"
-    } > "$status_file"
-fi
-
 case $db_query in
     local)
         if ! [[ $db_root ]]; then
@@ -217,12 +208,19 @@ case $db_query in
             printf >&2 '%s: %s: not a directory\n' "$argv0" "$db_root"
             exit 20
         fi
-        db_path=$db_root/$db_name.db
+        db_path=$db_root/$db_name.${db_ext:-db}
         ;;
     sync)
-        db_path=$pacman_dbpath/sync/$db_name.db
+        db_path=$pacman_dbpath/sync/$db_name.${db_ext:-db}
         ;;
 esac
+
+if [[ -v status_file ]]; then
+    { printf 'repo:%s\n' "$db_name"
+      printf 'root:%s\n' "$db_root"
+      printf 'path:%s\n' "$db_path"
+    } > "$status_file"
+fi
 
 case $mode in
     upgrades)
@@ -232,7 +230,7 @@ case $mode in
         db_table "$table_format" "$db_path"
         ;;
     path)
-        readlink -f -- "$db_root/$db_name".db
+        readlink -f -- "$db_path"
         ;;
     *)
         usage

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -64,16 +64,16 @@ db_table() {
 }
 
 usage() {
-    printf >&2 'usage: %s [-d repo] [-r path] [-alpqtuS]\n' "$argv0"
+    printf >&2 'usage: %s [-d repo] [-r path] [-alqtuS]\n' "$argv0"
     exit 1
 }
 
 source /usr/share/makepkg/util/parseopts.sh
 
 ## option parsing
-opt_short='c:d:r:alpqtuS'
-opt_long=('database:' 'repo:' 'config:' 'root:' 'path' 'all' 'list'
-          'repo-list' 'sync' 'upgrades' 'table' 'quiet' 'path-list')
+opt_short='c:d:r:alqtuS'
+opt_long=('database:' 'repo:' 'config:' 'root:' 'all' 'list' 'repo-list'
+          'sync' 'upgrades' 'table' 'quiet' 'path-list' 'status')
 opt_hidden=('dump-options' 'status-file:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -94,8 +94,6 @@ while true; do
             mode=packages ;;
         -t|--table)
             mode=packages; table_format=1 ;;
-        -p|--path)
-            mode=path ;;
         -a|--all)
             mode=upgrades; vercmp_args+=(-a) ;;
         -q|--quiet)
@@ -106,10 +104,12 @@ while true; do
             mode=repo_list ;;
         --path-list)
             mode=repo_list; list_path=1 ;;
-        -S|--sync)
-            db_query=sync ;;
+        --status)
+            mode=status; status_file=/dev/fd/1 ;;
         --status-file)
             shift; status_file=$1 ;;
+        -S|--sync)
+            db_query=sync ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
@@ -126,7 +126,7 @@ fi
 # assign environment variables
 : "${db_ext=$AUR_DBEXT}" "${db_name=$AUR_REPO}" "${db_root=$AUR_DBROOT}"
 
-unset conf_file_repo conf_file_serv server
+unset conf_file_repo conf_file_serv conf_file_path server
 while read -r key _ value; do
     case $key=$value in
         \[*\]*)
@@ -229,9 +229,8 @@ case $mode in
     packages)
         db_table "$table_format" "$db_path"
         ;;
-    path)
-        readlink -f -- "$db_path"
-        ;;
+    status)
+        ;; # status information printed to /dev/fd/1
     *)
         usage
         ;;

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -276,15 +276,16 @@ cd_safe "$tmp"
 # db_info: $1 pkgname $2 pkgver
 aur repo "${repo_args[@]}" --list --status-file=db >db_info
 
-# Retrieve path to local repo (#448)
+# Retrieve path to local repo (#448, #700)
 { IFS=: read -r _ db_name
   IFS=: read -r _ db_root
+  IFS=: read -r _ db_path
 } <db
 
-if [[ -w $db_root/$db_name.db ]]; then
+if [[ -w $db_path ]]; then
     msg >&2 'Using [%s] repository' "$db_name"
 else
-    error '%s: %s: permission denied' "$argv0" "$db_root/$db_name.db"
+    error '%s: %s: permission denied' "$argv0" "$db_path"
     exit 13
 fi
 

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,7 +1,19 @@
 ## 3.2.0
 
+* `aur-build`
+  + retrieve database extension from `AUR_DBEXT` (defaults to .db) (#700)
+  + resolve path argument to `--results`
+  + use `aur repo --status` for repository selection
+    - allows specifying `--root` without `--database`
+
+* `aur-repo`
+  + retrieve database extension from `AUR_DBEXT` (defaults to .db) (#700)
+  + add `--status`
+    - colon-delimited output (`repo:`, `root:`, `path:`)
+    - replaces `--path`
+
 * `aur-sync`
-  + Take transitive dependencies into account (#592)
+  + take transitive dependencies into account (#592)
 
 ## 3.1.2 - 2020-11-09
 

--- a/man1/aur-repo.1
+++ b/man1/aur-repo.1
@@ -4,11 +4,10 @@ aur\-repo \- manage local repositories
 .
 .SH SYNOPSIS
 .SY "aur repo"
-.OP \-\-path
 .OP \-\-list
 .OP \-\-table
 .OP \-\-upgrades
-.OP \-\-repo\-list
+.OP \-\-status
 .SY "aur repo"
 .OP \-c file
 .OP \-d name
@@ -77,10 +76,6 @@ repositories.
 List the resolved paths of configured local
 .BR pacman (8)
 repositories.
-
-.TP
-.BR \-p ", " \-\-path
-Print the (resolved) path to the specified local repository.
 .
 .SH OPTIONS
 .TP


### PR DESCRIPTION
1. Fix a bug with `--results` where the results file would be written to $PWD/package instead of $PWD, when using relative paths.

2. Fix #700 by not hardcoding `.db` in `aur-sync`, `aur-build` and `aur-repo`.

3. Add `aur repo --status` for repository selection in `aur-build`. This also generalizes `aur repo --path` (now removed).