### PR TITLE
List aur-chroot and aur-query in man1/aur.1

### DIFF
--- a/man1/aur.1
+++ b/man1/aur.1
@@ -41,6 +41,12 @@ Build packages to a local repository.
 .RE
 .
 .P
+.BR aur\-chroot (1)
+.RS 4
+Build pacman packages with systemd-nspawn.
+.RE
+.
+.P
 .BR aur\-depends (1)
 .RS 4
 Retrieve dependencies using aurweb.
@@ -62,6 +68,12 @@ Print package/dependency directed graph.
 .BR aur\-pkglist (1)
 .RS 4
 Print the AUR package list.
+.RE
+.
+.P
+.BR aur\-query (1)
+.RS 4
+Send GET requests to the aurweb RPC interface.
 .RE
 .
 .P


### PR DESCRIPTION
I'm finding `aur chroot --build` a great helper to check PKGBUILDs. Not finding `aur chroot` in `man 1 aur` threw me off for a bit :)