### PR TITLE
aur-repo-filter: run pacsift with unbuffer(1)

### DIFF
--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -12,7 +12,8 @@ sync_repo=0
 # spread arguments with xargs (and printf, as a shell built-in).
 satisfies() {
     #global sift_args
-    xargs -a <(printf -- '--satisfies=%s\n' "$@") pacsift "${sift_args[@]}" <&-
+    unbuffer xargs -a <(printf -- "--satisfies=%s\n" "$@") \
+             pacsift "${sift_args[@]}"
 }
 
 provides() {

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -11,7 +11,7 @@ changelog=aurutils.changelog
 sha256sums=('SKIP')
 conflicts=('aurutils')
 provides=("aurutils=${pkgver%%.r*}")
-depends=('git' 'jq' 'pacutils' 'curl')
+depends=('git' 'jq' 'pacutils' 'curl' 'expect')
 makedepends=('git')
 optdepends=('bash-completion: bash completion'
             'zsh: zsh completion'


### PR DESCRIPTION
As of pacman 6, it no longer suffices to close stdin. Use `unbuffer` to simulate a tty instead.

Fixes #804