### PR TITLE
aur-build: merge --config and --pacman-conf

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -85,12 +85,11 @@ fi
 
 ## option parsing
 opt_short='a:d:D:U:AcCfnrsvLNRST'
-opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:'
-          'sign' 'verify' 'directory:' 'no-sync' 'config:'
-          'pacman-conf:' 'results:' 'remove' 'pkgver' 'rmdeps'
-          'no-confirm' 'ignore-arch' 'log' 'new' 'makepkg-conf:'
-          'bind:' 'bind-rw:' 'prevent-downgrade' 'temp' 'syncdeps'
-          'clean' 'namcap' 'checkpkg' 'user:' 'makepkg-args:'
+opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
+          'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:' 'remove'
+          'pkgver' 'rmdeps' 'no-confirm' 'ignore-arch' 'log' 'new'
+          'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
+          'syncdeps' 'clean' 'namcap' 'checkpkg' 'user:' 'makepkg-args:'
           'buildscript:')
 opt_hidden=('dump-options' 'gpg-sign' 'ignorearch' 'noconfirm' 'nosync' 'margs:')
 
@@ -115,10 +114,12 @@ while true; do
         --buildscript)
             shift; buildscript=$1
             makepkg_common_args+=(-p "$1") ;;
-        --config)
-            shift; pacconf_args+=(--config "$1") ;;
         --nosync|--no-sync)
             no_sync=1 ;;
+        --makepkg-conf)
+            shift; makepkg_conf=$1 ;;
+        --pacman-conf)
+            shift; pacman_conf=$1 ;;
         --pkgver)
             run_pkgver=1; makepkg_args+=(--noextract) ;;
         --results)
@@ -135,8 +136,6 @@ while true; do
             shift; makechrootpkg_args+=(-D "$1") ;;
         --bind-rw)
             shift; makechrootpkg_args+=(-d"$1") ;;
-        --pacman-conf)
-            shift; pacman_conf=$1 ;;
         -N|--namcap)
             makechrootpkg_args+=(-n) ;;
         --checkpkg)
@@ -155,9 +154,6 @@ while true; do
             makepkg_common_args+=(--rmdeps) ;;
         -s|--syncdeps)
             makepkg_common_args+=(--syncdeps) ;;
-        --makepkg-conf)
-            shift; makepkg_conf=$1
-            makepkg_common_args+=(--config "$1") ;;
         # makepkg options (build)
         -C|--clean)
             makepkg_args+=(--clean) ;;
@@ -196,15 +192,31 @@ var_tmp=$(mktemp -d --tmpdir="${TMPDIR:-/var/tmp/}" "aurutils-$UID/$argv0.XXXXXX
 trap 'trap_exit' EXIT
 trap 'exit' INT
 
+if [[ -v makepkg_conf ]]; then
+    chroot_args+=(--makepkg-conf "$makepkg_conf")
+    makepkg_common_args+=(--config "$1")
+    # further used for load_makepkg_config (packagelist)
+fi
+
+if [[ -v pacman_conf ]]; then
+    chroot_args+=(--pacman-conf "$pacman_conf")
+    pacconf_args+=(--config "$pacman_conf")
+
+# pacman.conf fallback for chroot builds (#824, #808)
+elif (( chroot )); then
+    chroot_args+=(--pacman-conf "/etc/aurutils/pacman-$db_name.conf")
+    pacconf_args+=(--config "/etc/aurutils/pacman-$db_name.conf")
+fi
+
 # assign environment variables
 : "${db_ext=$AUR_DBEXT}" "${db_root=$AUR_DBROOT}" "${db_repo=$AUR_REPO}"
 
+# Automatically choose repository root and name based on pacman
+# configuration and user environment.
 if [[ $db_name ]] && [[ $db_root ]]; then
     db_path=$db_root/$db_name.${db_ext:-db}
     db_path=$(realpath -- "$db_path")
 else
-    # Automatically choose repository root and name based on pacman
-    # configuration and user environment.
     { IFS=: read -r _ db_name
       IFS=: read -r _ db_root
       IFS=: read -r _ db_path
@@ -234,15 +246,6 @@ if [[ -v results_file ]]; then
 fi
 
 if (( chroot )); then
-    if [[ -v makepkg_conf ]]; then
-        chroot_args+=(--makepkg-conf "$makepkg_conf")
-    fi
-    if [[ -v pacman_conf ]]; then
-        chroot_args+=(--pacman-conf "$pacman_conf")
-    else
-        chroot_args+=(--pacman-conf "/etc/aurutils/pacman-$db_name.conf")
-    fi
-
     # makepkg --packagelist includes the package extension, but
     # makechrootpkg ignores PKGEXT set on the host. Retrieve it
     # seperately.

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -122,7 +122,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'no-view' 'no-provides' 'no-build' 'rm-deps' 'sign' 'temp' 'upgrades'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
-          'results:' 'makepkg-args:' 'format:' 'config:' 'no-depends'
+          'results:' 'makepkg-args:' 'format:' 'no-depends'
           'no-makedepends' 'no-checkdepends')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
@@ -189,15 +189,13 @@ while true; do
             build_args+=(--chroot) ;;
         -f|--force)
             build_args+=(--force) ;;
-        --config)
-            shift; build_args+=(--config "$1")
-            repo_args+=(--config "$1") ;;
         --makepkg-args|--margs)
             shift; build_args+=(--margs "$1") ;;
         --makepkg-conf)
             shift; build_args+=(--makepkg-conf "$1") ;;
         --pacman-conf)
-            shift; build_args+=(--pacman-conf "$1") ;;
+            shift; build_args+=(--pacman-conf "$1")
+            repo_args+=(--config "$1") ;;
         --pkgver)
             build_args+=(--pkgver) ;;
         --results)

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -105,15 +105,6 @@ To use another key than the default, the
 environment variable can be set to the appropriate key identifier.
 .
 .TP
-.BI \-\-config= FILE
-The
-.BR pacman.conf (5)
-file to use for syncing and retrieving local repositories. This option
-does not affect
-.BR makepkg (8)
-calls.
-.
-.TP
 .BR \-\-no\-sync
 Do not sync the local repository after building.
 .
@@ -226,15 +217,18 @@ on the built package.
 .BI \-\-makepkg\-conf= FILE
 The
 .BR makepkg.conf (5)
-file used inside the container.
-.RB ( aur\-chroot " " \-\-makepkg\-conf )
+file used for
+.BR makepkg (8)
+operations. For chroot builds, the file is also used inside the container.
+.RB ( aur\-chroot " " \-\-makepkg\-conf ).
 .
 .TP
 .BI \-\-pacman\-conf= FILE
-The
-.BR pacman.conf (5)
-file used inside the container.
-.RB ( aur\-chroot " " \-\-pacman\-conf )
+The file used for syncing and retrieving local repositories. For chroot
+builds, the file is also used inside the container
+.RB ( aur\-chroot " " \-\-pacman\-conf ).
+.BR makepkg (8)
+calls are unaffected by this option.
 .
 .SS makepkg options
 Additional options may be passed to

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -33,13 +33,6 @@ terminates immediately.
 Do not download package files.
 .
 .TP
-.B \-\-config
-The
-.BR pacman.conf (5)
-file for syncing and retrieving local repositories.
-.RB ( "aur-build \-\-config" ", " "aur-repo \-\-config" )
-.
-.TP
 .BI \-\-ignore= PACKAGE
 Ignore a package upgrade. Multiple packages can be specified by
 separating them with a comma, or by repeating the \fB\-\-ignore\fR option.
@@ -197,6 +190,22 @@ database.
 Sign built packages with
 .BR gpg (1).
 .RB ( "aur build \-S" )
+.
+.TP
+.BR \-\-makepkg\-conf
+The
+.BR makepkg.conf (5)
+file for chroot and
+.BR makepkg (8)
+operations.
+.RB ( "aur\-build \-\-makepkg\-conf" )
+.
+.TP
+.BR \-\-pacman\-conf
+The
+.BR pacman.conf (5)
+file for chroot and local repository operations.
+.RB ( "aur\-build \-\-pacman\-conf" ", " "aur-repo \-\-config" )
 .
 .SS Dependency options
 Build dependencies are resolved with


### PR DESCRIPTION
There was no real reason to have both flags separated, and `aur-build` does not have a "config" per se. Actually document `--pacman-conf` and `--makepkg-conf` in `aur-sync` as well.

Fixes #808
Fixes #824