### PR TITLE
lib/aur-build: Add existing packages to the database when skipping them

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -323,7 +323,9 @@ while IFS= read -ru "$fd" path; do
             # makepkg invocation may take place
             warning '%s: skipping existing package (use -f to overwrite)' "$argv0"
 
-            printf '%q\n' >&2 "${exists[@]}"
+            cd_safe "$db_root"
+            LANG=C repo-add "${repo_add_args[@]}" "$db_path" "${exists[@]}"
+
             continue
         fi
     fi


### PR DESCRIPTION
```
The contract that we want to satisfy is that the package being built
will be present in the repo after the function returns. This isn't
satisfied if aur-build finds that the package file already exists, in
which case it is simply skipped (unless invoked with -f).

This becomes an issue for aur-sync, as it then proceeds, assuming that
this package will be found in the repositories, in case it occurs as a
dependency for other packages. However, this may not be true:

- The directory with the repository may be actually hosting multiple
  repositories, with a shared package file set.

- The repository in question may have been recreated, or otherwise
  modified.

Fix this by calling repo-add to update the database in this
circumstance. If the package is already in the database, then there is
no harm in re-adding it.
```

- Fixes #838