### PR TITLE
aur-vercmp: remove colon from version output

### DIFF
--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -26,11 +26,11 @@ cmp_equal_or_newer() {
         esac
 
         case $op in
-           -1) plain >&2 '%s: %s is newer than %s' "$pkg" "$v_cmp" "$v_in" >&2
+           -1) plain >&2 '%s %s is newer than %s' "$pkg" "$v_cmp" "$v_in" >&2
                printf '%s\n' "$pkg" ;;
             0) printf '%s\n' "$pkg" ;;
-            1) msg2 >&2 '%s: %s -> %s' "$pkg" "$v_cmp" "$v_in" ;;
-            2) msg2 >&2 '%s: (none) -> %s' "$pkg" "$v_in" ;;
+            1) msg2 >&2 '%s %s -> %s' "$pkg" "$v_cmp" "$v_in" ;;
+            2) msg2 >&2 '%s (none) -> %s' "$pkg" "$v_in" ;;
         esac
     done
 }
@@ -54,10 +54,10 @@ cmp_checkupdates() {
         fi
 
         case $op in
-           -1) printf '%s: %s -> %s\n' "$pkg" "$v_in" "$v_cmp" ;;
-            0) printf '%s: %s = %s\n'  "$pkg" "$v_in" "$v_cmp" ;;
-            1) printf '%s: %s <- %s\n' "$pkg" "$v_in" "$v_cmp" ;;
-            2) printf '%s: (none) -> %s\n' "$pkg" "$v_cmp"     ;;
+           -1) printf '%s %s -> %s\n' "$pkg" "$v_in" "$v_cmp" ;;
+            0) printf '%s %s = %s\n'  "$pkg" "$v_in" "$v_cmp" ;;
+            1) printf '%s %s <- %s\n' "$pkg" "$v_in" "$v_cmp" ;;
+            2) printf '%s (none) -> %s\n' "$pkg" "$v_cmp"     ;;
         esac
     done
 }

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -18,6 +18,9 @@
 * `aur-sync`
   + take transitive dependencies into account (#592)
 
+* `aur-vercmp`
+  + remove colon from `checkupdates` and `equal_or_newer` format (#833)
+
 ## 3.1.2 - 2020-11-09
 
 This releases fixes a regression in 3.1.1 where `AUR_LIB_DIR` was not

--- a/man7/aurvcs.7
+++ b/man7/aurvcs.7
@@ -69,7 +69,7 @@ combined with
 as follows:
 .PP
 .EX
-    $ mapfile \-t packages < <(aur vercmp\-devel | cut \-d: \-f1)
+    $ mapfile \-t packages < <(aur vercmp\-devel | cut \-d" " \-f1)
     $ aur sync "${packages[@]}" \-\-no\-ver\-shallow
 .EE
 .PP


### PR DESCRIPTION
`pkgname` cannot contain spaces either per `PKGBUILD(5)`, and this brings the format in line with `checkupdates` from pacman-contrib.

Fixes #833