### PR TITLE
aur-build: fall back to /etc/aurutils/pacman-<arch>.conf

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -50,7 +50,7 @@ Error:
     using --chroot, make sure this file is created and valid. See OPTIONS in
     aur-build(1) for configuration details.
 
-    The following path was used for lookup:
+    The following file path was checked:
 EOF
     printf '%8s%s\n' ' ' "$1"
 }

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -13,7 +13,8 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0
 
 # default arguments (empty)
-chroot_args=() pacconf_args=() repo_add_args=() repo_args=() makepkg_args=() makechrootpkg_makepkg_args=() makepkg_common_args=()
+chroot_args=() pacconf_args=() repo_add_args=() repo_args=()
+makepkg_args=() makechrootpkg_makepkg_args=() makepkg_common_args=()
 
 # default arguments
 gpg_args=(--detach-sign --no-armor --batch)
@@ -40,6 +41,15 @@ EOF
     realpath -z -- "$@" | while read -rd ''; do
         printf '%8s%s\n' ' ' "$REPLY"
     done
+}
+
+diag_pacman_conf() {
+	cat <<EOF >&2
+Note:
+	aur-build could not find a pacman.conf(5) file for container usage. Before
+	using --chroot, make sure this file is created and valid. See OPTIONS in
+	aur-build(1) for configuration details.
+EOF
 }
 
 run_msg() {
@@ -209,8 +219,16 @@ if [[ -v pacman_conf ]]; then
 # pacman.conf fallback for chroot builds (#824, #808)
 # fallback to uname when autodetecting db_name (#846)
 elif (( chroot )); then
-    chroot_args+=(--pacman-conf "/etc/aurutils/pacman-${db_name:-$machine}.conf")
-    pacconf_args+=(--config "/etc/aurutils/pacman-${db_name:-$machine}.conf")
+    pacman_conf=/etc/aurutils/pacman-${db_name:-$machine}.conf
+
+    chroot_args+=(--pacman-conf "$pacman_conf")
+    pacconf_args+=(--config "$pacman_conf")
+fi
+
+# Early check for availability of pacman.conf (#783)
+if ! [[ -f $pacman_conf ]]; then
+	error '%s: %s: no such file or directory' "$argv0" "$pacman_conf"
+	(( chroot )) && diag_pacman_conf
 fi
 
 # Automatically choose repository root and name based on pacman

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -44,12 +44,15 @@ EOF
 }
 
 diag_pacman_conf() {
-	cat <<EOF >&2
-Note:
-	aur-build could not find a pacman.conf(5) file for container usage. Before
-	using --chroot, make sure this file is created and valid. See OPTIONS in
-	aur-build(1) for configuration details.
+    cat <<EOF >&2
+Error:
+    aur-build could not find a pacman.conf(5) file for container usage. Before
+    using --chroot, make sure this file is created and valid. See OPTIONS in
+    aur-build(1) for configuration details.
+
+    The following path was used for lookup:
 EOF
+    printf '%8s%s\n' ' ' "$1"
 }
 
 run_msg() {
@@ -227,10 +230,10 @@ fi
 
 # Early check for availability of pacman.conf (#783)
 if ! [[ -f $pacman_conf ]]; then
-    error '%s: %s: no such file or directory' "$argv0" "$pacman_conf"
-
     if (( chroot )); then
-        diag_pacman_conf
+        diag_pacman_conf "$pacman_conf"
+    else
+        error '%s: %s: no such file or directory' "$argv0" "$pacman_conf"
     fi
     exit 2
 fi

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -227,8 +227,12 @@ fi
 
 # Early check for availability of pacman.conf (#783)
 if ! [[ -f $pacman_conf ]]; then
-	error '%s: %s: no such file or directory' "$argv0" "$pacman_conf"
-	(( chroot )) && diag_pacman_conf
+    error '%s: %s: no such file or directory' "$argv0" "$pacman_conf"
+
+    if (( chroot )); then
+        diag_pacman_conf
+    fi
+    exit 2
 fi
 
 # Automatically choose repository root and name based on pacman

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -183,6 +183,9 @@ while true; do
     shift
 done
 
+# assign environment variables
+: "${db_ext=$AUR_DBEXT}" "${db_root=$AUR_DBROOT}" "${db_repo=$AUR_REPO}"
+
 # shellcheck disable=SC2174
 mkdir -pm 0700 "${TMPDIR:-/tmp}/aurutils-$UID"
 tmp=$(mktemp -d --tmpdir "aurutils-$UID/$argv0.XXXXXXXX")
@@ -209,9 +212,6 @@ elif (( chroot )); then
     chroot_args+=(--pacman-conf "/etc/aurutils/pacman-${db_name:-$machine}.conf")
     pacconf_args+=(--config "/etc/aurutils/pacman-${db_name:-$machine}.conf")
 fi
-
-# assign environment variables
-: "${db_ext=$AUR_DBEXT}" "${db_root=$AUR_DBROOT}" "${db_repo=$AUR_REPO}"
 
 # Automatically choose repository root and name based on pacman
 # configuration and user environment.

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -4,6 +4,7 @@
 set -o errexit
 shopt -s extglob
 argv0=build
+machine=$(uname -m)
 startdir=$PWD
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
@@ -203,9 +204,10 @@ if [[ -v pacman_conf ]]; then
     pacconf_args+=(--config "$pacman_conf")
 
 # pacman.conf fallback for chroot builds (#824, #808)
+# fallback to uname when autodetecting db_name (#846)
 elif (( chroot )); then
-    chroot_args+=(--pacman-conf "/etc/aurutils/pacman-$db_name.conf")
-    pacconf_args+=(--config "/etc/aurutils/pacman-$db_name.conf")
+    chroot_args+=(--pacman-conf "/etc/aurutils/pacman-${db_name:-$machine}.conf")
+    pacconf_args+=(--config "/etc/aurutils/pacman-${db_name:-$machine}.conf")
 fi
 
 # assign environment variables

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -5,8 +5,10 @@
   + resolve path argument to `--results`
   + use `aur repo --status` for repository selection
     - allows specifying `--root` without `--database`
-  + merge `--config` and `--pacman-conf` (#808, #824)
   + print diagnostic if packages were not moved to local repository (#794)
+  + merge `--config` and `--pacman-conf` (#808, #824)
+  + fallback to /etc/aurutils/pacman-<arch>.conf if --chroot is used without --database (#846)
+  + add diagnostic if chroot pacman.conf is non-existing (#783)
 
 * `aur-depends`
   + add `--no-depends`, `--no-makedepends`, `--no-checkdepends` (#826)

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -66,6 +66,14 @@ configuration for the container is placed in
 .BI /etc/aurutils/pacman-<database>.conf \fR
 where <database> is specified with
 .BR \-\-database .
+If this option is not provided,
+.B aur\-build
+falls back to
+.B /etc/aurutils/pacman-<arch>.conf
+where
+.I <arch>
+is the output from
+.BR "uname \-m" .
 A different location can be chosen with the
 .BR \-\-pacman\-conf
 option.


### PR DESCRIPTION
With #831, `aur-build` detects repository information from the path:
```
  /etc/aurutils/pacman-<db_name>.conf
```
However, db_name is not available before this detection takes place. If the
user did not specify db_name, fallback to the path:
```
  /etc/aurutils/pacman-<arch>.conf
```
Fixes #846