### PR TITLE
lib/aur-build: Queue existing packages for adding to the repo

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -327,6 +327,7 @@ while IFS= read -ru "$fd" path; do
             warning '%s: skipping existing package (use -f to overwrite)' "$argv0"
 
             printf '%q\n' >&2 "${exists[@]}"
+            pkglist=("${exists[@]}")
             _build=0
         fi
     fi


### PR DESCRIPTION
Fixup for b6e2db4d90830686d8d220b939553044dc9573ed

Sorry, I could only actually test that patch today, looks like it was missing a tiny addition.