### PR TITLE
aur-repo: explicitly declare dependencies as array

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -18,17 +18,19 @@ db_table() {
     function print_previous() {
         table ? format = "%s\t%s\t%s\t%s\n" : format = "%1$s\t%4$s\n"
 
-        if (table && length(dependencies) > 0) {
+        ## Add reference to self (packages with no dependencies)
+        printf format, pkgname, pkgname, pkgbase, pkgver
+
+        if (table) {
             for (i in dependencies) {
                 printf format, pkgname, dependencies[i], pkgbase, pkgver
             }
-        } else {
-            printf format, pkgname, pkgname, pkgbase, pkgver
         }
     }
 
     BEGIN {
         pkgname = pkgbase = pkgver = "-"
+        dependencies[0] = ""
     }
 
     /^%FILENAME%$/ && FNR > 1 {


### PR DESCRIPTION
In case a repository package has no dependencies (i.e. the %DEPENDS% pattern is not executed), the `dependencies` variable is not initialized as an array.

The next package will then match `%FILENAME%`, and execute `length(dependencies) > 0` which initializes `dependencies` as a scalar (with value 0).

Avoid this by explicitly defining `dependencies` in BEGIN. Additionally, avoid defining `dependencies` as a scalar in the first place by removing `length(dependencies)`.

If `--table` is set, every package now is listed as depending on itself. This matches the behavior of `aur-graph` and `aur-depends`. Strictly speaking, this is only required for packages with no dependencies, so they appear when piping to `tsort`.

Fixes #813