### PR TITLE
aur-repo: remove --path, --repo ambiguities

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -75,8 +75,8 @@ source /usr/share/makepkg/util/parseopts.sh
 ## option parsing
 opt_short='c:d:r:alqtuS'
 opt_long=('database:' 'repo:' 'config:' 'root:' 'all' 'list' 'list-repo' 'list-path'
-          'sync' 'upgrades' 'table' 'quiet' 'status')
-opt_hidden=('dump-options' 'status-file:')
+          'sync' 'upgrades' 'table' 'quiet' 'status' 'status-file:')
+opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -18,7 +18,7 @@ db_table() {
     function print_previous() {
         table ? format = "%s\t%s\t%s\t%s\n" : format = "%1$s\t%4$s\n"
 
-        ## Add reference to self (packages with no dependencies)
+        ## Add dependency to self (packages with no dependencies)
         printf format, pkgname, pkgname, pkgbase, pkgver
 
         if (table) {
@@ -74,8 +74,8 @@ source /usr/share/makepkg/util/parseopts.sh
 
 ## option parsing
 opt_short='c:d:r:alqtuS'
-opt_long=('database:' 'repo:' 'config:' 'root:' 'all' 'list' 'repo-list'
-          'sync' 'upgrades' 'table' 'quiet' 'path-list' 'status')
+opt_long=('database:' 'repo:' 'config:' 'root:' 'all' 'list' 'list-repo' 'list-path'
+          'sync' 'upgrades' 'table' 'quiet' 'status')
 opt_hidden=('dump-options' 'status-file:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -102,9 +102,9 @@ while true; do
             mode=upgrades; vercmp_args+=(-q) ;;
         -u|--upgrades)
             mode=upgrades ;;
-        --path-list)
+        --list-path)
             list=path ;;
-        --repo-list)
+        --list-repo)
             list=repo ;;
         --status)
             mode=status; status_file=/dev/fd/1 ;;

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -20,8 +20,10 @@
 * `aur-repo`
   + retrieve database extension from `AUR_DBEXT` (defaults to .db) (#700)
   + add `--status`
-    - colon-delimited output (`repo:`, `root:`, `path:`)
+    - `repo:<NAME>\nroot:<PATH>\npath:<PATH/NAME.DBEXT>` output format
     - replaces `--path`
+  + rename `--repo-list` to `--list-repo`
+  + rename `--path-list` to `--list-path`
 
 * `aur-repo-filter`
   + run `pacsift` with `unbuffer` (#804)

--- a/man1/aur-repo.1
+++ b/man1/aur-repo.1
@@ -25,7 +25,7 @@ repositories. In particular, it serves to parse repository contents
 compare package versions to the AUR
 .RI ( \-\-upgrades ),
 and list local repository file paths
-.RI ( \-\-path ", " \-\-path\-list ).
+.RI ( \-\-list\-path ).
 .PP
 If
 .BR pacman.conf (5)
@@ -41,6 +41,18 @@ configured, they must specified explicitely with the
 List the contents of a local repository in the following format:
 .IP
 .BI pkgname \et pkgver \en
+.
+.TP
+.BR \-\-list\-path
+List the resolved paths of configured local
+.BR pacman (8)
+repositories.
+.
+.TP
+.BR \-\-list\-repo
+List the names of configured local
+.BR pacman (8)
+repositories.
 .
 .TP
 .BR \-t ", " \-\-table
@@ -64,18 +76,6 @@ in
 .BR \-u ", " \-\-upgrades
 Check package updates with
 .BR aur\-vercmp (1)
-.
-.TP
-.BR \-\-repo\-list
-List the names of configured local
-.BR pacman (8)
-repositories.
-.
-.TP
-.BR \-\-path\-list
-List the resolved paths of configured local
-.BR pacman (8)
-repositories.
 .
 .SH OPTIONS
 .TP
@@ -120,6 +120,19 @@ Query repositories in
 instead of by their
 .B file://
 path.
+.
+.TP
+.BR \-\-status
+Print status information to standard output, in the following format:
+.EX
+repo:<repository name>
+root:<root of repository>
+path:<path of repository>
+.EE
+.
+.BR \-\-status\-file FILE
+As \-\-status, but prints to a user-specified file. Can be combined
+with other operations.
 .
 .SH ENVIRONMENT
 .TP


### PR DESCRIPTION
Updates `aur-repo(1)` with `--status` and `--status-file`, and removes possible ambiguities between `--repo`, `--repo-list` and `--path` (removed option), `--path-list`