### PR TITLE
aur-query: remove workaround for curl --parallel exit codes

### DIFF
--- a/lib/aur-query
+++ b/lib/aur-query
@@ -115,23 +115,14 @@ if [[ ! -s $tmp/config ]]; then
     exit
 fi
 
+# support parallel transfers (curl >7.66.0)
 if (( AUR_QUERY_PARALLEL )); then
-    # support parallel transfers (curl >7.66.0)
+    # curl 7.77.0: tool_operate: don't discard failed parallel transfer result
     curl "${curl_args[@]}" -K "$tmp"/config --stderr "$tmp"/error \
          --parallel --parallel-max "$AUR_QUERY_PARALLEL_MAX"
 
-    # XXX: curl --parallel does not exit >0 on failed transfers, thus
-    # stderr has to be checked manually
-    # shellcheck disable=SC2181
-    if (( $? )) || [[ -s $tmp/error ]]; then
-        sort "$tmp"/error | uniq -c >&2
-        exit 1
-    else
-        cat "$tmp"/out/*
-    fi
 else
-    # XXX: discard exit codes to match curl --parallel logic
-    curl "${curl_args[@]}" -K "$tmp"/config || exit 1
+    curl "${curl_args[@]}" -K "$tmp"/config
 fi
 
 # vim: set et sw=4 sts=4 ft=sh:


### PR DESCRIPTION
Since curl 7.77.0, exit codes from failed transfers are no longer discarded with `curl --parallel`. Update the code to reflect this.