### PR TITLE
aur-fetch: add --existing

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -7,7 +7,7 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 
 # default options
-recurse=0 sync=no
+clone=1 recurse=0 sync=no
 
 results() {
     local mode=$1 prev=$2 current=$3 path=$4 dest=$5
@@ -34,7 +34,7 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
 fi
 
 opt_short='rS'
-opt_long=('recurse' 'sync:' 'results:')
+opt_long=('recurse' 'sync:' 'results:' 'existing')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -45,6 +45,8 @@ set -- "${OPTRET[@]}"
 unset results_file
 while true; do
     case "$1" in
+        --existing)
+            clone=0 ;;
         -r|--recurse)
             recurse=1 ;;
         -S)
@@ -139,13 +141,14 @@ fi | while read -r pkg; do
         fi
 
     # Otherwise, try to clone anew
-    elif git clone "$AUR_LOCATION/$pkg"; then
+    elif (( clone )) && git clone "$AUR_LOCATION/$pkg"; then
         head=$(git -C "$pkg" rev-parse HEAD)
 
         if [[ -v results_file ]]; then
             results 'clone' '0' "$head" "$PWD/$pkg" "$results_file"
         fi
-    else
+
+    elif (( clone )); then
         error '%s: %s: failed to clone repository' "$argv0" "$pkg"
         exit 1
     fi

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,17 @@
+## 3.2.1
+
+* `aur-query`
+  + support AUR_LOCATION
+  + preserve `curl --parallel` exit codes (requires curl >=7.77.0)
+  + complete aur-query(1) man page
+
+* `aur-pkglist`
+  + support multiinfo and search dumps (`--info`, `--search`)
+  + support HTTP Last-Modified
+
+* `aur-fetch`
+  + add `--existing`
+
 ## 3.2.0
 
 * `aur-build`

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -1,4 +1,4 @@
-.TH AUR-FETCH 1 2020-03-14 AURUTILS
+.TH AUR-FETCH 1 2021-11-28 AURUTILS
 .SH NAME
 aur\-fetch \- download packages from the AUR
 .
@@ -15,6 +15,11 @@ downloads packages specified on the command-line from the AUR using
 .BR git (1).
 .
 .SH OPTIONS
+.TP
+.BR \-\-existing
+If a git repository is not found for a given package, ignore it instead of running
+.BR git\-clone (1).
+.
 .TP
 .BR \-r ", " \-\-recurse
 Download packages and their dependencies with


### PR DESCRIPTION
Possible options to make `aur-fetch` more suitable for non-AUR workflows. Related discussion: #860