### PR TITLE
scripts: support both CLI arguments and stdin

### DIFF
--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -54,7 +54,7 @@ tr_ver() {
 chain() {
     local a num sub
 
-    printf '%s\n' "$@" | aur query -t info > json/0 || exit
+    aur query -t info "$@" > json/0 || exit
     num=$(count json/0)
 
     if (( num < 1 )); then
@@ -74,7 +74,7 @@ chain() {
         # Avoid querying duplicates (#4)
         cut -f1 tsv/$sub >> seen # pkgname
         cut -f2 tsv/$sub | tr_ver | grep -Fxvf seen | \
-            aur query -t info > json/$a || exit # rpc error
+            aur query -t info - > json/$a || exit # rpc error
 
         if [[ -s json/$a ]]; then
             num=$(count json/$a)

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -7,7 +7,7 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 
 # default options
-clone=1 recurse=0 sync=no
+clone=1 sync=no
 
 results() {
     local mode=$1 prev=$2 current=$3 path=$4 dest=$5
@@ -22,7 +22,7 @@ usage() {
 ICAgICAgICAgICAgIC4tLX5+LF9fCjotLi4uLiwtLS0tLS0tYH5+Jy5fLicKIGAtLCwsICAs
 XyAgICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
 !
-    plain >&2 'usage: %s [-rS] [--] pkgname...' "$argv0"
+    plain >&2 'usage: %s [-S] [--] pkgname...' "$argv0"
     exit 1
 }
 
@@ -33,8 +33,8 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
     [[ -t 2 ]] && colorize
 fi
 
-opt_short='rS'
-opt_long=('recurse' 'sync:' 'results:' 'existing')
+opt_short='S'
+opt_long=('sync:' 'results:' 'existing')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -47,8 +47,6 @@ while true; do
     case "$1" in
         --existing)
             clone=0 ;;
-        -r|--recurse)
-            recurse=1 ;;
         -S)
             sync=auto ;;
         --sync)
@@ -71,7 +69,13 @@ while true; do
     shift
 done
 
-if ! (( $# )); then
+# Single hyphen to denote input taken from stdin
+stdin=0
+if (( $# == 1 )) && [[ $1 == "-" || $1 == "/dev/stdin" ]]; then
+    stdin=1
+fi
+
+if (( ! $# )); then
     error '%s: no pkgname given' "$argv0"
     exit 1
 fi
@@ -81,10 +85,10 @@ if [[ -v results_file ]]; then
     : >"$results_file" || exit 1 # truncate file
 fi
 
-if (( recurse )); then
-    aur depends --pkgbase "$@"
+if (( stdin )); then
+    tee # noop
 else
-   printf '%s\n' "$@"
+    printf '%s\n' "$@"
 fi | while read -r pkg; do
     unset -f git
 

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -41,7 +41,7 @@ trap_exit() {
 }
 
 usage() {
-    printf 'usage: %s [-t [info|search] ] [-b by]\n' "$argv0" >&2
+    printf 'usage: %s [-t [info|search] ] [-b by] <package...>\n' "$argv0" >&2
     exit 1
 }
 
@@ -77,6 +77,16 @@ mkdir -pm 0700 "${TMPDIR:-/tmp}/aurutils-$UID"
 tmp=$(mktemp -d --tmpdir "aurutils-$UID/$argv0.XXXXXXXX") || exit
 trap 'trap_exit' EXIT
 
+# Single hyphen to denote input taken from stdin
+stdin=0
+if (( $# == 1 )) && [[ $1 == "-" || $1 == "/dev/stdin" ]]; then
+    stdin=1
+fi
+
+if (( ! $# )); then
+    usage
+fi
+
 # set filters
 case $arg_type in
       info) uri_write() { uri_info; } ;;
@@ -84,32 +94,26 @@ case $arg_type in
          *) usage ;;
 esac
 
-# check for interactive terminal
-if [[ -t 0 ]]; then
-    cat >&2 <<EOF
-Warning: Input is read from the terminal. You either know what you
-Warning: are doing, or you forgot to pipe data into $argv0.
-Warning: Press CTRL-D to exit.
-EOF
-fi
-
 # generate curl config
-if (( AUR_QUERY_PARALLEL )); then
+if (( stdin )); then
+    tee # noop
+else
+    printf '%s\n' "$@"
+fi | jq -R -r '@uri' | uri_write | if (( AUR_QUERY_PARALLEL )); then
     mkdir "$tmp"/out
     unset i
 
-    jq -R -r '@uri' | uri_write | while IFS= read -r uri; do
+    while IFS= read -r uri; do
         i=$((i+1))
 
         printf 'url %s\n' "$uri"
         printf 'output %q\n' "$tmp/out/$i"
-    done > "$tmp"/config
-
+    done
 else
-    jq -R -r '@uri' | uri_write | while IFS= read -r uri; do
+    while IFS= read -r uri; do
         printf 'url "%s"\n' "$uri"
-    done > "$tmp"/config
-fi
+    done
+fi > "$tmp"/config
 
 # exit cleanly on empty input (#706)
 if [[ ! -s $tmp/config ]]; then

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -203,7 +203,7 @@ case $multiple in
 esac
 
 # check results
-printf '%s\n' "$@" | aur query -t "$type" -b "$search_by" > "$tmp" || exit
+aur query -t "$type" -b "$search_by" "$@" > "$tmp" || exit
 
 # exit early on raw output (#187)
 case $output in

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -285,7 +285,7 @@ fi
 if [[ -s argv ]]; then
     # shellcheck disable=SC2094
     # depends: $1 pkgname $2 depends $3 pkgbase $4 pkgver $5 depends_type
-    xargs -a argv -d'\n' aur depends --table "${depends_args[@]}" -- >depends
+    aur depends --table "${depends_args[@]}" - <argv >depends
 else
     plain >&2 "there is nothing to do"
     exit
@@ -346,7 +346,7 @@ fi
 
 if (( download )); then
     msg >&2 "Retrieving package files"
-    xargs -a "$tmp"/queue -d'\n' aur fetch -S --results "$tmp"/fetch_results
+    aur fetch -S --results "$tmp"/fetch_results - < "$tmp"/queue
 
     # shellcheck disable=SC2034
     while IFS=: read -r mode rev_old rev path; do

--- a/lib/aur-vercmp
+++ b/lib/aur-vercmp
@@ -63,7 +63,7 @@ cmp_checkupdates() {
 }
 
 parse_aur() {
-    aur query -t info | jq -r '.results[] | [.Name, .Version] | @tsv'
+    aur query -t info - | jq -r '.results[] | [.Name, .Version] | @tsv'
 }
 
 trap_exit() {

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,16 @@
+## 3.3.0
+
+`aur-query` and `aur-fetch` now take arguments from the command-line
+by default. If `-` or `/dev/stdin` is the first (and only) arguments,
+they are taken from `stdin` instead. In particular, `aur fetch --recurse`
+is now written as `aur depends --pkgbase ... | aur fetch -`, and the
+explicit `--recurse` option was removed.
+
+The `-` argument propagates to `aur-depends` and `aur-search`
+transparently. Additionally, `aur-sync` no longer calls `aur-depends`
+and `aur-fetch` with `xargs`, avoiding the 123 exit code on failure of
+these commands.
+
 ## 3.2.1
 
 * `aur-query`

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -21,15 +21,6 @@ If a git repository is not found for a given package, ignore it instead of runni
 .BR git\-clone (1).
 .
 .TP
-.BR \-r ", " \-\-recurse
-Download packages and their dependencies with
-.BR aur\-depends (1).
-If this option is specified, arguments must be supplied by
-.B pkgname
-instead of by
-.BR pkgbase .
-.
-.TP
 .BI \-\-sync= MODE
 If
 .I MODE
@@ -121,6 +112,15 @@ is the absolute path to the corresponding git repository.
 .IP
 Can be used by higher level tools to differentiate new clones from
 updates to existing repositories.
+.
+.SH EXAMPLES
+Packages can be retrieved recursively by piping
+.BR aur\-depends :
+.EX
+
+  aur depends --pkgbase "$@" | aur fetch -
+
+.EE
 .
 .SH SEE ALSO
 .ad l

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -1,4 +1,4 @@
-.TH AUR-FETCH 1 2021-11-28 AURUTILS
+.TH AUR-FETCH 1 2021-12-06 AURUTILS
 .SH NAME
 aur\-fetch \- download packages from the AUR
 .
@@ -13,6 +13,11 @@ aur\-fetch \- download packages from the AUR
 .B aur\-fetch
 downloads packages specified on the command-line from the AUR using
 .BR git (1).
+If the first argument is
+.B \-
+or
+.BR /dev/stdin ,
+packages are taken from standard input.
 .
 .SH OPTIONS
 .TP
@@ -114,13 +119,12 @@ Can be used by higher level tools to differentiate new clones from
 updates to existing repositories.
 .
 .SH EXAMPLES
-Packages can be retrieved recursively by piping
-.BR aur\-depends :
+Retrieve packages recursively:
+.PP
 .EX
-
-  aur depends --pkgbase "$@" | aur fetch -
-
+  $ aur depends --pkgbase "$@" | aur fetch -
 .EE
+.PP
 .
 .SH SEE ALSO
 .ad l

--- a/man1/aur-query.1
+++ b/man1/aur-query.1
@@ -6,6 +6,7 @@ aur\-query \- send GET requests to the aurweb RPC interface
 .SY "aur query"
 .OP \-t type
 .OP \-b by
+.IR pkgname " [" pkgname... ]
 .YS
 .
 .SH DESCRIPTION
@@ -17,7 +18,12 @@ RPC interface
 .UE
 with
 .BR curl(1).
-Parallel transfers and URI splitting are supported.
+.PP
+Arguments are taken from the command-line. If the first argument is
+.B \-
+or
+.BR /dev/stdin ,
+they are taken from standard input.
 .
 .SH OPTIONS
 The request type and arguments must be compatible to the chosen RPC version (see the

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -296,7 +296,7 @@ repository that are unavailable in the AUR:
 As above, but for orphaned packages:
 .PP
 .EX
-    $ pacman \-Slq custom | aur query \-t info | \e
+    $ pacman \-Slq custom | aur query \-t info - | \e
           jq \-r \(aq.[].results[] | select(.Maintainer == null)\(aq
 .EE
 .PP

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -1,4 +1,4 @@
-.TH AUR 1 2019-03-03 AURUTILS
+.TH AUR 1 2021-12-06 AURUTILS
 .SH NAME
 aur \- helper tool for the arch user repository
 .
@@ -243,7 +243,13 @@ is the interactive shell.
 Run actions on the dependency tree of an AUR package:
 .PP
 .EX
-    $ echo foo | aur depends | while read \-r pkg; do ... done
+    $ aur depends foo | while read \-r pkg; do ... done
+.EE
+.PP
+Retrieve AUR packages and their dependencies recursively:
+.PP
+.EX
+    $ aur depends --pkgbase foo | aur fetch -
 .EE
 .PP
 Build
@@ -316,7 +322,7 @@ and
 in the name:
 .PP
 .EX
-    $ aur pkglist \-P \(aq(?=.*wm)(?=.*git)\(aq | xargs aur search \-i
+    $ aur pkglist \-P \(aq(?=.*wm)(?=.*git)\(aq | aur search \-i \-
 .EE
 .PP
 Select an AUR package with name matching

--- a/tests/issue/706
+++ b/tests/issue/706
@@ -1,5 +1,5 @@
 #!/bin/bash
-out=$(aur query -t info </dev/null)
+out=$(aur query -t info - </dev/null)
 err=$?
 
 # expected: empty output, exit 0


### PR DESCRIPTION
This change allows most `aur` scripts to support both stdin and command-line arguments. In particular, this removes use of `xargs` in `aur-sync` and with that preserves error codes of `aur-depends` and `aur-fetch`. 

Only `aur-fetch` and `aur-query` require explicit support for `-` and `/dev/stdin`. Other scripts call them with their arguments, and so support `-` implicitly.

This PR also removes `--recurse` from `aur-fetch`, because `aur-depends --pkgbase` can now be directly piped into it, as well as stdin "warnings" because the user now has to explicitly request stdin.