### PR TITLE
aur-view: add --arg-file, remove /dev/stdin

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -369,7 +369,7 @@ fi
 
 # Inspect package files
 if (( view )); then
-    aur view "${view_args[@]}" - < "$tmp"/queue
+    aur view -a "$tmp"/queue "${view_args[@]}"
 fi
 
 if (( build )); then

--- a/lib/aur-view
+++ b/lib/aur-view
@@ -29,8 +29,8 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
     [[ -t 2 ]] && colorize
 fi
 
-opt_short=''
-opt_long=('format:') # TODO: add --confirm? (overrides AUR_CONFIRM_PAGER)
+opt_short='a:'
+opt_long=('format:' 'arg-file:') # TODO: add --confirm? (overrides AUR_CONFIRM_PAGER)
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -38,8 +38,11 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
+unset queue
 while true; do
     case "$1" in
+        -a|--arg-file)
+            shift; queue=$1 ;;
         --format)
             shift; log_fmt=$1 ;;
         --dump-options)
@@ -60,19 +63,23 @@ trap 'trap_exit' EXIT
 view_db=$XDG_DATA_HOME/aurutils/view
 mkdir -p "$view_db"
 
-if (( ! $# )); then
+# Take input from a file instead of redirecting stdin (#871)
+packages=()
+if [[ -v queue ]]; then
+    exec {fd}< "$queue"
+
+    while read -ru "$fd"; do
+        [[ $REPLY ]] && packages+=("$REPLY")
+    done
+else
+    packages=("$@")
+    set --
+fi
+
+if (( ! ${#packages[@]} )); then
     plain >&2 "there is nothing to do"
     exit
 fi
-
-# Single hyphen to denote input taken from stdin
-if (( $# == 1 )) && [[ $1 == "-" || $1 == "/dev/stdin" ]]; then
-    # Array for multiple iterations (symlink, diff, inspection, update)
-    readarray -t packages
-else
-    packages=("$@")
-fi
-set --
 
 # Link build files in the queue (absolute links)
 for pkg in "${packages[@]}"; do


### PR DESCRIPTION
Redirecting standard input to aur-view (from a file or elsewhere, using `-`) does the same for any command running inside the script, including file managers set in `AUR_PAGER`.

Most file managers have problems when standard input is not connected to a terminal, e.g. by not displaying files (`nnn`) or aborting immediately (`ranger`). To handle these cases, remove the option to take input from stdin, and add an `--arg-file` option instead, similar to `aur-build`.

Fixes #871