### PR TITLE
aur-build: add --no-check

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -101,11 +101,12 @@ fi
 opt_short='a:d:D:U:AcCfnrsvLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'repo:' 'force' 'root:' 'sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:' 'results:' 'remove'
-          'pkgver' 'rmdeps' 'no-confirm' 'ignore-arch' 'log' 'new'
+          'pkgver' 'rmdeps' 'no-confirm' 'no-check' 'ignore-arch' 'log' 'new'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
           'syncdeps' 'clean' 'namcap' 'checkpkg' 'user:' 'makepkg-args:'
           'buildscript:')
-opt_hidden=('dump-options' 'gpg-sign' 'ignorearch' 'noconfirm' 'nosync' 'margs:')
+opt_hidden=('dump-options' 'gpg-sign' 'ignorearch' 'noconfirm' 'nocheck'
+            'nosync' 'margs:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -173,6 +174,8 @@ while true; do
             makepkg_args+=(--clean) ;;
         -L|--log)
             makepkg_args+=(--log) ;;
+        --nocheck|--no-check)
+            makepkg_args+=(--nocheck) ;;
         --makepkg-args|--margs)
             shift; IFS=, read -a arg -r <<< "$1"
             makepkg_args+=("${arg[@]}")

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -132,7 +132,8 @@ while true; do
         --nomakedepends|--no-makedepends)
             depends_args+=(--no-makedepends) ;;
         --nocheckdepends|--no-checkdepends)
-            depends_args+=(--no-checkdepends) ;;
+            depends_args+=(--no-checkdepends)
+            build_args+=(--no-check) ;;
         --nograph|--no-graph)
             graph=0 ;;
         --nover|--no-ver)

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -98,12 +98,10 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'no-view' 'no-provides' 'no-build' 'rm-deps' 'sign' 'temp' 'upgrades'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
-          'results:' 'makepkg-args:' 'format:' 'no-depends'
-          'no-makedepends' 'no-checkdepends')
+          'results:' 'makepkg-args:' 'format:' 'no-check')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
-            'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign' 'margs:'
-            'nodepends' 'nomakedepends' 'nocheckdepends')
+            'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign' 'margs:' 'nocheck')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -127,11 +125,7 @@ while true; do
             shift; ignore_file=$1 ;;
         -o|--nobuild|--no-build)
             build=0 ;;
-        --nodepends|--no-depends)
-            depends_args+=(--no-depends) ;;
-        --nomakedepends|--no-makedepends)
-            depends_args+=(--no-makedepends) ;;
-        --nocheckdepends|--no-checkdepends)
+        --nocheck|--no-check)
             depends_args+=(--no-checkdepends)
             build_args+=(--no-check) ;;
         --nograph|--no-graph)

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -246,6 +246,11 @@ by placing them after
 (comma-separated).
 .
 .TP
+.BR \-\-nocheck
+Do not run the check() function in the PKGBUILD.
+.RB ( makepkg " " \-\-nocheck )
+.
+.TP
 .BR \-n ", " \-\-noconfirm
 Do not wait for user input.
 .RB ( makepkg " " \-\-noconfirm )

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -68,7 +68,11 @@ and
 .BR \-\-no\-checkdepends
 are supported and appended to the
 .B aur\-depends
-command-line.
+command-line. The
+.B \-\-no\-checkdepends
+option enables
+.B aur\-build \-\-no\-check
+in addition.
 .
 .TP
 .BR \-\-nograph ", " \-\-no\-graph

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -61,18 +61,11 @@ Update all obsolete AUR packages in a local repository.
 .SS Dependency options
 Build dependencies are resolved with
 .BR aur\-depends (1).
-The options
-.BR \-\-no\-depends ,
-.BR \-\-no\-makedepends ,
-and
-.BR \-\-no\-checkdepends
-are supported and appended to the
-.B aur\-depends
-command-line. The
-.B \-\-no\-checkdepends
-option enables
-.B aur\-build \-\-no\-check
-in addition.
+.
+.TP
+.BR \-\-nocheck ", " \-\-no\-check
+Do not handle checkdepends.
+.RB ( "aur\-build \-\-no-\check" ", " "aur\-depends \-\-no\-checkdepends" )
 .
 .TP
 .BR \-\-nograph ", " \-\-no\-graph


### PR DESCRIPTION
Allows to do `aur depends --no-checkdepends` and `makepkg --nocheck` in one step, via `aur sync --no-checkdepends`.

Closes #874