### PR TITLE
Add & fix dependency selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+aur
+completions/bash/aur
+completions/zsh/_aur

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -54,6 +54,9 @@ tr_ver() {
 chain() {
     local a num sub
 
+    select_args=("$1" "$2" "$3")
+    shift 3
+
     aur query -t info "$@" > json/0 || exit
     num=$(count json/0)
 
@@ -69,7 +72,15 @@ chain() {
     # dependencies) the difference is unlikely to be noticeable.
     for (( a = 1; a <= max_request; ++a )); do
         sub=$(( a - 1 ))
-        tabulate json/$sub | tee -a tsv/n > tsv/$sub
+        tabulate json/$sub > tsv/x$sub
+
+        # filter dependencies by type
+        if [[ "${select_args[*]}" == *0* ]]; then
+            select_deps "${select_args[@]}" tsv/x$sub > tsv/$sub
+        else
+            mv tsv/x$sub tsv/$sub
+        fi
+        cat tsv/$sub >> tsv/n
 
         # Avoid querying duplicates (#4)
         cut -f1 tsv/$sub >> seen # pkgname
@@ -154,7 +165,9 @@ trap 'trap_exit' EXIT
 
 rings=0
 if cd "$tmp" && mkdir json tsv; then
-    chain "$@" || rings=$? # tsv/n: pkgname\tdepends\tpkgbase\pkgver
+    # tsv/n: pkgname\tdepends\tpkgbase\pkgver
+    chain "$resolve_depends" "$resolve_makedepends" "$resolve_checkdepends" "$@" || rings=$?
+    deptable=tsv/n
 
     # check iteration number
     case $rings in
@@ -164,14 +177,6 @@ if cd "$tmp" && mkdir json tsv; then
             printf >&2 '%s: total requests: %d (out of range)\n' "$argv0" $(( max_request + 1 ))
             exit 34 ;;
     esac
-
-    # filter dependencies by type
-    if (( resolve_depends == 0 || resolve_makedepends == 0 || resolve_checkdepends == 0 )); then
-        select_deps "$resolve_depends" "$resolve_makedepends" "$resolve_checkdepends" tsv/n > tsv/x
-        deptable=tsv/x
-    else
-        deptable=tsv/n
-    fi
 
     case $mode in
         # pkgbase (AUR, total order)

--- a/lib/aur-graph
+++ b/lib/aur-graph
@@ -40,6 +40,7 @@ while true; do
 done
 
 depends_types=''
+no_depends=0
 if (( resolve_depends == 1 )); then
     depends_types+="|depends"
 fi
@@ -55,7 +56,7 @@ if [ "$depends_types" == '' ]; then
 fi
 depends_types="${depends_types:1}"
 
-awk '
+awk -v no_depends=$no_depends '
 # < 0 : if ver1 < ver2
 # = 0 : if ver1 == ver2
 # > 0 : if ver1 > ver2
@@ -104,7 +105,7 @@ function get_vercmp(ver1, ver2, op) {
 }
 
 /^\t('"$depends_types"')/ {
-    if (!in_split_pkg'"${no_depends:+" && 0"}"') {
+    if (!no_depends && !in_split_pkg) {
         # POSIX array of arrays!
         pkg_deps[pkgbase, ++dep_counts[pkgbase]] = $3 # versioned
     }

--- a/lib/aur-graph
+++ b/lib/aur-graph
@@ -1,6 +1,7 @@
 #!/bin/bash
 # aur-graph - print package/dependency pairs
 
+argv0=graph
 resolve_depends=1
 resolve_makedepends=1
 resolve_checkdepends=1

--- a/lib/aur-graph
+++ b/lib/aur-graph
@@ -1,6 +1,60 @@
-#!/bin/awk -f
+#!/bin/bash
 # aur-graph - print package/dependency pairs
 
+resolve_depends=1
+resolve_makedepends=1
+resolve_checkdepends=1
+
+usage() {
+    printf >&2 'usage: %s [.SRCINFO...]\n' "$argv0"
+    exit 1
+}
+
+source /usr/share/makepkg/util/parseopts.sh
+
+opt_short=''
+opt_long=('no-depends' 'no-makedepends' 'no-checkdepends')
+opt_hidden=()
+
+if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
+    usage
+fi
+set -- "${OPTRET[@]}"
+
+while true; do
+    case "$1" in
+        --no-depends)
+            resolve_depends=0 ;;
+        --no-makedepends)
+            resolve_makedepends=0 ;;
+        --no-checkdepends)
+            resolve_checkdepends=0 ;;
+        --dump-options)
+            printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
+            printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
+            exit ;;
+        --) shift; break ;;
+    esac
+    shift
+done
+
+depends_types=''
+if (( resolve_depends == 1 )); then
+    depends_types+="|depends"
+fi
+if (( resolve_makedepends == 1 )); then
+    depends_types+="|makedepends"
+fi
+if (( resolve_checkdepends == 1 )); then
+    depends_types+="|checkdepends"
+fi
+if [ "$depends_types" == '' ]; then
+    depends_types="|depends"
+    no_depends=1
+fi
+depends_types="${depends_types:1}"
+
+awk '
 # < 0 : if ver1 < ver2
 # = 0 : if ver1 == ver2
 # > 0 : if ver1 > ver2
@@ -48,8 +102,8 @@ function get_vercmp(ver1, ver2, op) {
     }
 }
 
-/^\t(make|check)?depends/ {
-    if (!in_split_pkg) {
+/^\t('"$depends_types"')/ {
+    if (!in_split_pkg'"${no_depends:+" && 0"}"') {
         # POSIX array of arrays!
         pkg_deps[pkgbase, ++dep_counts[pkgbase]] = $3 # versioned
     }
@@ -130,4 +184,4 @@ END {
 
     if (_vercmp_exit)
         exit _vercmp_exit
-}
+}' "$@"

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -10,7 +10,7 @@ AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
-build_args=(--clean --syncdeps) depends_args=() repo_args=() view_args=()
+build_args=(--clean --syncdeps) depends_args=() repo_args=() view_args=() graph_args=()
 
 # default options
 build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1
@@ -64,7 +64,7 @@ complement_pattern() {
 srcinfo_graph() {
     while read -r pkg; do
         [[ $pkg ]] && printf '%s\0' "$pkg/.SRCINFO"
-    done | xargs -0 cat -- | aur graph >/dev/null
+    done | xargs -0 cat -- | aur graph "${graph_args[@]}" >/dev/null
 }
 
 trap_exit() {
@@ -131,6 +131,7 @@ while true; do
             build=0 ;;
         --nocheck|--no-check)
             depends_args+=(--no-checkdepends)
+            graph_args+=(--no-checkdepends)
             build_args+=(--no-check) ;;
         --nograph|--no-graph)
             graph=0 ;;

--- a/man1/aur-graph.1
+++ b/man1/aur-graph.1
@@ -25,6 +25,23 @@ files may be concatenated before processing:
     $ cat */.SRCINFO | aur graph | tsort | tac
 .EE
 .
+.SH OPTIONS
+.SS Dependency options
+When ordering packages,
+.B aur\-graph
+considers all types (
+.IR depends ,
+.IR makedepends ,
+and
+.IR checkdepends )
+of dependencies by default. Types can be removed selectively with
+the
+.BR \-\-no\-depends ,
+.BR \-\-no\-makedepends ,
+and
+.B \-\-no\-checkdepends
+options. In particular, these options may be used to bypass cycles between dependencies of differing types.
+.
 .SH EXAMPLES
 .B aur\-graph
 supports

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -65,7 +65,7 @@ Build dependencies are resolved with
 .TP
 .BR \-\-nocheck ", " \-\-no\-check
 Do not handle checkdepends.
-.RB ( "aur\-build \-\-no-\check" ", " "aur\-depends \-\-no\-checkdepends" )
+.RB ( "aur\-build \-\-no\-check" ", " "aur\-depends \-\-no\-checkdepends" )
 .
 .TP
 .BR \-\-nograph ", " \-\-no\-graph

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -65,7 +65,7 @@ Build dependencies are resolved with
 .TP
 .BR \-\-nocheck ", " \-\-no\-check
 Do not handle checkdepends.
-.RB ( "aur\-build \-\-no\-check" ", " "aur\-depends \-\-no\-checkdepends" )
+.RB ( "aur\-build \-\-no\-check" ", " "aur\-depends \-\-no\-checkdepends" ", " "aur\-graph \-\-no\-checkdepends")
 .
 .TP
 .BR \-\-nograph ", " \-\-no\-graph

--- a/tests/package
+++ b/tests/package
@@ -17,3 +17,7 @@ test_package_huge=(
     'plasma-git-meta' # 100+ depends
     'ros-lunar-desktop' # 250+ depends 
 )
+
+test_package_checkcycle=(
+    'ruby-activemodel' # contain dependency cycles if checkdepends is considered
+)


### PR DESCRIPTION
- Add `--no-depends`, `--no-makedepends`, `--no-checkdepends` options to aur-graph
- Use `aur graph --no-checkdepends` when `--no-check` is given to aur-sync.
- The dependency selection code in aur-depends was incorrect (it would fetch unneeded dependencies); this is now fixed.

Also fixes #845.