### PR TITLE
aur-build.1: Remove mention of `keyserver-options`

### DIFF
--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -443,7 +443,7 @@ user.
 GPG signatures defined in the
 .B validpgpkeys
 array may be automatically retrieved by setting the
-.I "keyserver\-options auto\-key\-retrieve"
+.I auto\-key\-retrieve
 option in
 .BR gpg.conf .
 Note that this option only works with signatures that include an


### PR DESCRIPTION
The option has been deprecated and is now just called `auto-key-retrieve`.

>  --keyserver-options {name=value}
> …
>    auto-key-retrieve
>      This is an obsolete alias for the option auto-key-retrieve.  Please do not use it; it will be removed in future versions..