### PR TITLE
aur-repo: add --path, --path-list, --repo-list compat options

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -7,7 +7,7 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 
 # default options
-clone=1 sync=no
+clone=1 recurse=0 sync=no
 
 results() {
     local mode=$1 prev=$2 current=$3 path=$4 dest=$5
@@ -33,8 +33,8 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
     [[ -t 2 ]] && colorize
 fi
 
-opt_short='S'
-opt_long=('sync:' 'results:' 'existing')
+opt_short='rS'
+opt_long=('sync:' 'results:' 'existing' 'recurse')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -60,6 +60,9 @@ while true; do
             esac ;;
         --results)
             shift; results_file=$1 ;;
+        ## deprecated options
+        --recurse|-r)
+            recurse=1 ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
@@ -85,7 +88,9 @@ if [[ -v results_file ]]; then
     : >"$results_file" || exit 1 # truncate file
 fi
 
-if (( stdin )); then
+if (( recurse )); then
+    aur depends --pkgbase "$@" # stdin handled by aur-depends
+elif (( stdin )); then
     tee # noop
 else
     printf '%s\n' "$@"

--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -5,7 +5,7 @@ argv0=repo
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
-db_query=local table_format=0
+db_query=local table_format=0 mode=none
 
 # default arguments
 conf_args=()
@@ -74,9 +74,10 @@ source /usr/share/makepkg/util/parseopts.sh
 
 ## option parsing
 opt_short='c:d:r:alqtuS'
-opt_long=('database:' 'repo:' 'config:' 'root:' 'all' 'list' 'list-repo' 'list-path'
-          'sync' 'upgrades' 'table' 'quiet' 'status' 'status-file:')
-opt_hidden=('dump-options')
+opt_long=('config:' 'database:' 'repo:' 'root:' 'all' 'list' 'path'
+          'path-list' 'repo-list' 'sync' 'upgrades' 'table' 'quiet'
+          'status-file:')
+opt_hidden=('dump-options' 'list-repo' 'list-path' 'status')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -102,16 +103,19 @@ while true; do
             mode=upgrades; vercmp_args+=(-q) ;;
         -u|--upgrades)
             mode=upgrades ;;
-        --list-path)
-            list=path ;;
-        --list-repo)
-            list=repo ;;
-        --status)
-            mode=status; status_file=/dev/fd/1 ;;
         --status-file)
             shift; status_file=$1 ;;
         -S|--sync)
             db_query=sync ;;
+        ## deprecated options
+        --path)
+            mode=path ;;
+        --path-list|--list-path)
+            list=path ;;
+        --repo-list|--list-repo)
+            list=repo ;;
+        --status)
+            status_file=/dev/stdout ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
@@ -230,10 +234,10 @@ case $mode in
     packages)
         db_table "$table_format" "$db_path"
         ;;
-    status)
-        ;; # status information printed to /dev/fd/1
+    path)
+        printf '%s\n' -- "$db_path"
+        ;;
     *)
-        usage
         ;;
 esac
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -105,7 +105,8 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'repo:' 'directory:' 'ignore:' 'root:'
           'results:' 'makepkg-args:' 'format:' 'no-check')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
-            'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign' 'margs:' 'nocheck')
+            'rebuildall' 'rebuildtree' 'rmdeps' 'gpg-sign' 'margs:' 'nocheck' 
+            'no-checkdepends' 'nocheckdepends')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -129,7 +130,7 @@ while true; do
             shift; ignore_file=$1 ;;
         -o|--nobuild|--no-build)
             build=0 ;;
-        --nocheck|--no-check)
+        --nocheck|--no-check|--nocheckdepends|--no-checkdepends)
             depends_args+=(--no-checkdepends)
             build_args+=(--no-check) ;;
         --nograph|--no-graph)

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -90,6 +90,15 @@ Alias for
 .BR \-\-sync=auto .
 .
 .TP
+.BR \-r ", " \-\-recurse
+Download packages and their dependencies with
+.BR aur\-depends (1).
+If this option is specified, arguments must be supplied by
+.B pkgname
+instead of by
+.BR pkgbase .
+.
+.TP
 .BI \-\-results= FILE
 Write colon-delimited output in the following form to
 .IR FILE :

--- a/man1/aur-repo.1
+++ b/man1/aur-repo.1
@@ -7,7 +7,6 @@ aur\-repo \- manage local repositories
 .OP \-\-list
 .OP \-\-table
 .OP \-\-upgrades
-.OP \-\-status
 .SY "aur repo"
 .OP \-c file
 .OP \-d name
@@ -43,18 +42,6 @@ List the contents of a local repository in the following format:
 .BI pkgname \et pkgver \en
 .
 .TP
-.BR \-\-list\-path
-List the resolved paths of configured local
-.BR pacman (8)
-repositories.
-.
-.TP
-.BR \-\-list\-repo
-List the names of configured local
-.BR pacman (8)
-repositories.
-.
-.TP
 .BR \-t ", " \-\-table
 List the contents of a local repository in the following format:
 .IP
@@ -77,6 +64,20 @@ in
 Check package updates with
 .BR aur\-vercmp (1)
 .
+.TP
+.BR \-\-list\-path
+List the paths of configured local repositories.
+.
+.TP
+.BR \-\-list\-repo
+List the names of configured local repositories.
+.
+.TP
+.BR \-\-path
+List the resolved path of the selected
+.BR pacman (8)
+repository.
+.
 .SH OPTIONS
 .TP
 .BI \-c " FILE" "\fR,\fP \-\-config=" FILE
@@ -85,7 +86,7 @@ Specify an alternate
 configuration file.
 .
 .TP
-.BI \-d " NAME" "\fR,\fP \-\-database=" NAME
+.BI \-d " NAME" "\fR,\fP \-\-database=" NAME "\fR,\fP \-\-repo=" NAME
 The name of a
 .BR pacman (8)
 repository.
@@ -122,17 +123,16 @@ instead of by their
 path.
 .
 .TP
-.BR \-\-status
-Print status information to standard output, in the following format:
+.BR \-\-status\-file FILE
+Print status information to a specified file, in the following format:
 .EX
+.PP
 repo:<repository name>
 root:<root of repository>
 path:<path of repository>
+.PP
 .EE
-.
-.BR \-\-status\-file FILE
-As \-\-status, but prints to a user-specified file. Can be combined
-with other operations.
+Can be combined with other operations.
 .
 .SH ENVIRONMENT
 .TP


### PR DESCRIPTION
For compatibility with aurutils <3.2.0. All these options (including `--status`) should be considered deprecated and may be modified or removed in any later release.