### PR TITLE
aur-repo: initialize dependencies array with zero length

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -30,7 +30,7 @@ db_table() {
 
     BEGIN {
         pkgname = pkgbase = pkgver = "-"
-        dependencies[0] = ""
+        delete dependencies[0]
     }
 
     /^%FILENAME%$/ && FNR > 1 {


### PR DESCRIPTION
Fixes #892