### PR TITLE
sync: fix --upgrades if --ignore is specified

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -30,7 +30,7 @@ lib32() {
 
 # files: $1 pkgname\tpkgbase $2 pkgname (order by $2)
 select_pkgbase() {
-    awk 'NR == FNR {
+    awk 'ARGV[1] == FILENAME {
         map[$1] = $2
         next
     }
@@ -49,12 +49,12 @@ select_pkgbase() {
 
 # files: $1 pkgname $2 pkgname\tpkgver
 select_ignores() {
-    awk 'NR == FNR {
+    awk 'ARGV[1] == FILENAME {
         map[$1] = 1
         next
     }
     !($1 in map) {
-        printf("%s\t%s\n", $1, $2)
+        print
     }' "$@"
 }
 

--- a/tests/issue/741
+++ b/tests/issue/741
@@ -40,13 +40,13 @@ env - HOME=$HOME USER=$USER PATH=$PATH aur build --no-sync \
      -rnd "$tmp_uid" --margs --skippgpcheck --pacman-conf "$tmp"/pacman.conf
 
 fakeroot -- pacman --config "$tmp"/pacman.conf --dbpath "$tmp" -Sy
-pacsift --config "$tmp"/pacman.conf --dbpath "$tmp" \
-    --repo="$tmp_uid" --satisfies="$pkg=$ver"
+found_package=$(pacsift --config "$tmp"/pacman.conf --dbpath "$tmp" --repo="$tmp_uid" --satisfies="$pkg=$ver")
+[[ -n $found_package ]]
 
 # update to latest revision
 cd -
-env - HOME=$HOME USER=$USER PATH=$PATH AURDEST="$tmp" aur sync --no-build \
-    -d "$tmp_uid" --no-view --pacman-conf "$tmp"/pacman.conf "$pkg"
+env - HOME=$HOME USER=$USER PATH=$PATH AURDEST="$tmp" aur sync --no-build --upgrades \
+    -d "$tmp_uid" --no-view --pacman-conf "$tmp"/pacman.conf
 
 # build new version
 cd "$pkg"
@@ -54,7 +54,7 @@ env - HOME=$HOME USER=$USER PATH=$PATH aur build --no-sync  \
      -rnd "$tmp_uid" --margs --skippgpcheck --pacman-conf "$tmp"/pacman.conf
 
 fakeroot -- pacman --config "$tmp"/pacman.conf --dbpath "$tmp" -Sy
-pacsift --config "$tmp"/pacman.conf --dbpath "$tmp" \
-    --repo="$tmp_uid" --satisfies="$pkg>$ver"
+found_package=$(pacsift --config "$tmp"/pacman.conf --dbpath "$tmp" --repo="$tmp_uid" --satisfies="$pkg>$ver")
+[[ -n $found_package ]]
 
 # vim: set et sw=4 sts=4 ft=sh:\n


### PR DESCRIPTION
Due to `select_ignores()` using `FNR == NR`, if the ignore file (`igni`) is empty, no lines would be printed at all. In other words, `db_info` would be empty, and no targets from `aur repo -u` would be added.

Fixes #901