### PR TITLE
srcver: add -E / --env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ETCDIR ?= /etc
 AURUTILS_LIB_DIR ?= $(LIBDIR)/$(PROGNM)
 AURUTILS_VERSION ?= $(shell git describe --tags || true)
 ifeq ($(AURUTILS_VERSION),)
-AURUTILS_VERSION := 4.3
+AURUTILS_VERSION := 5
 endif
 
 .PHONY: shellcheck install build completion aur

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -6,7 +6,7 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 srcver_pkgbuild_info() {
     # shellcheck disable=SC2016
-    env -C "$1" -i bash -c '
+    env -C "$1" -i "${@:2}" bash -c '
         PATH= source PKGBUILD
 
         if [[ -v epoch ]]; then
@@ -34,8 +34,8 @@ usage() {
 
 source /usr/share/makepkg/util/parseopts.sh
 
-opt_short=j:
-opt_long=('no-prepare' 'jobs:')
+opt_short=j:E:
+opt_long=('no-prepare' 'jobs:' 'env:')
 opt_hidden=('dump-options' 'noprepare')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -46,10 +46,13 @@ set -- "${OPTRET[@]}"
 makepkg_args=('--nobuild' '--nodeps' '--skipinteg')
 num_procs=$(( "$(nproc)" + 2 ))
 
+unset extra_env
 while true; do
     case "$1" in
         --noprepare|--no-prepare)
             makepkg_args+=(--noprepare) ;;
+        -E|--env)
+            shift; extra_env+=("$1=${!1@Q}") ;;
         -j|--jobs)
             shift; num_procs=$1 ;;
         --dump-options)
@@ -91,7 +94,7 @@ for n in "$@"; do
     if [[ -e $tmp/$n/failed ]]; then
         failed+=("$n")
     else
-        srcver_pkgbuild_info "$n"
+        srcver_pkgbuild_info "$n" "${extra_env[@]}"
     fi
 done
 

--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -5,9 +5,12 @@ argv0=srcver
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 srcver_pkgbuild_info() {
+    # Unset PATH before invocation, because it can not be modified in bash's
+    # restricted mode. If PATH is taken from the environment (-E PATH), it will
+    # override the empty value.
     # shellcheck disable=SC2016
-    env -C "$1" -i "${@:2}" bash -c '
-        PATH= source PKGBUILD
+    env -C "$1" -i PATH= "${@:2}" /usr/bin/bash -rc '
+        source PKGBUILD
 
         if [[ -v epoch ]]; then
             fullver=$epoch:$pkgver-$pkgrel
@@ -52,7 +55,7 @@ while true; do
         --noprepare|--no-prepare)
             makepkg_args+=(--noprepare) ;;
         -E|--env)
-            shift; extra_env+=("$1=${!1@Q}") ;;
+            shift; extra_env+=("$1=${!1}") ;;
         -j|--jobs)
             shift; num_procs=$1 ;;
         --dump-options)

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,13 @@
+## 5
+
+* `aur-srcver`
+  + add `-E` / `--env` (#898)
+
+## 4.4
+
+* `aur-sync`
+  + fix regressions with `--ignore` from 4.3 release
+
 ## 4.3
 
 * `aur-build`


### PR DESCRIPTION
Some PKGBUILDs run commands outside of the package function, which causes `aur-srcver` to fail because the PKGBUILD is sourced with an empty environment (`PATH` is empty).

Allow the user to specify environment variables that can be preserved with `-E`.

Issue #898