### PR TITLE
aur-query: add HTTP POST for info-type requests

### DIFF
--- a/lib/aur-query
+++ b/lib/aur-query
@@ -5,31 +5,57 @@ argv0=query
 AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
 AUR_QUERY_PARALLEL=${AUR_QUERY_PARALLEL:-0}
 AUR_QUERY_PARALLEL_MAX=${AUR_QUERY_PARALLEL_MAX:-15}
-AUR_QUERY_RPC=${AUR_QUERY_RPC:-$AUR_LOCATION/rpc/?v=5}
+AUR_QUERY_RPC=${AUR_QUERY_RPC:-$AUR_LOCATION/rpc}
+AUR_QUERY_RPC_POST=${AUR_QUERY_RPC_POST:-1}
 AUR_QUERY_RPC_SPLITNO=${AUR_QUERY_RPC_SPLITNO:-150}
+AUR_QUERY_RPC_VERSION=${AUR_QUERY_RPC_VERSION:-5}
 PS4='+(${BASH_SOURCE}:${LINENO}):${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
 curl_args=(-fgLsS --tcp-fastopen)
 
-uri_info() {
-    awk -v rpc="$AUR_QUERY_RPC&type=info" -v splitno="$AUR_QUERY_RPC_SPLITNO" '{
+# Filters for generating curl configuration
+rpc_info() {
+    local rpc_url="$AUR_QUERY_RPC?v=$AUR_QUERY_RPC_VERSION&type=info"
+    local splitno="$AUR_QUERY_RPC_SPLITNO"
+
+    # Write opening and closing quotes with \x22 (hexadecimal)
+    awk -v rpc="$rpc_url" -v splitno="$splitno" '{
         if (NR == 1)
-            printf "%s&arg[]=%s", rpc, $0
+            printf "url \x22%s&arg[]=%s", rpc, $0
         else if (NR % splitno == 0)
-            printf "\n%s&arg[]=%s", rpc, $0
+            printf "\x22\nurl \x22%s&arg[]=%s", rpc, $0
         else if (NR > 1)
             printf "&arg[]=%s", $0
     } END {
         if (NR != 0)
-            printf "\n"
+            printf "\x22\n"
     }'
 }
 
-uri_search() {
-    awk -v rpc="$AUR_QUERY_RPC&type=search&by=$1&arg" '{
-        printf "%s=%s\n", rpc, $0
-    }'
+# POST requests are useful for info-type requests to circumvent limits on the
+# URL length with GET requests. The difference is that all data is now included
+# in the message body, instead of in the URI.
+rpc_info_post() {
+    # TODO: This could potentially be split into multiple url sections for use
+    # with curl --parallel (benchmarks?)
+    printf 'url "%s"\n' "$AUR_QUERY_RPC"
+    printf 'data "v=%s"\n' "$AUR_QUERY_RPC_VERSION"
+    printf 'data "type=info"\n'
+
+    while IFS= read -r pkg; do
+        printf 'data-urlencode "arg[]=%s"\n' "$pkg"
+    done
+}
+
+# Search-type requests can only contain one package argument, and GET requests
+# are sufficient for this.
+rpc_search() {
+    local rpc_url="$AUR_QUERY_RPC?v=$AUR_QUERY_RPC_VERSION&type=search&by=$1&arg"
+
+    while IFS= read -r term; do
+        printf 'url "%s=%s"\n' "$rpc_url" "$term"
+    done
 }
 
 trap_exit() {
@@ -88,20 +114,22 @@ if (( ! $# )); then
 fi
 
 # set filters
-case $arg_type in
-      info) uri_write() { uri_info; } ;;
-    search) uri_write() { uri_search "${arg_by:-name-desc}"; } ;;
-         *) usage ;;
-esac
+if [[ $arg_type == "search" ]]; then
+    curl_config() { jq -R -r '@uri' | rpc_search "${arg_by:-name-desc}"; }
 
-# generate curl config
+elif [[ $arg_type == "info" ]] && (( AUR_QUERY_RPC_POST )); then
+    curl_config() { rpc_info_post; }  # URI encoding is handled by curl --data-urlencode
+
+elif [[ $arg_type == "info" ]]; then
+    curl_config() { jq -R -r '@uri' | rpc_info; }
+fi
+
+# main pipeline
 if (( stdin )); then
     tee # noop
 else
     printf '%s\n' "$@"
-fi | jq -R -r '@uri' | uri_write | while IFS= read -r uri; do
-    printf 'url "%s"\n' "$uri"
-done > "$tmp"/config
+fi | curl_config > "$tmp"/config
 
 # exit cleanly on empty input (#706)
 if [[ ! -s $tmp/config ]]; then

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -12,7 +12,7 @@ AUR_QUERY_RPC_VERSION=${AUR_QUERY_RPC_VERSION:-5}
 PS4='+(${BASH_SOURCE}:${LINENO}):${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
-curl_args=(-fgLsS --tcp-fastopen)
+curl_args=(-fgLsSq --tcp-fastopen)
 
 # Filters for generating curl configuration
 rpc_info() {

--- a/man1/aur-query.1
+++ b/man1/aur-query.1
@@ -1,6 +1,6 @@
 .TH AUR-QUERY 1 2021-11-27 AURUTILS
 .SH NAME
-aur\-query \- send GET requests to the aurweb RPC interface
+aur\-query \- send requests to the aurweb RPC interface
 .
 .SH SYNOPSIS
 .SY "aur query"
@@ -12,7 +12,7 @@ aur\-query \- send GET requests to the aurweb RPC interface
 .SH DESCRIPTION
 .B aur\-query
 retrieves package information from an AUR endpoint by sending HTTP GET
-requests to the
+or POST requests to the
 .UR https://\:aur.archlinux.org/\:rpc.php
 RPC interface
 .UE
@@ -78,17 +78,35 @@ The URI of the RPC interface. Defaults to
 .IR "$AUR_LOCATION/rpc/?v=5" .
 .
 .TP
+.B AUR_QUERY_RPC_POST
+If set to a positive value, use HTTP POST for info-type requests.
+Defaults to
+.IR 1 .
+HTTP GET results in a significantly higher number of requests
+(potentially leading to rate limiting), so HTTP POST should be preferred
+in most cases. Due to FastAPI limitations, the maximum number of
+packages queried with HTTP POST is around 27k.
+.
+.TP
 .B AUR_QUERY_RPC_SPLITNO
-The amount of packages per GET request. Defaults to 150. Used to avoid
-HTTP 414 errors with large amounts of packages
+This variable sets the amount of packages listed per URI when using HTTP
+GET for info-type requests. This is used to avoid HTTP 414 errors with
+larger sets (>200) of packages
 .RI ( FS#49089 ).
+Defaults to
+.IR 150 .
+.
+.TP
+.B AUR_QUERY_RPC_VERSION
+The version for the RPC endpoint. Defaults to
+.IR 5 .
 .
 .SH NOTES
 The default set of options for
 .BR curl (1)
 are
 .BR "\-fgLsS \-\-tcp\-fastopen" .
-
+.
 .SH SEE ALSO
 .ad l
 .nh

--- a/man1/aur-query.1
+++ b/man1/aur-query.1
@@ -105,7 +105,7 @@ The version for the RPC endpoint. Defaults to
 The default set of options for
 .BR curl (1)
 are
-.BR "\-fgLsS \-\-tcp\-fastopen" .
+.BR "\-fgLsSq \-\-tcp\-fastopen" .
 .
 .SH SEE ALSO
 .ad l


### PR DESCRIPTION
In theory POST allows for an unlimited amount of packages per info-type request, because URI length limits do not need to be considered.

The behavior is controlled by the `AUR_QUERY_RPC_POST` variable, which enables HTTP POST when set to a positive value (defaults to 1).

Search-type requests still use HTTP GET, because each request can only contain a single package (removing the need to deal with URI length limits.)

Because of the changes above, the `AUR_QUERY_RPC` variable should now only point to the address of the AUR endpoint, e.g. https://aur.archlinux.org/rpc.

Closes #902