### PR TITLE
query, pkglist: use `aurutils` user-agent

### DIFF
--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -14,11 +14,11 @@ http_last_modified() {
 }
 
 list_update() {
-    curl -f "$1" --compressed --output "$2" --dump-header "$3"
+    curl -A aurutils -f "$1" --compressed --output "$2" --dump-header "$3"
 }
 
 list_headers() {
-    curl -f "$1" --head -Ss
+    curl -A aurutils -f "$1" --head -Ss
 }
 
 usage() {

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -12,7 +12,7 @@ AUR_QUERY_RPC_VERSION=${AUR_QUERY_RPC_VERSION:-5}
 PS4='+(${BASH_SOURCE}:${LINENO}):${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
-curl_args=(-fgLsSq --tcp-fastopen)
+curl_args=(-A aurutils -fgLsSq --tcp-fastopen)
 
 # Filters for generating curl configuration
 rpc_info() {

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -3,6 +3,13 @@
 * `aur-srcver`
   + add `-E` / `--env` (#898)
 
+* `aur-query`
+  + support HTTP POST for info-type requests
+  + use `aurutils` user agent (`curl -A`)
+
+* `aur-pkglist`
+  + use `aurutils` user agent (`curl -A`)
+
 ## 4.4
 
 * `aur-sync`

--- a/man1/aur-query.1
+++ b/man1/aur-query.1
@@ -105,7 +105,7 @@ The version for the RPC endpoint. Defaults to
 The default set of options for
 .BR curl (1)
 are
-.BR "\-fgLsSq \-\-tcp\-fastopen" .
+.BR "\-A aurutils \-fgLsSq \-\-tcp\-fastopen" .
 .
 .SH SEE ALSO
 .ad l


### PR DESCRIPTION
Fixes #912