### PR TITLE
aur-repo-filter: add --config

### DIFF
--- a/lib/aur-repo-filter
+++ b/lib/aur-repo-filter
@@ -17,7 +17,8 @@ satisfies() {
 }
 
 provides() {
-    pacinfo | awk -F'[:<=>]' '
+    #global info_args
+    pacinfo "${info_args[@]}" | awk -F'[:<=>]' '
         /Name:/     { pkgname=$2; print $2, $2; }
         /Provides:/ { print pkgname, $2; }
         /Replaces:/ { print pkgname, $2; }
@@ -32,7 +33,7 @@ usage() {
 source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='d:a'
-opt_long=('all' 'sync' 'database:' 'repo:' 'sysroot:')
+opt_long=('all' 'sync' 'config:' 'database:' 'repo:' 'sysroot:')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -40,15 +41,19 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset argv_repo sift_args
+unset argv_repo sift_args info_args
 while true; do
     case "$1" in
         -a|--all|--sync)
             sync_repo=1 ;;
         -d|--database|--repo)
             shift; argv_repo+=("$1") ;;
+        --config)
+            shift; sift_args+=(--config="$1")
+            info_args+=(--config="$1") ;;
         --sysroot)
-            shift; sift_args+=("--sysroot=$1") ;;
+            shift; sift_args+=(--sysroot="$1")
+            info_args+=(--sysroot="$1") ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -10,7 +10,7 @@ AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
-build_args=(--clean --syncdeps) depends_args=() repo_args=() view_args=()
+build_args=(--clean --syncdeps) depends_args=() repo_args=() view_args=() filter_args=()
 
 # default options
 build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1
@@ -178,7 +178,8 @@ while true; do
             shift; build_args+=(--makepkg-conf "$1") ;;
         --pacman-conf)
             shift; build_args+=(--pacman-conf "$1")
-            repo_args+=(--config "$1") ;;
+            repo_args+=(--config "$1")
+            filter_args+=(--config "$1") ;;
         --pkgver)
             build_args+=(--pkgver) ;;
         --results)
@@ -333,9 +334,9 @@ cut -f2,5 --complement depends | sort -u >pkginfo
 
   if (( provides )); then
       if (( ${#repo_p[@]} )); then
-          filter_args=("${repo_p[@]/#/--repo=}")
+          filter_args+=("${repo_p[@]/#/--repo=}")
       else
-          filter_args=(--sync)
+          filter_args+=(--sync)
       fi
 
       # Note: this uses pacman's copy of the repo (as used by makepkg -s)

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -10,6 +10,9 @@
 * `aur-pkglist`
   + use `aurutils` user agent (`curl -A`)
 
+* `aur-repo-filter`
+  + add `--config` to set pacman configuration
+
 ## 4.4
 
 * `aur-sync`

--- a/man1/aur-repo-filter.1
+++ b/man1/aur-repo-filter.1
@@ -53,12 +53,19 @@ Multiple repositories can be specified by repeating this argument.
 Set an alternate system root. See
 .BR pacutils\-sysroot (7).
 .
+.TP
+.BI \-\-config= PATH
+Set an alternate
+.BR pacman.conf (5)
+file path.
+.
 .SH SEE ALSO
 .ad l
 .nh
 .BR aur (1),
 .BR pacinfo (1),
 .BR pacsift (1),
+.BR pacman.conf (5),
 .BR pacutils\-sysroot (7)
 .
 .SH AUTHORS


### PR DESCRIPTION
Also ensure the arguments are passed on both to `pacinfo` and `pacsift` (this step was missing for `--sysroot`).