### PR TITLE
aur-query: store intermediary results

### DIFF
--- a/lib/aur-query
+++ b/lib/aur-query
@@ -129,6 +129,18 @@ elif [[ $arg_type == "info" ]]; then
     curl_config() { jq -R -r '@uri' | rpc_info; }
 fi
 
+# generate curl configuration
+if (( $# == 1 )) && [[ $1 == "-" || $1 == "/dev/stdin" ]]; then
+    tee # noop
+else
+    printf '%s\n' "$@"
+fi | curl_config >"$tmp"/config
+
+# exit cleanly on empty input (#706)
+if [[ ! -s $tmp/config ]]; then
+    exit
+fi
+
 # Set intersection only applies to search queries, where one search term leads
 # to multiple results. This is the default, unless --any is specified. Info
 # queries are already implicitly a union of terms (packages), unless duplicate
@@ -165,18 +177,6 @@ case $multiple in
     none)
         combine() { jq -Mrc; } ;; # format to JSON Lines
 esac
-
-# generate curl configuration
-if (( $# == 1 )) && [[ $1 == "-" || $1 == "/dev/stdin" ]]; then
-    tee # noop
-else
-    printf '%s\n' "$@"
-fi | curl_config >"$tmp"/config
-
-# exit cleanly on empty input (#706)
-if [[ ! -s $tmp/config ]]; then
-    exit
-fi
 
 # support parallel transfers (curl >7.66.0)
 if (( AUR_QUERY_PARALLEL )); then

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -13,7 +13,6 @@ AUR_QUERY_RPC_VERSION=${AUR_QUERY_RPC_VERSION:-5}
 PS4='+(${BASH_SOURCE}:${LINENO}):${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
-# add an extra newline for JSON Lines output (#919)
 curl_args=(-A aurutils -fgLsSq)
 
 # Filters for generating curl configuration
@@ -81,7 +80,7 @@ usage() {
 
 source /usr/share/makepkg/util/parseopts.sh
 
-opt_short='b:t:'
+opt_short='b:t:r'
 opt_long=('by:' 'type:' 'any' 'raw')
 opt_hidden=('dump-options' 'dump-curl-config')
 
@@ -95,7 +94,7 @@ while true; do
     case "$1" in
         --any) # set union
             multiple=union ;;
-        --raw)
+        -r|--raw)
             multiple=none ;;
         -b|--by)
             shift; arg_by=$1 ;;
@@ -184,7 +183,7 @@ case $multiple in
             }'
         } ;;
     none)
-        combine() { tee; } ;; # format to JSON Lines
+        combine() { tee; } ;;
 esac
 
 # support parallel transfers (curl >7.66.0)

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -175,7 +175,7 @@ case $multiple in
             }'
         } ;;
     none)
-        combine() { jq -Mrc; } ;; # format to JSON Lines
+        combine() { tee; } ;; # format to JSON Lines
 esac
 
 # support parallel transfers (curl >7.66.0)

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -82,14 +82,14 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='b:t:'
 opt_long=('by:' 'type:' 'any' 'raw')
-opt_hidden=('dump-options')
+opt_hidden=('dump-options' 'dump-curl-config')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
 fi
 set -- "${OPTRET[@]}"
 
-unset arg_by arg_type multiple
+unset arg_by arg_type multiple dump_curl_config
 while true; do
     case "$1" in
         --any) # set union
@@ -100,6 +100,8 @@ while true; do
             shift; arg_by=$1 ;;
         -t|--type)
             shift; arg_type=$1 ;;
+        --dump-curl-config)
+            dump_curl_config=1 ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
@@ -135,6 +137,12 @@ if (( $# == 1 )) && [[ $1 == "-" || $1 == "/dev/stdin" ]]; then
 else
     printf '%s\n' "$@"
 fi | curl_config >"$tmp"/config
+
+# easy access to curl config for debugging
+if (( ${dump_curl_config-0} )); then
+    cat "$tmp"/config
+    exit
+fi
 
 # exit cleanly on empty input (#706)
 if [[ ! -s $tmp/config ]]; then

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -23,12 +23,13 @@ rpc_info() {
 
     # Write opening and closing quotes with \x22 (hexadecimal)
     awk -v rpc="$rpc_url" -v splitno="$splitno" '{
-        if (NR == 1)
+        if ((NR-1) % splitno == 0) {
+            if (NR > 1)
+                printf "\x22\n"             
             printf "url \x22%s&arg[]=%s", rpc, $0
-        else if (NR % splitno == 0)
-            printf "\x22\nurl \x22%s&arg[]=%s", rpc, $0
-        else if (NR > 1)
+        } else if (NR > 1) {
             printf "&arg[]=%s", $0
+        }
     } END {
         if (NR != 0)
             printf "\x22\n"

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -14,7 +14,7 @@ PS4='+(${BASH_SOURCE}:${LINENO}):${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
 # add an extra newline for JSON Lines output (#919)
-curl_args=(-A aurutils -fgLsSq --tcp-fastopen)
+curl_args=(-A aurutils -fgLsSq)
 
 # Filters for generating curl configuration
 rpc_info() {

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -24,7 +24,8 @@ rpc_info() {
     awk -v rpc="$rpc_url" -v splitno="$splitno" '{
         if ((NR-1) % splitno == 0) {
             if (NR > 1)
-                printf "\x22\n"             
+                printf "\x22\n"
+            printf "output \x22args-%s-%s\x22\n", NR-1, (NR-1)+splitno
             printf "url \x22%s&arg[]=%s", rpc, $0
         } else if (NR > 1) {
             printf "&arg[]=%s", $0
@@ -47,6 +48,7 @@ rpc_info_post() {
     awk -v rpc="$rpc_url" -v version="$rpc_ver" -v splitno="$splitno" '{
         if ((NR-1) % splitno == 0) {
             printf "next\n"
+            printf "output \x22args-%s-%s\x22\n", NR-1, (NR-1)+splitno
             printf "url \x22%s\x22\n", rpc
             printf "data \x22v=%s\x22\n", version
             printf "data \x22type=info\x22\n"
@@ -62,6 +64,7 @@ rpc_search() {
 
     while IFS= read -r term; do
         printf 'url "%s=%s"\n' "$rpc_url" "$term"
+        printf 'output "arg-%s"\n' "$term"
     done
 }
 
@@ -192,10 +195,32 @@ if (( AUR_QUERY_PARALLEL )); then
     curl_args+=(--parallel --parallel-max "$AUR_QUERY_PARALLEL_MAX" --fail-early)
 fi
 
-# PIPESTATUS[0] > 0: network errors
-# PIPESTATUS[1] > 0: aurweb response errors
-( set -o pipefail
-  curl "${curl_args[@]}" -K "$tmp"/config | combine
-)
+# requests are stored in a subdirectory to avoid problems from the random
+# ordering of curl --parallel output (#925)
+mkdir  "$tmp"/output
+env -C "$tmp"/output curl "${curl_args[@]}" -K "$tmp"/config || exit
+
+files=("$tmp"/output/*)
+if [[ ! -f ${files[0]} ]]; then
+    exit 1
+fi
+
+# check responses for errors (#257)
+for f in "${files[@]}"; do
+    f_count=$(jq -sr 'map(.resultcount) | add' "$f")
+    f_error=$(jq -r '.error' "$f")
+
+    if (( ! f_count )) && [[ $f_error != 'null' ]]; then
+        cat "$f" # response error
+        exit 2
+
+    elif (( ! f_count )); then
+        cat "$f" # no results found
+        exit 1
+    fi
+done
+
+# concatenate results
+cat "${files[@]}" | combine
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -206,25 +206,13 @@ esac
 aur query -t "$type" -b "$search_by" "${query_args[@]}" "$@" > "$tmp" || exit
 
 # exit early on json output (#187)
+# FIXME: print formatted error message, depending on aur-query exit status
 if [[ $output == "json" ]]; then
-    cat -- "$tmp"
-    exit
+    aur query -t "$type" -b "$search_by" "${query_args[@]}" "$@"
+else
+  ( set -o pipefail
+    aur query -t "$type" -b "$search_by" "${query_args[@]}" "$@" | tabulate "$sort_key" | info
+  )
 fi
-
-# check results (#257)
-count=$(jq -r '.resultcount' "$tmp" | awk '{s += $1} END {print s}')
-error=$(jq -r '.error' "$tmp")
-
-case $count in
-    0) if [[ $error != 'null' ]]; then
-           error '%s' "$error"
-           exit 2
-       else
-           # no results found
-           exit 1
-       fi ;;
-    *) tabulate "$sort_key" < "$tmp" | info
-       ;;
-esac
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/tests/issue/925
+++ b/tests/issue/925
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -o pipefail
+export AUR_QUERY_RPC_POST=0
+export AUR_QUERY_RPC_SPLITNO=1
+export AUR_QUERY_PARALLEL=1
+
+# search requests
+for i in {1..10}; do
+    printf 'search: %d/10\n' "$i"
+    aur query --raw -t search 'perl' 'rpm' | jq >/dev/null
+    (( $? != 0 )) && exit # results concatenated from both queries
+done
+
+# info requests
+for i in {1..10}; do
+    printf 'info: %d/10\n' "$i"
+    aur query --raw -t info 'perl-git' 'rpm' | jq >/dev/null
+    (( $? != 1 )) && exit # no results on second argument
+done


### PR DESCRIPTION
This ensures the output from each (search/info) request can be concatenated in a fixed order, i.e. the same order as the arguments provided.

Storing these results also allows to check them for errors directly in `aur-query`.

Closes #925