### PR TITLE
search: improve error handling

### DIFF
--- a/lib/aur-query
+++ b/lib/aur-query
@@ -81,12 +81,7 @@ usage() {
     exit 1
 }
 
-source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
-
-if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
-    [[ -t 2 ]] && colorize
-fi
 
 opt_short='b:t:er'
 opt_long=('by:' 'type:' 'any' 'raw' 'exit-if-empty')
@@ -210,18 +205,15 @@ fi
 for f in "${files[@]}"; do
     f_error=$(jq -r '.error' "$f")
 
-    if [[ $f_error != 'null' ]] && [[ $multiple == 'none' ]]; then
-        cat "$f"
-        exit 2
-    elif [[ $f_error != 'null' ]]; then
-        error '%s' "$f_error"
+    if [[ $f_error != 'null' ]]; then
+        cat >&2 "$f"
         exit 2
     fi
 done
 
 # abort on empty results only if requested (#929)
 if (( ${exit_if_empty-0} )); then
-    # TODO: print formatted message
+    # halt_error() prints input to stderr
     cat "${files[@]}" | combine | jq -Mrc 'if(.resultcount == 0) then halt_error(1) else . end'
 else
     cat "${files[@]}" | combine

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -208,30 +208,23 @@ fi
 
 # check responses for errors (#257)
 for f in "${files[@]}"; do
-    f_count=$(jq -sr 'map(.resultcount) | add' "$f")
     f_error=$(jq -r '.error' "$f")
 
-    if (( ! f_count )) && [[ $f_error != 'null' ]]; then
-        if [[ $multiple == 'none' ]]; then
-            cat "$f"
-        else
-            error '%s' "$f_error"
-        fi
+    if [[ $f_error != 'null' ]] && [[ $multiple == 'none' ]]; then
+        cat "$f"
         exit 2
-    fi
-
-    # abort on empty results only if requested (#929)
-    if (( ! f_count )) && (( ${exit_if_empty-0} )); then
-        if [[ $multiple == 'none' ]]; then
-            cat "$f"
-        else
-            error 'No results found.'
-        fi
-        exit 1
+    elif [[ $f_error != 'null' ]]; then
+        error '%s' "$f_error"
+        exit 2
     fi
 done
 
-# concatenate results
-cat "${files[@]}" | combine
+# abort on empty results only if requested (#929)
+if (( ${exit_if_empty-0} )); then
+    # TODO: print formatted message
+    cat "${files[@]}" | combine | jq -Mrc 'if(.resultcount == 0) then halt_error(1) else . end'
+else
+    cat "${files[@]}" | combine
+fi
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -81,7 +81,12 @@ usage() {
     exit 1
 }
 
+source /usr/share/makepkg/util/message.sh
 source /usr/share/makepkg/util/parseopts.sh
+
+if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
+    [[ -t 2 ]] && colorize
+fi
 
 opt_short='b:t:r'
 opt_long=('by:' 'type:' 'any' 'raw')
@@ -205,7 +210,12 @@ for f in "${files[@]}"; do
     f_error=$(jq -r '.error' "$f")
 
     if (( ! f_count )) && [[ $f_error != 'null' ]]; then
-        cat "$f" # type=error
+        if [[ $multiple == 'none' ]]; then
+            cat "$f"
+        else
+            error '%s' "$f_error"
+        fi
+
         exit 2
     fi
 done

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -148,14 +148,14 @@ else
     printf '%s\n' "$@"
 fi | curl_config >"$tmp"/config
 
-# easy access to curl config for debugging
-if (( ${dump_curl_config-0} )); then
-    cat "$tmp"/config
+# exit cleanly on empty input (#706)
+if [[ ! -s $tmp/config ]]; then
     exit
 fi
 
-# exit cleanly on empty input (#706)
-if [[ ! -s $tmp/config ]]; then
+# easy access to curl config for debugging
+if (( ${dump_curl_config-0} )); then
+    cat "$tmp"/config
     exit
 fi
 

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -88,8 +88,8 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
     [[ -t 2 ]] && colorize
 fi
 
-opt_short='b:t:r'
-opt_long=('by:' 'type:' 'any' 'raw')
+opt_short='b:t:er'
+opt_long=('by:' 'type:' 'any' 'raw' 'exit-if-empty')
 opt_hidden=('dump-options' 'dump-curl-config')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -97,11 +97,13 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset arg_by arg_type multiple dump_curl_config
+unset arg_by arg_type multiple dump_curl_config exit_if_empty
 while true; do
     case "$1" in
         --any) # set union
             multiple=union ;;
+        -e|--exit-if-empty)
+            exit_if_empty=1 ;;
         -r|--raw)
             multiple=none ;;
         -b|--by)
@@ -215,8 +217,17 @@ for f in "${files[@]}"; do
         else
             error '%s' "$f_error"
         fi
-
         exit 2
+    fi
+
+    # abort on empty results only if requested (#929)
+    if (( ! f_count )) && (( ${exit_if_empty-0} )); then
+        if [[ $multiple == 'none' ]]; then
+            cat "$f"
+        else
+            error 'No results found.'
+        fi
+        exit 1
     fi
 done
 

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -194,7 +194,13 @@ if [[ $output == "json" ]]; then
     aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@"
 else
     aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@" | tabulate "$sort_key" | info
-    exit "${PIPESTATUS[0]}"
+    errno=${PIPESTATUS[0]}
+
+    case $errno in
+        1) error '%s: no results found' "$argv0" ;;
+        2) error '%s: request error' "$argv0" ;;
+    esac
+    exit "$errno"
 fi
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -99,14 +99,6 @@ info_short() {
     done
 }
 
-trap_exit() {
-    if [[ ! -v AUR_DEBUG ]]; then
-        rm -rf -- "$tmp"
-    else
-        printf >&2 'AUR_DEBUG: %s: temporary files at %s\n' "$argv0" "$tmp"
-    fi
-}
-
 usage() {
     plain >&2 'usage: %s [-adimnqrsv] [-k key] pkgname...' "$argv0"
     exit 1
@@ -178,11 +170,6 @@ if ! (( $# )); then
     usage
 fi
 
-# shellcheck disable=SC2174
-mkdir -pm 0700 "${TMPDIR:-/tmp}/aurutils-$UID"
-tmp=$(mktemp --tmpdir "aurutils-$UID/$argv0.XXXXXXXX") || exit
-trap 'trap_exit' EXIT
-
 # set format depending on query type (#319)
 case $type in
       info) format=${format-long}  ;;
@@ -202,17 +189,12 @@ case $multiple in
       union) query_args+=('--any') ;;
 esac
 
-# check results
-aur query -t "$type" -b "$search_by" "${query_args[@]}" "$@" > "$tmp" || exit
-
 # exit early on json output (#187)
-# FIXME: print formatted error message, depending on aur-query exit status
 if [[ $output == "json" ]]; then
     aur query -t "$type" -b "$search_by" "${query_args[@]}" "$@"
 else
-  ( set -o pipefail
     aur query -t "$type" -b "$search_by" "${query_args[@]}" "$@" | tabulate "$sort_key" | info
-  )
+    exit "${PIPESTATUS[0]}"
 fi
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -191,9 +191,9 @@ esac
 
 # exit early on json output (#187)
 if [[ $output == "json" ]]; then
-    aur query -t "$type" -b "$search_by" "${query_args[@]}" "$@"
+    aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@"
 else
-    aur query -t "$type" -b "$search_by" "${query_args[@]}" "$@" | tabulate "$sort_key" | info
+    aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@" | tabulate "$sort_key" | info
     exit "${PIPESTATUS[0]}"
 fi
 

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -6,14 +6,16 @@ results, the symmetric difference with `-a` (bug), and the concatenation with
 
 `-a` now correctly returns the union, and the `-r` output is processed with
 jq(1) to return the intersection by default, or the union (with duplicates
-filtered) with `-a`. This processing is done because the RPC interface (as of
-aurweb 6.0.11) does not expose set operations, and so `aur-search` performs one
+removed) with `-a`. This processing is done because the RPC interface as of
+aurweb 6.0.11 does not expose set operations, and so `aur-search` performs one
 search for each argument.
 
 The implementation is done in `aur-query`, which now takes the intersection of
 search results by default. The union can be taken with `--any`, or unprocessed
 results shown with `--raw`. In each case, the output is newline-delimited (JSON
-Lines, `jq -r`).
+Lines, `jq -r`). If the search resulted in no results, `aur-query` will either
+exit with status 0 (if no request resulted in an error), 1 (if the `-e` option
+was specified), or 2 (if at least one request resulted in an error).
 
 `AUR_QUERY_RPC_SPLITNO_POST` received bug fixes (#920), and the default has
 been reduced to 500 after experiencing issues with a larger number of

--- a/man1/aur-query.1
+++ b/man1/aur-query.1
@@ -64,9 +64,23 @@ Return the set union of results instead of the intersection. Applies to
 requests. The result is a single JSON structure, delimited by a newline.
 .
 .TP
-.BR \-\-raw
+.BR \-e ", " \-\-exit\-if\-empty
+If no results are found, exit with status 1 instead of 0.
+.
+.TP
+.BR \-r ", " \-\-raw
 Do not process results. Implied by
 .BR \-\-type=info .
+.
+.SH EXIT STATUS
+.B aur\-query
+returns 0 if no errors occured, 1 if no results were found
+.I and
+the
+.B \-\-exit\-if\-empty
+option is specified,
+and 2 if a request resulted in an error
+.RB ( type=error ).
 .
 .SH ENVIRONMENT
 .TP


### PR DESCRIPTION
Unless `--raw` is specified, a formatted error message is displayed which can be propagated to other tools (specifically, `aur-search`).

- [x] `query`: format error messages
- [x] `search`: exit 1 if no results found (https://github.com/AladW/aurutils/commit/416e81e40d45769ff25c493f6866f2b11f2b1829)

Fixes #927