### PR TITLE
aur-sync: add per-repository sections to --ignore-file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ETCDIR ?= /etc
 AURUTILS_LIB_DIR ?= $(LIBDIR)/$(PROGNM)
 AURUTILS_VERSION ?= $(shell git describe --tags || true)
 ifeq ($(AURUTILS_VERSION),)
-AURUTILS_VERSION := 6.2
+AURUTILS_VERSION := 6.3
 endif
 
 .PHONY: shellcheck install build completion aur

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -247,26 +247,8 @@ fi
 mkdir -p "$AURDEST"
 cd_safe "$tmp"
 
-# Concatenate ignores from file and command-line arguments
-: "${ignore_file=$XDG_CONFIG_HOME/aurutils/sync/ignore}"
-
-{ if [[ -r $ignore_file ]] && [[ ! -d $ignore_file ]]; then
-      while IFS='#' read -r pkg _; do
-          [[ $pkg ]] && printf '%s\n' "$pkg"
-      done < "$ignore_file"
-  fi
-
-  if (( ${#pkg_i[@]} )); then
-      printf '%s\n' "${pkg_i[@]}"
-  fi
-} >igni
-
-# db_info: $1 pkgname $2 pkgver
-( set -o pipefail
-  aur repo "${repo_args[@]}" --list --status-file=db | select_ignores igni -
-) >db_info
-
 # Retrieve path to local repo (#448, #700)
+aur repo "${repo_args[@]}" --status-file=db
 { IFS=: read -r _ db_name
   IFS=: read -r _ db_root
   IFS=: read -r _ db_path
@@ -284,10 +266,33 @@ else
     exit 13
 fi
 
+# Concatenate ignores from file and command-line arguments
+: "${ignore_file=$XDG_CONFIG_HOME/aurutils/sync/ignore}"
+
+{ if [[ -r $ignore_file ]] && [[ ! -d $ignore_file ]]; then
+      mapfile -t isect < <(pacini "$ignore_file" --section-list)
+
+      if (( ${#isect[@]} )); then
+          pacini "$ignore_file" --section="$db_name"
+      else
+          pacini "$ignore_file"
+      fi
+  fi
+
+  if (( ${#pkg_i[@]} )); then
+      printf '%s\n' "${pkg_i[@]}"
+  fi
+} >igni
+
 if [[ -s igni ]]; then
     printf '%s: packages ignored: ' "$argv0"
     awk -v ORS=' ' '{print} END {printf("\n")}' igni
 fi
+
+# db_info: $1 pkgname $2 pkgver
+( set -o pipefail
+  aur repo "${repo_args[@]}" --list -d "$db_name" -r "$db_root" | select_ignores igni -
+) >db_info
 
 { if (( $# )); then
       # append command-line arguments

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -282,7 +282,7 @@ fi
   if (( ${#pkg_i[@]} )); then
       printf '%s\n' "${pkg_i[@]}"
   fi
-} >igni
+} | complement <(printf '%s\n' "$@") >igni
 
 if [[ -s igni ]]; then
     printf '%s: packages ignored: ' "$argv0"

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Alad Wenter <https://github.com/AladW>
 pkgname=aurutils-git
-pkgver=4.2.r15.g08fffb6
+pkgver=6.1.r13.gf098d34
 pkgrel=1
 pkgdesc='helper tools for the arch user repository'
 url='https://github.com/AladW/aurutils'

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -2,6 +2,7 @@
 
 * `aur-sync`
   - `--ignore-file` now supports per-repository sections (INI-style)
+  - do not ignore targets when specified on the command-line
 
 ## 6.2
 

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,8 @@
+## 6.3
+
+* `aur-sync`
+  - `--ignore-file` now supports per-repository sections (INI-style)
+
 ## 6.2
 
 * `aur-pkglist`

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -46,9 +46,24 @@ separating them with a comma, or by repeating the \fB\-\-ignore\fR option.
 .BI \-\-ignore\-file= FILE
 Ignore package upgrades listed in
 .IR FILE .
-Each package name should be specified on a separate line. Comments may
-be specified after a number sign. Defaults to
+Each package name should be specified on a separate line. If a section
+(enclosed in square brackets) is specified, package names only apply to the
+local repository matching this section. Comments can be specified after
+a number sign. For example:
+.RS
+.PP
+.EX
+  [custom]
+  package-foo
+  package-bar
+
+  [custom-testing]
+  package-baz
+.EE
+.PP
+Defaults to
 .BR $XDG_CONFIG_HOME/aurutils/sync/ignore .
+.RE
 .
 .TP
 .BR \-\-noview ", " \-\-no\-view


### PR DESCRIPTION
Example:
```
[custom]
package-foo
package-bar
    
[custom-testing]
package-baz
```
Targets from `--ignore` apply to the selected local repository as before.
