### PR TITLE
sync: use number of started edges

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -416,7 +416,7 @@ if (( AUR_SYNC_USE_NINJA )); then
 
     elif (( build )); then
         # print all targets in dependency order
-        NINJA_STATUS='[%f/%t] ' ninja -nC /var/empty -f "$PWD"/build.ninja | \
+        NINJA_STATUS='[%s/%t] ' ninja -nC /var/empty -f "$PWD"/build.ninja | \
             # [\w@\.\-\+]: valid characters for pkgname
             # alternative: [^\s]+ from rule `env -C ... > pkgbase.stamp`
             pcregrep -o1 -o3 '(\[\d+/\d+\] )(.+?)([\w@\.\-\+]+)(\.stamp)' | while read -r status pkg


### PR DESCRIPTION
Using the number of remaining edges (%r) leads to an off-by-one in the
summary:
```
[0/2]  masterpassword-cli  [FAIL]
[1/2]  mkv-extractor-qt    [FAIL]
```
Use the number of started edges (%s) instead.

Closes #940