### PR TITLE
query: avoid hardcoding request types

### DIFF
--- a/lib/aur-query
+++ b/lib/aur-query
@@ -180,7 +180,7 @@ case $multiple in
             })'
         } ;;
     none)
-        combine() { tee; } ;;
+        combine() { jq -Mrc; } ;;
 esac
 
 # support parallel transfers (curl >7.66.0)

--- a/lib/aur-query
+++ b/lib/aur-query
@@ -16,18 +16,22 @@ PS4='+(${BASH_SOURCE}:${LINENO}):${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 curl_args=(-A aurutils -fgLsSq)
 
 # Filters for generating curl configuration
-rpc_info() {
-    local rpc_url="$AUR_QUERY_RPC?v=$AUR_QUERY_RPC_VERSION&type=info"
-    local splitno="$AUR_QUERY_RPC_SPLITNO"
+request_get() {
+    local rpc_url=$1 rpc_ver=$2 splitno=$3 type=$4 by=$5
 
     # Write opening and closing quotes with \x22 (hexadecimal)
-    awk -v rpc="$rpc_url" -v splitno="$splitno" '{
+    awk -v url="$rpc_url" -v ver="$rpc_ver" -v splitno="$splitno" -v type="$type" -v by="$by" '
+    BEGIN {
+        form = sprintf("%s&v=%s&type=%s", url, ver, type)
+        if (by) form = sprintf("%s&by=%s", form, by)
+    } {
         if ((NR-1) % splitno == 0) {
             if (NR > 1)
                 printf "\x22\n"
             printf "output \x22args-%s-%s\x22\n", NR-1, (NR-1)+splitno
-            printf "url \x22%s&arg[]=%s", rpc, $0
-        } else if (NR > 1) {
+            printf "url \x22%s&arg[]=%s", form, $0
+        } 
+        else if (NR > 1) {
             printf "&arg[]=%s", $0
         }
     } END {
@@ -39,33 +43,21 @@ rpc_info() {
 # POST requests are useful for info-type requests to circumvent limits on the
 # URL length with GET requests. The difference is that all data is now included
 # in the message body, instead of in the URI.
-rpc_info_post() {
-    local rpc_url="$AUR_QUERY_RPC"
-    local rpc_ver="$AUR_QUERY_RPC_VERSION"
-    local splitno="$AUR_QUERY_RPC_SPLITNO_POST"
+request_post() {
+    local rpc_url=$1 rpc_ver=$2 splitno=$3 type=$4 by=$5
 
     # Write opening and closing quotes with \x22 (hexadecimal)
-    awk -v rpc="$rpc_url" -v version="$rpc_ver" -v splitno="$splitno" '{
+    awk -v url="$rpc_url" -v ver="$rpc_ver" -v splitno="$splitno" -v type="$type" -v by="$by" '{
         if ((NR-1) % splitno == 0) {
             printf "next\n"
             printf "output \x22args-%s-%s\x22\n", NR-1, (NR-1)+splitno
-            printf "url \x22%s\x22\n", rpc
-            printf "data \x22v=%s\x22\n", version
-            printf "data \x22type=info\x22\n"
+            printf "url \x22%s\x22\n", url
+            printf "data \x22v=%s\x22\n", ver
+            printf "data \x22type=%s\x22\n", type
+            if (by) printf "data \x22by=%s\x22\n", by
         }
-        printf "data-urlencode \x22arg[]=%s\x22\n", $0
+        printf "data \x22arg[]=%s\x22\n", $0
     }'
-}
-
-# Search-type requests can only contain one package argument, and GET requests
-# are sufficient for this.
-rpc_search() {
-    local rpc_url="$AUR_QUERY_RPC?v=$AUR_QUERY_RPC_VERSION&type=search&by=$1&arg"
-
-    while IFS= read -r term; do
-        printf 'url "%s=%s"\n' "$rpc_url" "$term"
-        printf 'output "arg-%s"\n' "$term"
-    done
 }
 
 trap_exit() {
@@ -125,17 +117,21 @@ if (( ! $# )); then
     usage
 fi
 
-# set filters
-if [[ $arg_type == "search" ]]; then
-    curl_config() { jq -R -r '@uri' | rpc_search "${arg_by:-name-desc}"; }
+# request parameters
+rpc=$AUR_QUERY_RPC
+ver=$AUR_QUERY_RPC_VERSION
 
-elif [[ $arg_type == "info" ]] && (( AUR_QUERY_RPC_POST )); then
-    curl_config() { rpc_info_post; }  # URI encoding is handled by curl --data-urlencode
-
-elif [[ $arg_type == "info" ]]; then
-    curl_config() { jq -R -r '@uri' | rpc_info; }
+if (( AUR_QUERY_RPC_POST )); then
+    http='post'
+    splitno=$AUR_QUERY_RPC_SPLITNO_POST
 else
-    usage
+    http='get'
+    splitno=$AUR_QUERY_RPC_SPLITNO
+fi
+
+# search requests require 1 argument per URI
+if [[ $arg_type == "search" ]]; then
+    splitno=1
 fi
 
 # generate curl configuration
@@ -143,7 +139,7 @@ if (( $# == 1 )) && [[ $1 == "-" || $1 == "/dev/stdin" ]]; then
     tee # noop
 else
     printf '%s\n' "$@"
-fi | curl_config >"$tmp"/config
+fi | jq -R -r '@uri' | request_"$http" "$rpc" "$ver" "$splitno" "$arg_type" "${arg_by-}" >"$tmp"/config
 
 # exit cleanly on empty input (#706)
 if [[ ! -s $tmp/config ]]; then

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -5,9 +5,9 @@
 
 * `aur-sync`
   + avoid off-by-one in ninja build summary (#940)
- 
+
 * `aur-query`
-  + print usage if `-t` is not specified (#938)
+  + do not abort if `-t` is unspecified (#938)
 
 ## 7
 

--- a/man1/aur-query.1
+++ b/man1/aur-query.1
@@ -1,4 +1,4 @@
-.TH AUR-QUERY 1 2021-11-27 AURUTILS
+.TH AUR-QUERY 1 2022-02-25 AURUTILS
 .SH NAME
 aur\-query \- send requests to the aurweb RPC interface
 .
@@ -108,13 +108,14 @@ The URI of the RPC interface. Defaults to
 .
 .TP
 .B AUR_QUERY_RPC_POST
-If set to a positive value, use HTTP POST for info-type requests.
+If set to a positive value, use HTTP POST for requests.
 Defaults to
 .IR 1 .
 .RS
 .PP
-HTTP GET results in a higher number of requests than HTTP POST, so
-latter should be preferred in the general case.
+For info-type requests, more packages can be queried in a single
+request with HTTP POST than with HTTP GET, and this approach is
+preferable especially when querying large numbers of packages.
 .RE
 .
 .TP
@@ -145,7 +146,7 @@ The version for the RPC endpoint. Defaults to
 The default set of options for
 .BR curl (1)
 are
-.BR "\-A aurutils \-fgLsSq \-\-tcp\-fastopen" .
+.BR "\-A aurutils \-fgLsSq" .
 .
 .SH SEE ALSO
 .ad l

--- a/tests/issue/938
+++ b/tests/issue/938
@@ -1,4 +1,4 @@
 #!/bin/bash
 aur query linux
-# if -t [info|search] is not specified, print usage (#938)
-(( $? == 1 ))
+# aurweb error if no type is specified
+(( $? == 2 ))


### PR DESCRIPTION
When considering a "default" query type, we can make two observations:

1. `search`-type requests work both with HTTP POST and HTTP GET:
```
$ curl -d 'v=5' -d type='search' -d by='name' -d 'arg=aurutils' https://aur.archlinux.org/rpc
{"resultcount":2,"results": ...
```
2. aurweb has error-handling for invalid or missing type parameters:
```
$ curl -d 'v=5' -d type='foobar' -d by='name' -d 'arg=aurutils' https://aur.archlinux.org/rpc
{"error":"Incorrect request type specified.","resultcount":0,"results":[],"type":"error","version":5}
```
It thus makes sense to decouple GET and POST methods from the specific type of request. This way, a wrong (or missing) type is directly handled by aurweb. In addition, the default "by" search argument from aurweb no longer needs to be hardcoded in aur-query.

The approach is not as general as it could be, because the POST and GET functions still hardcode the existence of a "type" and "by" argument. Instead, a `key=value` (similar to `curl -d`) approach could be taken.

Search requests now use HTTP POST to make the `AUR_QUERY_RPC_POST` option more consistent, however this needs further testing.

Issue #938