### PR TITLE
chroot: use positional arguments for packages

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -14,11 +14,11 @@ chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0
 
 # default arguments (empty)
 chroot_args=() pacconf_args=() repo_add_args=() repo_args=()
-makepkg_args=() makechrootpkg_makepkg_args=() makepkg_common_args=()
+makepkg_common_args=() makepkg_args=() makechrootpkg_makepkg_args=()
 
 # default arguments
 gpg_args=(--detach-sign --no-armor --batch)
-makechrootpkg_args=(-cu)
+makechrootpkg_args=(-c)
 
 args_csv() {
     # shellcheck disable=SC2155

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -379,13 +379,11 @@ while IFS= read -ru "$fd" path; do
         wait "$!"
 
         if [[ ${exists[*]} ]]; then
-            # XXX: use lint_pkgbuild in this case as no lint from a
-            # makepkg invocation may take place
             warning '%s: skipping existing package (use -f to overwrite)' "$argv0"
+            _build=0
 
             printf '%q\n' >&2 "${exists[@]}"
             pkglist=("${exists[@]}")
-            _build=0
         fi
     fi
 

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -18,7 +18,13 @@ makepkg_args=() makechrootpkg_makepkg_args=() makepkg_common_args=()
 
 # default arguments
 gpg_args=(--detach-sign --no-armor --batch)
-makechrootpkg_args=(-c -u)
+makechrootpkg_args=(-cu)
+
+args_csv() {
+    # shellcheck disable=SC2155
+    local str=$(printf '%s,' "$@")
+    printf '%s' "${str%,}"
+}
 
 db_replaces() {
     bsdcat "$1" | awk '
@@ -309,6 +315,8 @@ if (( chroot )); then
     # makepkg --packagelist includes the package extension, but
     # makechrootpkg ignores PKGEXT set on the host.
     # Retrieve the path to the container makepkg.conf separately.
+    # XXX: this is hardcoded to etc/makepkg.conf (where arch-nspawn
+    # copies the makepkg configuration to)
     pkglist_makepkg_conf=$(aur chroot --path "${chroot_args[@]}")
     pkglist_makepkg_conf+=/etc/makepkg.conf
 else
@@ -383,12 +391,15 @@ while IFS= read -ru "$fd" path; do
 
     if (( _build )); then
         if (( chroot )); then
-            PKGDEST="$var_tmp" run_msg aur chroot --build "${chroot_args[@]}" \
-                   -- "${makechrootpkg_args[@]}" \
-                   -- "${makechrootpkg_makepkg_args[@]}"
+            if (( ${#makechrootpkg_args[@]} )); then
+                chroot_args+=(--cargs "$(args_csv "${makechrootpkg_args[@]}")")
+            fi
+            if (( ${#makechrootpkg_makepkg_args[@]} )); then
+                chroot_args+=(--margs "$(args_csv "${makechrootpkg_makepkg_args[@]}")")
+            fi
+            PKGDEST="$var_tmp" run_msg aur chroot --build "${chroot_args[@]}"
         else
-            PKGDEST="$var_tmp" run_msg makepkg \
-                   "${makepkg_common_args[@]}" "${makepkg_args[@]}"
+            PKGDEST="$var_tmp" run_msg makepkg "${makepkg_common_args[@]}" "${makepkg_args[@]}"
         fi
 
         cd_safe "$var_tmp"

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -10,6 +10,8 @@ machine=$(uname -m)
 # default arguments
 directory=/var/lib/aurbuild/$machine
 suffix=extra
+makechrootpkg_args=()
+makechrootpkg_makepkg_args=()
 
 # default options
 update=0 build=0 packagelist=0 create=0 print_path=0
@@ -17,8 +19,7 @@ update=0 build=0 packagelist=0 create=0 print_path=0
 usage() {
     cat <<EOF
 Usage:
-  $argv0 [-BU] [-CDM path] -- <makechrootpkg args>
-  $argv0 --create [-CDM path] [package...]
+  $argv0 [-BU] [--create] [-CDM path] [package...]
 EOF
     exit 1
 }
@@ -27,9 +28,9 @@ source /usr/share/makepkg/util/option.sh
 source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='C:D:M:x:BU'
-opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'build' 'update'
-          'create' 'suffix:' 'bind:' 'bind-rw:' 'path')
-opt_hidden=('dump-options' 'packagelist')
+opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'build' 'update' 'create'
+          'suffix:' 'bind:' 'bind-rw:' 'path' 'makepkg-args:' 'makechrootpkg-args:')
+opt_hidden=('dump-options' 'packagelist' 'margs:' 'cargs:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
     usage
@@ -60,6 +61,12 @@ while true; do
             shift; bindmounts_ro+=("$1") ;;
         --bind-rw)
             shift; bindmounts_rw+=("$1") ;;
+        --makechrootpkg-args|--cargs)
+            shift; IFS=, read -a arg -r <<< "$1"
+            makechrootpkg_args+=("${arg[@]}") ;;
+        --makepkg-args|--margs)
+            shift; IFS=, read -a arg -r <<< "$1"
+            makechrootpkg_makepkg_args+=("${arg[@]}") ;;
         # deprecated options
         --packagelist)
             packagelist=1 ;;
@@ -72,6 +79,11 @@ while true; do
     esac
     shift
 done
+
+# additional makechrootpkg arguments if none are specified
+if (( ! ${#makechrootpkg_args[@]} )); then
+    makechrootpkg_args=(-c)
+fi
 
 # required for chroot creation and update
 # if specified, copied to the container by arch-nspawn
@@ -135,8 +147,7 @@ if (( create )); then
     fi
 
     if [[ ! -d $directory/root ]]; then
-        sudo mkarchroot -C "$pacman_conf" -M "$makepkg_conf" \
-             "$directory"/root "${base_packages[@]}"
+        sudo mkarchroot -C "$pacman_conf" -M "$makepkg_conf" "$directory"/root "${base_packages[@]}"
     fi
 fi
 
@@ -163,20 +174,15 @@ if (( update )); then
     # locking is done by systemd-nspawn
     sudo arch-nspawn -C "$pacman_conf" -M "$makepkg_conf" "$directory"/root \
          "${bindmounts_ro[@]/#/--bind-ro=}" \
-         "${bindmounts_rw[@]/#/--bind=}" pacman -Syu --noconfirm
-fi
-
-# XXX: workaround for --build taking seperate command-line arguments (#807)
-if (( create + update )); then
-    exit 0
+         "${bindmounts_rw[@]/#/--bind=}" pacman -Syu --noconfirm "$@"
 fi
 
 if (( build )); then
     # use makechrootpkg -c as default build command (sync /root container)
     # arguments after -- (if present) are used as makechrootpkg arguments
     sudo --preserve-env=GNUPGHOME,SSH_AUTH_SOCK,PKGDEST makechrootpkg -r "$directory" \
-         "${bindmounts_ro[@]/#/-D}" \
-         "${bindmounts_rw[@]/#/-d}" "${@:--c}"
+         "${bindmounts_ro[@]/#/-D}" "${bindmounts_rw[@]/#/-d}" \
+         "${makechrootpkg_args[@]}" -- "${makechrootpkg_makepkg_args[@]}"
 fi
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -12,6 +12,9 @@ can be specified multiple times. (Issues: #950, #807)
 The `--packagelist` command is now deprecated. The container path can be
 retrieved with the `--path` option, e.g for use with `makepkg --config`.
 
+* `aur-build`
+  + use `makechrootpkg -c` instead of `-cu` (`aur-build --chroot`)
+
 * `aur-srcver`
   + add `--buildscript`
   + deprecate `-E` / `--env`

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,9 +1,16 @@
 ## 8
 
 * `aur-chroot`
-  + add `--path` to retrieve path to container template
-  + do not exit on chroot creation (`--create`, #950)
-  + deprecate `--packagelist`, remove `--buildscript`
+
+The `aur-chroot` command-line was changed so that `--create`, `--build` and
+`--update` can be used in a single command. Command-line arguments are now
+exclusively used for packages passed to `mkarchroot` and `arch-nspawn`.
+To set `makechrootpkg` options, the new `--margs` and `--cargs` options are
+available. As `aur-build --margs`, these take a comma-delimited string and
+can be specified multiple times. (Issues: #950, #807)
+
+The `--packagelist` command is now deprecated. The container path can be
+retrieved with the `--path` option, e.g for use with `makepkg --config`.
 
 * `aur-srcver`
   + add `--buildscript`

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -251,7 +251,7 @@ Do not run the check() function in the PKGBUILD.
 .RB ( makepkg " " \-\-nocheck )
 .
 .TP
-.BR \-n ", " \-\-noconfirm
+.BR \-n ", " \-\-noconfirm ", " \-\-no\-confirm
 Do not wait for user input.
 .RB ( makepkg " " \-\-noconfirm )
 .

--- a/man1/aur-chroot.1
+++ b/man1/aur-chroot.1
@@ -1,4 +1,4 @@
-.TH AUR-CHROOT 2020-11-01 AURUTILS
+.TH AUR-CHROOT 2022-03-04 AURUTILS
 .SH NAME
 aur\-chroot \- build pacman packages with systemd-nspawn
 .
@@ -6,21 +6,12 @@ aur\-chroot \- build pacman packages with systemd-nspawn
 .SY "aur chroot"
 .OP \-\-build
 .OP \-\-update
-.OP \-D directory
-.OP \-C pacman_conf
-.OP \-M makepkg_conf
-.OP \-\-
-.RI [ "makechrootpkg args" ]
-.
-.SY "aur chroot"
 .OP \-\-create
 .OP \-D directory
 .OP \-C pacman_conf
 .OP \-M makepkg_conf
+.OP \-\-
 .RI [ "package..." ]
-.
-.SY "aur chroot"
-.OP \-D directory
 .YS
 .
 .SH DESCRIPTION
@@ -33,13 +24,11 @@ container.
 .SH OPERATIONS
 .TP
 .BR \-B ", " \-\-build
-Build a package inside the container. Arguments after
-.B \-\-
-are passed to
+Build a package inside the container with
 .BR makechrootpkg .
-If none are specified,
-.B makechrootpkg \-c
-is run.
+Assumes
+.B \-\-create
+was run at least once.
 .
 .TP
 .BR \-U ", " \-\-update
@@ -110,6 +99,34 @@ file used inside the container. Defaults to devtools'
 .IR makepkg\-<machine>.conf .
 .
 .TP
+.BI \-\-cargs= ARG
+Arguments (comma-separated) to be passed to
+.B makechrootpkg
+for 
+.BR \-\-build .
+Defaults to
+.BR "makechrootpkg \-c" .
+.
+.TP
+.BI \-\-margs= ARG
+Additional (comma-separated)
+.B makepkg 
+arguments for
+.BR makechrootpkg .
+A default list of arguments can be listed with
+.BR "makechrootpkg \-\-help" .
+.
+.TP
+.B \-\-bind
+Bind a directory read-only to the container.
+.RB ( makechrootpkg " " \-D )
+.
+.TP
+.B \-\-bind\-rw
+Bind a directory read-write to the container.
+.RB ( makechrootpkg " " \-d )
+.
+.TP
 .B \-\-path
 Print the path to the container template
 .RI ( $directory/root ).
@@ -124,16 +141,6 @@ Defaults to
 .BR extra .
 A full path may be specified with
 .BR \-\-pacman\-conf .
-.
-.TP
-.B \-\-bind
-Bind a directory read-only to the container.
-.RB ( makechrootpkg " " \-D )
-.
-.TP
-.B \-\-bind\-rw
-Bind a directory read-write to the container.
-.RB ( makechrootpkg " " \-d )
 .
 .SH ENVIRONMENT
 Packages are placed in the directory set in
@@ -218,7 +225,7 @@ As in
 install the required packages:
 .EX
 
-  # arch-nspawn /var/lib/aurbuild/root pacman \-S ccache distcc
+  # aur chroot --update ccache distcc
 
 .EE
 Ensure write access to
@@ -226,7 +233,7 @@ Ensure write access to
 directories on the host:
 .EX
 
-  # aur chroot -- -d /home/_ccache:/build/.ccache -cu
+  # aur chroot --build --bind /home/_ccache:/build/.ccache
 
 .EE
 Necessary


### PR DESCRIPTION
The `aur-chroot` command-line was changed so that `--create`, `--build` and `--update` can be used in a single command. Command-line arguments are now exclusively used for packages passed to `mkarchroot` and `arch-nspawn`.

To set `makechrootpkg` options, the new `--margs` and `--cargs` options are available. As `aur-build --margs`, these take a comma-delimited string and can be specified multiple times.

Closes #950, #807