### PR TITLE
srcver: fix directory to source the build script from

### DIFF
--- a/lib/aur-srcver
+++ b/lib/aur-srcver
@@ -100,7 +100,7 @@ for d in "$tmp"/*/; do # iterate over directories
         # Precautions when sourcing the PKGBUILD have no effect here,
         # because makepkg already sourced the PKGBUILD above.
         # shellcheck disable=SC1090
-        ( source "${buildscript-PKGBUILD}"
+        ( source "$n/${buildscript-PKGBUILD}"
 
           fullver=$(get_full_version)
           printf '%s\t%s\n' "${pkgbase:-$pkgname}" "$fullver"


### PR DESCRIPTION
The [previously used function `srcver_pkgbuild_info()`](https://github.com/AladW/aurutils/commit/257362fff5efc7d86b8ee6065eb7ab45c9e4e9bb#diff-1e8bf88edce180a3c750b38531053b933c7335473488fd78aa9c987c622ab462L7) changed the currently directory to `$n`  sourcing the PKGBUILD. Since switching to libmakepkg this does not happen any more, leading to the following error:
```
/usr/lib/aurutils/aur-srcver: line 103: PKGBUILD: No such file or directory
```