### PR TITLE
aur-fetch: add --no-pager to the git log command

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -102,7 +102,7 @@ fi | while read -r pkg; do
         git() { command git -C "$pkg" "$@"; }
 
         # Verify if the repository is empty (#959)
-        if ! git log --pretty=reference -1; then
+        if ! git --no-pager log --pretty=reference -1; then
             continue
         fi
 
@@ -157,7 +157,7 @@ fi | while read -r pkg; do
     # Otherwise, try to clone anew
     elif (( clone )) && git clone "$AUR_LOCATION/$pkg"; then
         # Verify if the repository is empty (#959)
-        if git -C "$pkg" log --pretty=reference -1; then
+        if git -C "$pkg" --no-pager log --pretty=reference -1; then
             head=$(git -C "$pkg" rev-parse HEAD)
         else
             head=0


### PR DESCRIPTION
Invoking the pager needlessly interrupts/delays the command by forcing interactive action to close the pager.