### PR TITLE
aur-sync: redirect aur-fetch output to stderr

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -102,7 +102,7 @@ fi | while read -r pkg; do
         git() { command git -C "$pkg" "$@"; }
 
         # Verify if the repository is empty (#959)
-        if ! git --no-pager log --pretty=reference -1; then
+        if ! git --no-pager log --pretty=reference -1 >&2; then
             continue
         fi
 
@@ -157,7 +157,7 @@ fi | while read -r pkg; do
     # Otherwise, try to clone anew
     elif (( clone )) && git clone "$AUR_LOCATION/$pkg"; then
         # Verify if the repository is empty (#959)
-        if git -C "$pkg" --no-pager log --pretty=reference -1; then
+        if git -C "$pkg" --no-pager log --pretty=reference -1 >&2; then
             head=$(git -C "$pkg" rev-parse HEAD)
         else
             head=0

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -366,7 +366,7 @@ fi
 
 if (( download )); then
     msg >&2 "Retrieving package files"
-    aur fetch -S --results "$tmp"/fetch_results - < "$tmp"/queue
+    aur fetch -S --results "$tmp"/fetch_results - < "$tmp"/queue >&2
 
     # shellcheck disable=SC2034
     while IFS=: read -r mode rev_old rev path; do


### PR DESCRIPTION
In aur-sync, the `--no-build` option prints the paths of target packages.

With the recent addition of the `git log` check in aur-fetch in #960, the output
of `aur sync --no-build` has now become polluted with the `aur fetch` output from `git log`.
That makes the output of `aur sync --no-build` less usable when automating builds.

This PR redirects the `aur-fetch` output, which is purely diagnostic anyway, to standard error.
