### PR TITLE
`aur`: load environment variables

### DIFF
--- a/aur.in
+++ b/aur.in
@@ -1,4 +1,5 @@
 #!/bin/bash -
+readonly XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 readonly argv0=aur
 readonly aur_version='AURUTILS_VERSION'
 readonly lib_dir=${AUR_EXEC_PATH:-'AURUTILS_LIB_DIR'}
@@ -23,10 +24,26 @@ if [[ -z $1 ]]; then
     exit 1
 fi
 
-if [[ $1 == '--version' ]]; then
-    printf >&2 'aur version %s\n' "$aur_version"
-    exit 0
+# load environment
+if [[ -f $XDG_CONFIG_HOME/aurutils/env ]]; then
+    while IFS=' = ' read -r key value; do
+        case $key in
+            AUR*) printf -v "$key" '%s' "$value"
+                  export "${key?}" ;;
+        esac
+    done < <(pacini "$XDG_CONFIG_HOME/aurutils/env")
+
+    wait "$!"
 fi
+
+case $1 in
+    --version)
+        printf >&2 'aur version %s\n' "$aur_version"
+        exit 0 ;;
+    --env)
+        printenv | grep -E '^AUR' >&2
+        exit 0 ;;
+esac
 
 if [[ "$PATH" != "$lib_dir:"* ]]; then
     readonly PATH=$lib_dir:$PATH

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,5 +1,9 @@
 ## 10
 
+* `aur`
+  + support environment files (`$XDG_CONFIG_HOME/aurutils/env`)
+  + add `--env`
+
 * `aur-build`
   + use `AUR_PACMAN_AUTH` as elevation command (prior: `PACMAN_AUTH`)
 

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -117,6 +117,29 @@ Programs follow a subset of errno(3), or preserve command status where
 applicable.
 .
 .SH ENVIRONMENT
+Environment variables for
+.B aur
+programs are prefixed with
+.BR AUR .
+Where applicable, standard variables such as
+.B XDG_CONFIG_HOME
+are respected. Variables supported by specific programs are listed
+in their respective man pages (see
+.BR "AUR COMMANDS" ).
+.PP
+Variables can be set in the user environment or in
+.IR $XDG_CONFIG_HOME/aurutils/env ,
+using a key/value format separated by newlines. For example:
+.PP
+.RS
+.EX
+AURDEST=/home/custompkgs
+AUR_PACMAN_AUTH=sudo --askpass
+AUR_PAGER=ranger
+AUR_REPO=custom
+.EE
+.RE
+.
 .TP
 .B AUR_DEBUG
 Setting this variable enables debug mode (typically


### PR DESCRIPTION
This is more convenient than changing environment variables globally (e.g. in ~/.bashrc, which is sourced by ~/.bash_profile), while not being as complex as a fully-fledged configuration system.

- [x] add to `aur.in`
- [x] document in `aur(1)`