### PR TITLE
pkglist: check local timestamp against system time

### DIFF
--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -75,6 +75,11 @@ if (( $# > 0 )) && [[ $mode == "plain" ]]; then
     mode=regex
 fi
 
+if ! [[ $ttl =~ [0-9]+ ]]; then
+    printf >&2 "error: --ttl requires an integer ('%s' provided)\n" "$ttl"
+    exit 1
+fi
+
 # packages.gz cache
 install -dm700 "$AUR_METADEST"
 cd "$AUR_METADEST" || exit

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -83,11 +83,16 @@ if [[ ! -s headers_$pkglist || ! -s $pkglist ]]; then
     update=1
 
 elif [[ -s $pkglist ]]; then
+    # Check local timestamp before checking remote (#984)
     sec_l=$(http_last_modified "headers_$pkglist" | date -f - '+%s')
-    sec_r=$(http_last_modified <(list_headers "$AUR_LOCATION/$pkglist.gz") | date -f - '+%s')
+    sec_d=$(date '+%s')
 
-    if (( sec_l )) && (( sec_r )) && (( sec_r - sec_l > ttl )); then
-        update=1
+    if (( sec_l )) && (( sec_d - sec_l > ttl )); then
+        sec_r=$(http_last_modified <(list_headers "$AUR_LOCATION/$pkglist.gz") | date -f - '+%s')
+
+        if (( sec_r )) && (( sec_r - sec_l > ttl )); then
+            update=1
+        fi
     fi
 fi
 

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -23,7 +23,7 @@ list_headers() {
 }
 
 usage() {
-    printf >&2 'usage: %s [-bt] [-FP pattern]\n' "$argv0"
+    printf >&2 'usage: %s [-bUqv] [-t ttl] [-FP pattern]\n' "$argv0"
     exit 1
 }
 

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -8,7 +8,7 @@ AUR_METADEST=${AUR_METADEST:-$XDG_CACHE_HOME/aurutils/$argv0} # variable name pr
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
-ttl=300 mode=plain pkglist=packages update=0 verify=0
+ttl=300 mode=plain pkglist=packages update=0 verify=0 use_system_time=0
 
 http_last_modified() {
     awk -F', ' '/^[Ll]ast-[Mm]odified:/ {print $2}' "$1"
@@ -31,7 +31,7 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='t:bqvFPSIU'
 opt_long=('pkgbase' 'search' 'info' 'fixed-strings' 'perl-regexp' 'plain'
-          'ttl:' 'users' 'verify' 'quiet')
+          'ttl:' 'users' 'verify' 'quiet' 'systime')
 opt_hidden=('dump-options' 'time:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -61,6 +61,8 @@ while true; do
             shift; ttl=$1 ;;
         -v|--verify)
             verify=1 ;;
+        --systime)
+            use_system_time=1 ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
@@ -92,7 +94,7 @@ elif [[ -s $pkglist ]]; then
     sec_l=$(http_last_modified "headers_$pkglist" | date -f - '+%s')
     sec_d=$(date '+%s')
 
-    if (( sec_l )) && (( sec_d - sec_l > ttl )); then
+    if (( ! use_system_time )) || (( sec_d - sec_l > ttl )); then
         sec_r=$(http_last_modified <(list_headers "$AUR_LOCATION/$pkglist.gz") | date -f - '+%s')
 
         if (( sec_r )) && (( sec_r - sec_l > ttl )); then

--- a/lib/aur-pkglist
+++ b/lib/aur-pkglist
@@ -90,16 +90,16 @@ if [[ ! -s headers_$pkglist || ! -s $pkglist ]]; then
     update=1
 
 elif [[ -s $pkglist ]]; then
-    # Check local timestamp before checking remote (#984)
     sec_l=$(http_last_modified "headers_$pkglist" | date -f - '+%s')
-    sec_d=$(date '+%s')
 
-    if (( ! use_system_time )) || (( sec_d - sec_l > ttl )); then
-        sec_r=$(http_last_modified <(list_headers "$AUR_LOCATION/$pkglist.gz") | date -f - '+%s')
+    if (( use_system_time )); then
+        sec_d=$(date '+%s')
+    else
+        sec_d=$(http_last_modified <(list_headers "$AUR_LOCATION/$pkglist.gz") | date -f - '+%s')
+    fi
 
-        if (( sec_r )) && (( sec_r - sec_l > ttl )); then
-            update=1
-        fi
+    if (( sec_d - sec_l > ttl )); then
+        update=1
     fi
 fi
 

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -10,6 +10,9 @@
 * `aur-chroot`
   + use `AUR_PACMAN_AUTH` as elevation command (prior: `PACMAN_AUTH`)
 
+* `aur-pkglist`
+  + add `--systime`
+
 ## 9.6
 
 * `aur-pkglist`

--- a/man1/aur-pkglist.1
+++ b/man1/aur-pkglist.1
@@ -8,7 +8,7 @@ aur\-pkglist \- retrieve AUR metadata archives
 .OP \-bUqv
 .OP \-I pattern
 .OP \-S pattern
-.OP \-t time
+.OP \-t ttl
 .YS
 .
 .SH DESCRIPTION
@@ -104,6 +104,13 @@ minutes; setting a lower interval with
 .B \-t
 thus has no benefit.
 .RE
+.
+.TP
+.B \-\-systime
+Use the system clock when verifying the list modification date (see
+.BR \-\-time ).
+This option should only be used when the clock is synchronized, for
+example with NTP.
 .
 .TP
 .BR \-v ", " \-\-verify


### PR DESCRIPTION
This avoids a HTTP request when the file was retrieved before expiration of the TTL.

Before:
```
$ time aur pkglist --ttl 1800 >/dev/null 

real	0m0.121s
user	0m0.028s
sys	0m0.020s
```
After:
```
$ time ./aur-pkglist --ttl 1800 >/dev/null 

real	0m0.013s
user	0m0.014s
sys	0m0.000s
```
Issue #984