### PR TITLE
search: add --fmt-stdin

### DIFF
--- a/lib/aur-search
+++ b/lib/aur-search
@@ -6,14 +6,13 @@ AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
-multiple=section output=hrm search_by=name-desc sort_key=Name type=search
+multiple=section output=hrm search_by=name-desc sort_key=Name type=search fmt_stdin=0
 
 # default arguments
 query_args=()
 
 hyperlink() {
-    local uri=$1
-    local mesg=$2
+    local uri=$1 mesg=$2
 
     if [[ ! -v ALL_OFF ]]; then
         printf "%s" "$mesg"
@@ -61,7 +60,6 @@ tabulate() {
             (.OptDepends     | sel_join)
         ] | @tsv'
 }
-
 
 info_long() {
     local -a desc=(
@@ -139,7 +137,8 @@ fi
 
 opt_short='k:adimnqrsv'
 opt_long=('any' 'info' 'search' 'desc' 'maintainer' 'name' 'depends' 'verbose'
-          'makedepends' 'optdepends' 'checkdepends' 'key:' 'json' 'short' 'table')
+          'makedepends' 'optdepends' 'checkdepends' 'key:' 'json' 'short'
+          'table' 'fmt-stdin')
 opt_hidden=('dump-options' 'raw')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -176,6 +175,8 @@ while true; do
             format=long ;;
         --table)
             format=table ;;
+        --fmt-stdin)
+            fmt_stdin=1 ;;
         -r|--raw|--json)
             output=json ;;
         -k|--key)
@@ -189,7 +190,7 @@ while true; do
     shift
 done
 
-if ! (( $# )); then
+if ! (( $# + fmt_stdin )); then
     usage
 fi
 
@@ -212,8 +213,11 @@ case $multiple in
       union) query_args+=('--any') ;;
 esac
 
-# exit early on json output (#187)
-if [[ $output == "json" ]]; then
+if (( fmt_stdin )); then
+    tabulate "$sort_key" | info
+
+elif [[ $output == "json" ]]; then
+    # exit early on json output (#187)
     aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@"
 else
     aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@" | tabulate "$sort_key" | info

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -13,6 +13,9 @@
 * `aur-pkglist`
   + add `--systime`
 
+* `aur-search`
+  + add `--fmt-stdin`
+
 * `aur-sync`
   + exit 22 on dependency cycles (regression introduced in v7)
 

--- a/man1/aur-search.1
+++ b/man1/aur-search.1
@@ -73,6 +73,14 @@ Valid choices are \fIName\fR, \fIVersion\fR, \fINumVotes\fR,
 \fIFirstSubmitted\fR, \fILastModified\fR (for \fB\-v\fR verbose
 output).
 .
+.TP
+.B \-\-fmt\-stdin
+Take JSON from standard input and format it (see
+.BR \-\-short ,
+.BR \-\-verbose ).
+Input should match the output from
+.BR aur\-query (1).
+.
 .SS Search types
 .TP
 .BR \-d ", " \-\-desc


### PR DESCRIPTION
When `--fmt-stdin` is set, JSON is taken directly from standard input, instead of from `aur-query`. This allows in particular to pipe aur-pkglist --info / --search output to aur-search.

For example, the following pipeline returns all orphan packages whose name starts in `r-`:
```bash
 $ aur pkglist --info | jq -r '{
        "results": [.[] |
            select(.Maintainer == null) |
            select(.Name | test("^r-"))
        ], "type": "search", "version": 5
    }' | aur search --fmt-stdin
```
_(Arguably having a pipeline of generator and formatter is how things should have been in the first place.)_

This example originates from aurweb returning "Too many results" when querying an empty maintainer (orphan) search. [1] It could also be used for e.g. `provides` search:
```
$ aur pkglist --info | jq -r '.[] | select(.Provides[]? | contains("libcubeb.so")) | .Name'
cubeb-git
```

[1] https://gitlab.archlinux.org/archlinux/aurweb/-/issues/357