### PR TITLE
search: add `--stdin-table`, rename `--fmt-stdin` -> `--stdin-json`

### DIFF
--- a/lib/aur-search
+++ b/lib/aur-search
@@ -6,7 +6,7 @@ AUR_LOCATION=${AUR_LOCATION:-'https://aur.archlinux.org'}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
-multiple=section output=hrm search_by=name-desc sort_key=Name type=search fmt_stdin=0
+multiple=section search_by=name-desc sort_key=Name type=search mode=query
 
 # default arguments
 query_args=()
@@ -138,7 +138,7 @@ fi
 opt_short='k:adimnqrsv'
 opt_long=('any' 'info' 'search' 'desc' 'maintainer' 'name' 'depends' 'verbose'
           'makedepends' 'optdepends' 'checkdepends' 'key:' 'json' 'short'
-          'table' 'fmt-stdin')
+          'table' 'stdin-json' 'stdin-table')
 opt_hidden=('dump-options' 'raw')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -175,10 +175,12 @@ while true; do
             format=long ;;
         --table)
             format=table ;;
-        --fmt-stdin)
-            fmt_stdin=1 ;;
+        --stdin-json)
+            mode=stdin_json ;;
+        --stdin-table)
+            mode=stdin_table ;;
         -r|--raw|--json)
-            output=json ;;
+            mode=query_raw ;;
         -k|--key)
             shift; sort_key=$1 ;;
         --dump-options)
@@ -190,7 +192,7 @@ while true; do
     shift
 done
 
-if ! (( $# + fmt_stdin )); then
+if ! (( $# )) && ! [[ $mode == "stdin_json" || $mode == "stdin_table" ]]; then
     usage
 fi
 
@@ -213,15 +215,16 @@ case $multiple in
       union) query_args+=('--any') ;;
 esac
 
-if (( fmt_stdin )); then
-    tabulate "$sort_key" | info
-
-elif [[ $output == "json" ]]; then
-    # exit early on json output (#187)
-    aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@"
-else
-    aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@" | tabulate "$sort_key" | info
-    exit "${PIPESTATUS[0]}"
-fi
+case $mode in
+    query)
+        aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@" | tabulate "$sort_key" | info
+        exit "${PIPESTATUS[0]}" ;;
+    query_raw)
+        aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@" ;;
+    stdin_json)
+        tabulate "$sort_key" | info ;;
+    stdin_table)
+        info ;;
+esac
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -14,7 +14,7 @@
   + add `--systime`
 
 * `aur-search`
-  + add `--fmt-stdin`
+  + add `--stdin-json`, `--stdin-table`
 
 * `aur-sync`
   + exit 22 on dependency cycles (regression introduced in v7)

--- a/man1/aur-search.1
+++ b/man1/aur-search.1
@@ -59,7 +59,7 @@ Display more package information.
 .BR \-\-table
 Display output in
 .B tsv
-format.
+(tab-separated) format.
 .
 .TP
 .BI "\-k " key "\fR,\fP \-\-key=" key
@@ -74,12 +74,17 @@ Valid choices are \fIName\fR, \fIVersion\fR, \fINumVotes\fR,
 output).
 .
 .TP
-.B \-\-fmt\-stdin
-Take JSON from standard input and format it (see
-.BR \-\-short ,
-.BR \-\-verbose ).
-Input should match the output from
-.BR aur\-query (1).
+.B \-\-stdin\-json
+Format JSON from standard input, assumed to match
+.BR aur\-query (1)
+output.
+.
+.TP
+.B \-\-stdin\-table
+Format tab-separated values from standard input, assumed to match
+from
+.B aur\-search \-\-table
+output.
 .
 .SS Search types
 .TP


### PR DESCRIPTION
These two options replace --fmt-stdin and allow more flexibility. For example, the pipeline given in 1633366b7d6f6cdf75deec37cec3aacae5e67c8e using jq(1) can be replaced with a faster awk(1) pipeline:
```bash
$ time aur pkglist --info | jq ... | aur search --stdin-json

real	0m2.661s
user	0m3.569s
sys	0m0.283s

$ time aur pkglist -- '^r-' | aur search -i --table - \
    | awk -F\\t '{ if ($8 == "-") print; }' \
    | aur search --stdin-table

real	0m0.725s
user	0m0.531s
sys	0m0.125s
```
