### PR TITLE
search: print package name once with NO_COLOR

### DIFF
--- a/lib/aur-search
+++ b/lib/aur-search
@@ -13,13 +13,8 @@ query_args=()
 
 hyperlink() {
     local uri=$1 mesg=$2
+    local OSC8="\e]8" ST="\e\\"
 
-    if [[ ! -v ALL_OFF ]]; then
-        printf "%s" "$mesg"
-    fi
-
-    OSC8="\e]8"
-    ST="\e\\"
     printf "$OSC8;;%s$ST%s$OSC8;;$ST" "$uri" "$mesg"
 }
 


### PR DESCRIPTION
Issue #995

Alternative: always print the hyperlink, even with NO_COLOR=1. The `hyperlink` function is then reduced to:
```bash
hyperlink() {
    local OSC8="\e]8" ST="\e\\"
    printf "$OSC8;;%s$ST%s$OSC8;;$ST" "$1" "$2"
}
```