### PR TITLE
search: remove --stdin-table, rename --stdin-json to --json-stdin

### DIFF
--- a/completions/zsh/_aur.zsh
+++ b/completions/zsh/_aur.zsh
@@ -322,13 +322,12 @@ _aur_search() {
         '--table[display output in tsv format]'
 
         + '(stdin-format)'
-        '--stdin-json[Format JSON from standard input, assumed to match aur-query]'
-        '--stdin-table[Format tab-separated values from standard input, assumed to match aur-search --table]'
+        '--json-stdin[Format JSON from standard input, assumed to match aur-query]'
 
         + options
         '(-a --any)'{-a,--any}'[show the union of results instead of the intersection]'
         '(-r --json)'{-r,--json}'[display results as json]'
-        '(-k --key)'{-k,--key=}'[sort results via key]:key:(Name Version NumVotes Description PackageBase URL Popularity OutOfDatate Maintainer FirstSubmitted LastModified)'
+        '(-k --key)'{-k,--key=}'[sort results via key]:key:(Name Version NumVotes Description PackageBase URL Popularity OutOfDate Maintainer FirstSubmitted LastModified)'
 
         + '(search_by)'
         {-d,--desc}'[search by package name and description]'

--- a/lib/aur-search
+++ b/lib/aur-search
@@ -137,8 +137,8 @@ fi
 
 opt_short='k:adimnqrsv'
 opt_long=('any' 'info' 'search' 'desc' 'maintainer' 'name' 'depends' 'verbose'
-          'makedepends' 'optdepends' 'checkdepends' 'key:' 'json' 'short'
-          'table' 'stdin-json' 'stdin-table')
+          'makedepends' 'optdepends' 'checkdepends' 'key:' 'short' 'table'
+          'json' 'json-stdin')
 opt_hidden=('dump-options' 'raw')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -175,12 +175,10 @@ while true; do
             format=long ;;
         --table)
             format=table ;;
-        --stdin-json)
-            mode=stdin_json ;;
-        --stdin-table)
-            mode=stdin_table ;;
         -r|--raw|--json)
-            mode=query_raw ;;
+            mode=json ;;
+        --json-stdin)
+            mode=json_stdin ;;
         -k|--key)
             shift; sort_key=$1 ;;
         --dump-options)
@@ -219,12 +217,12 @@ case $mode in
     query)
         aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@" | tabulate "$sort_key" | info
         exit "${PIPESTATUS[0]}" ;;
-    query_raw)
-        aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@" ;;
-    stdin_json)
-        tabulate "$sort_key" | info ;;
-    stdin_table)
-        info ;;
+    json)
+        aur query -t "$type" -b "$search_by" -e "${query_args[@]}" "$@"
+        ;;
+    json_stdin)
+        tabulate "$sort_key" | info
+        ;;
 esac
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -12,16 +12,19 @@
   + use `AUR_PACMAN_AUTH` as elevation command (prior: `PACMAN_AUTH`)
 
 * `aur-fetch`
-  + support multiple branches, with commits merged from `origin/master`
-  + changes are merged with `git-pull` by default
+  + `--sync=auto` now runs `git-pull` and is the default operation
     - local changes are no longer discarded automatically
-    - rebase can be set per-repository with `pull.rebase` git config
-    - add `--rebase`, `--no-rebase`, `--ff-only` `--autostash`, `--no-commit`
-  + add `--no-pull`, `--reset`
+    - add `--no-pull` for running `git-fetch`
+    - add `--ff-only`, `--autostash`, `--no-commit`, `--rebase`, `--no-rebase`
+    - set per-repository rebase with `pull.rebase` git configuration
+  + add `--rebase` and `--reset` as shorthand for `--sync=rebase` and `--sync=reset`
+  + support multiple branches, with commits merged from `origin/master`
+  + `--results` output now uses `pull`, `reset` and `fetch` keywords
 
 * `aur-pkglist`
   + output is now independent of command-line argument order
-  + rename `-I` and `-S` short options to `-i` and `-s`, remove `-u`
+  + rename `-I` and `-S` short options to `-i` and `-s`
+  + remove `-u`
   + add `--systime`
 
 * `aur-repo`
@@ -29,7 +32,10 @@
   + add `--list-field`
 
 * `aur-search`
-  + add `--stdin-json`, `--stdin-table`
+  + add `--json--stdin`
+
+* `aur-srcver`
+  + remove `-E`, `--env` (deprecated in v8)
 
 * `aur-sync`
   + add `--rebase`, `--reset`, use `aur-fetch --sync=merge` default

--- a/man1/aur-search.1
+++ b/man1/aur-search.1
@@ -52,6 +52,12 @@ Only display package name, version and description.
 Display results as JSON.
 .
 .TP
+.B \-\-json\-stdin
+Format JSON from standard input, assumed to match
+.BR aur\-query (1)
+output.
+.
+.TP
 .BR \-v ", " \-\-verbose
 Display more package information.
 .
@@ -72,19 +78,6 @@ Valid choices are \fIName\fR, \fIVersion\fR, \fINumVotes\fR,
 \fIPopularity\fR, \fIOutOfDate\fR, \fIMaintainer\fR,
 \fIFirstSubmitted\fR, \fILastModified\fR (for \fB\-v\fR verbose
 output).
-.
-.TP
-.B \-\-stdin\-json
-Format JSON from standard input, assumed to match
-.BR aur\-query (1)
-output.
-.
-.TP
-.B \-\-stdin\-table
-Format tab-separated values from standard input, assumed to match
-from
-.B aur\-search \-\-table
-output.
 .
 .SS Search types
 .TP


### PR DESCRIPTION
The future `aur-format` will exclusively take JSON as standard input, and either print JSON or formatted output. Remove the `--stdin-table` option to reflect this.

Rename `--stdin-json` to `--json-stdin`, such that a tab-completion for `--json` shows both `--json` and `--json-stdin`.