### PR TITLE
fetch: improve compatibility with aurutils <=9.6

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -1,6 +1,7 @@
 #!/bin/bash
 # aur-fetch - retrieve build files from the AUR
 [[ -v AUR_DEBUG ]] && set -o xtrace
+shopt -s extglob
 argv0=fetch
 AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
@@ -12,18 +13,31 @@ export GIT_AUTHOR_EMAIL=aurutils@localhost
 export GIT_COMMITTER_NAME=aurutils
 export GIT_COMMITTER_EMAIL=aurutils@localhost
 
-# Skip global git-config
-export GIT_CONFIG_GLOBAL=/dev/null
-export GIT_CONFIG_NOSYSTEM=1
+# Placeholder for repositories without commits
+git_empty_object=$(git hash-object -t tree /dev/null)
 
 # default options
-existing=0 recurse=0 discard=0 sync=merge
+existing=0 recurse=0 discard=0 sync=fetch
 
 results() {
     local mode=$1 prev=$2 current=$3 path=$4 dest=$5
 
     if [[ -w $dest ]]; then
         printf >> "$dest" '%s:%s:%s:file://%s\n' "$mode" "$prev" "$current" "$path"
+    fi
+}
+
+sync_package_config() {
+    local sync=$1 pkg=$2
+
+    if [[ $sync == 'auto' ]] && [[ $(git config --get --type bool aurutils.rebase) == 'true' ]]; then
+        printf >&2 '%s: aurutils.rebase is set for %s\n' "$argv0" "$pkg"
+        printf '%s' rebase
+
+    elif [[ $sync == 'auto' ]]; then
+        printf '%s' merge
+    else
+        printf '%s' "$sync"
     fi
 }
 
@@ -39,9 +53,9 @@ XyAgICAgIDsnflUnCiAgXywtJyAsJ2AtX187ICctLS4KIChfLyd+fiAgICAgICcnJycoOwoK
 # option handling
 source /usr/share/makepkg/util/parseopts.sh
 
-opt_short='rS'
-opt_long=('existing' 'fetch-only' 'reset' 'rebase' 'results:' 'discard'
-          'ff' 'ff-only' 'no-ff' 'no-commit' 'recurse')
+opt_short='frS'
+opt_long=('auto' 'merge' 'reset' 'rebase' 'discard' 'existing' 'results:' 'ff'
+          'ff-only' 'no-ff' 'no-commit' 'recurse')
 opt_hidden=('dump-options' 'sync:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -53,12 +67,14 @@ unset rebase_args merge_args results_file
 while true; do
     case "$1" in
         # aur-fetch options
-        --discard)
+        -S|--auto)
+            sync=auto ;;
+        -f|--discard)
             discard=1 ;;
         --existing)
             existing=1 ;;
-        --fetch-only)
-            sync=fetch ;;
+        --merge)
+            sync=merge ;;
         --rebase)
             sync=rebase ;;
         --reset)
@@ -75,12 +91,9 @@ while true; do
         --no-ff)
             merge_args+=(--no-ff); rebase_args+=(--no-ff) ;;
         # Compatibility options
-        -S)
-            printf >&2 'deprecation notice: %s -S is an alias for --discard\n' "$argv0"
-            discard=1; sync=merge ;;
         --sync)
             shift; sync=$1 ;;
-        --recurse|-r)
+        -r|--recurse)
             recurse=1 ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
@@ -92,16 +105,10 @@ while true; do
 done
 
 # option validation
-case $sync in
-    merge|rebase|reset|fetch)
-        true ;;
-    auto)
-        printf >&2 'deprecation notice: %s --sync=auto is an alias for --discard\n' "$argv0"
-        discard=1; sync=merge ;;
-    *)
-        printf >&2 '%s: invalid --sync mode\n' "$argv0"
-        exit 1 ;;
-esac
+if [[ $sync == !(auto|merge|rebase|reset|fetch) ]]; then
+    printf >&2 '%s: invalid --sync mode\n' "$argv0"
+    exit 1
+fi
 
 if (( ! $# )); then
     printf >&2 '%s: no arguments given\n' "$argv0"
@@ -116,9 +123,6 @@ fi
 if (( ! ${#merge_args[@]} )); then
     merge_args=(--ff-only)
 fi
-
-# Placeholder for repositories without commits
-git_empty_object=$(git hash-object -t tree /dev/null)
 
 # Main loop
 if (( recurse )); then
@@ -147,11 +151,7 @@ fi | while read -r pkg; do
         orig_head=${orig_head:-$git_empty_object}
 
         # Retrieve per-package configuration (defaults to global setting, #1007)
-        # XXX: no distinction between default (sync=merge) and command-line (--sync=merge)
-        sync_pkg=$sync
-        if [[ $sync == 'merge' ]] && [[ $(git config --get --type bool aurutils.rebase) == 'true' ]]; then
-            sync_pkg=rebase
-        fi
+        sync_pkg=$(sync_package_config "$sync" "$pkg")
 
         # Reset working tree if new commits will be merged (--discard)
         reset_on_update() {

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -11,11 +11,10 @@ AUR_SYNC_USE_NINJA=${AUR_SYNC_USE_NINJA:-0}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default arguments
-build_args=(--clean --syncdeps)
-depends_args=() fetch_args=() repo_args=() view_args=() filter_args=()
+build_args=(--clean --syncdeps) depends_args=() repo_args=() view_args=() filter_args=()
 
 # default options
-build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1 keep_going=1
+build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1 keep_going=1 fetch_mode=auto
 
 # default options (disabled)
 rotate=0 update=0 repo_targets=0
@@ -165,9 +164,9 @@ while true; do
             shift; repo_args+=(-r "$1") ;;
         # fetch options
         --rebase)
-            fetch_args+=(--rebase) ;;
+            fetch_mode=rebase ;;
         --reset)
-            fetch_args+=(--reset) ;;
+            fetch_mode=reset ;;
         # build options
         -c|--chroot)
             build_args+=(--chroot) ;;
@@ -377,7 +376,7 @@ fi
 
 if (( download )); then
     msg >&2 "Retrieving package files"
-    aur fetch "${fetch_args[@]}" --results "$tmp"/fetch_results --discard - < "$tmp"/queue >&2
+    aur fetch --sync="$fetch_mode" --results "$tmp"/fetch_results --discard - < "$tmp"/queue >&2
 
     # shellcheck disable=SC2034
     while IFS=: read -r mode rev_old rev path; do

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -12,14 +12,13 @@
   + use `AUR_PACMAN_AUTH` as elevation command (prior: `PACMAN_AUTH`)
 
 * `aur-fetch`
-  + change default operation to `git fetch && git-merge --ff-only`
-    - local (uncommited) changes are preserved, unless `--discard` is specified
-    - set default author for merge commits to `aurutils@localhost`
-    - add `--fetch-only` to only run `git-fetch`
-    - add `--discard` to run `git-reset` on new upstream commits
+  + `--sync=auto`: run `git-merge` instead of `git-reset`
     - add `--ff`, `--ff-only`, `--no-ff`, `--no-commit` options
-    - deprecate `-S`, `--sync=auto`
-  + add `--reset` and `--rebase`, deprecate `--sync=reset`, `--sync=rebase`
+    - fix a bug where setting `aurutils.rebase` affected unrelated targets
+    - set default author for merge commits to `aurutils@localhost`
+  + `--sync=auto` now preserves local changes by default
+    - `--discard` (`-f`) resets the repository on new upstream commits
+  + add `--reset`, `--rebase`, `--auto` aliases for `--sync=reset`, `--sync=rebase`, `--sync=auto`
   + support multiple branches, with commits merged from `origin/master`
 
 * `aur-pkglist`

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -1,9 +1,9 @@
-.TH AUR-FETCH 1 2022-06-24 AURUTILS
+.TH AUR-FETCH 1 2022-07-03 AURUTILS
 .SH NAME
 aur\-fetch \- download packages from the AUR
 .
 .SH SYNOPSIS
-.SY "aur fetch [--rebase] [--reset]"
+.SY "aur fetch [-S] [-f] [--rebase] [--reset]"
 .IR pkgbase " [" pkgbase... ]
 .YS
 .
@@ -24,16 +24,14 @@ repositories are retrieved with
 if they do not exist. Otherwise, the
 .B origin
 remote is updated with
-.B git\-fetch
-and changes are merged with
-.B git\-merge \-\-ff\-only
-by default. Alternatively,
-.BR git\-rebase ,
-.BR git\-reset
-or only
-.BR git\-fetch
-can be run.
+.BR git\-fetch (1).
+Changes can be merged with
+.BR git\-merge " (" \-\-merge ),
+.BR git\-rebase " (" \-\-rebase ),
+or
+.BR git\-reset " (" \-\-reset ).
 .PP
+.B Note:
 AUR packages have
 .B master
 as the only remote branch, so changes are always merged
@@ -43,21 +41,11 @@ Local changes may however live in different branches.
 .
 .SH OPTIONS
 .TP
-.BR \-\-sync=merge
+.BR \-\-sync=merge ", " \-\-merge
 Run
-.BR git\-merge (1)
-to merge in upstream changes. This is the default, unless
-.B aurutils.rebase
-equals
-.BR true
-in
-.BR git\-config (1).
-In this case,
-.BR git\-rebase (1)
-is run instead (see
-.B \-\-rebase
-for details).
-.
+.BR git\-fetch (1)
+and merge upstream changes with
+.BR git\-merge (1).
 .IP
 If no
 .BR git\-merge (1)
@@ -107,7 +95,21 @@ option should thus be used with care. See
 for details.
 .
 .TP
-.BR \-\-reset ", " \-\-sync=rebase
+.BR \-\-sync=auto ", " \-\-auto
+Run
+.BR git\-rebase (1)
+for a repository with
+.B aurutils.rebase
+set to
+.B true
+in
+.BR git\-config (1),
+and
+.BR git\-merge (1)
+otherwise.
+.
+.TP
+.BR \-\-reset ", " \-\-sync=reset
 Retrieve new revisions with
 .B git\-fetch origin
 and
@@ -115,13 +117,6 @@ and
 to the
 .B master@{upstream}
 commit, removing any local commits.
-.
-.TP
-.BR \-\-fetch\-only ", " \-\-sync=fetch
-Only retrieve new revisions with
-.BR git\-fetch ,
-if the repository exists, otherwise run
-.BR git\-clone .
 .
 .TP
 .BR \-\-discard
@@ -158,19 +153,13 @@ If this option is specified, arguments must be supplied by
 .B pkgname
 instead of by
 .BR pkgbase .
-.IP
-This is equivalent to the pipeline:
-.IP
-.EX
-aur depends --pkgbase "$@" | aur fetch -
-.EE
 .
 .TP
 .BI \-\-results= FILE
 Write colon-delimited output in the following form to
 .IR FILE :
 .IP
-<action>:<head_from>:<head_to>:file://<path>
+    <action>:<head_from>:<head_to>:file://<path>
 .IP
 Possible values for
 .I action
@@ -180,6 +169,9 @@ are
 .BR rebase ,
 and
 .BR fetch .
+Can be used by higher level tools to differentiate new clones from
+updates to existing repositories.
+.IP
 If
 .I action
 is set to
@@ -192,9 +184,6 @@ the
 empty tree object.
 .I <path>
 is the absolute path to the corresponding git repository.
-.IP
-Can be used by higher level tools to differentiate new clones from
-updates to existing repositories.
 .IP
 .B Note:
 When using

--- a/tests/issue/1007
+++ b/tests/issue/1007
@@ -27,7 +27,7 @@ head3=$(git rev-parse --verify HEAD)
 
 # merge can be solved as fast-forward
 cd ..
-aur fetch aurutils aurutils-git
+aur fetch --sync=auto aurutils aurutils-git
 cd aurutils
 [[ $(git rev-parse --verify HEAD) == $head1 ]]
 cd ../aurutils-git
@@ -35,8 +35,8 @@ cd ../aurutils-git
 
 # diverging history, --ff-only default
 cd ..
-aur fetch yuzu || err=$?
+aur fetch --sync=auto yuzu || err=$?
 (( err == 1 ))
-aur fetch yuzu --rebase
+aur fetch --sync=rebase yuzu
 cd yuzu
 [[ $(git rev-parse --verify HEAD) != $head3 ]]


### PR DESCRIPTION
* Do not ignore system configuration, i.e. in $HOME/.gitconfig
* Only run git-fetch by default
* Add --auto flag (shorthand for --sync=auto)
* Add -f flag (shorthand for --discard), i.e. aur fetch -Sf
* Remove deprecation notices