### PR TITLE
sync: use pkgspec for ignores instead of pacini

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -29,6 +29,16 @@ lib32() {
     }' "$@"
 }
 
+split_pkgspec() {
+    awk -F'/' '{
+        if (NF == 2) {
+            printf("%s\t%s\n", $1, $2)
+        } else {
+            printf("-\t%s\n", $1)
+        }
+    }' "$@"
+}
+
 # argv[1]: $1 pkgname $2 depends $3 pkgbase
 # note: edges are not checked for duplicates
 select_pkgbase() {
@@ -270,13 +280,10 @@ fi
 : "${ignore_file=$XDG_CONFIG_HOME/aurutils/sync/ignore}"
 
 { if [[ -r $ignore_file ]] && [[ ! -d $ignore_file ]]; then
-      mapfile -t isect < <(pacini "$ignore_file" --section-list)
-
-      if (( ${#isect[@]} )); then
-          pacini "$ignore_file" --section="$db_name"
-      else
-          pacini "$ignore_file"
-      fi
+      # Restrict ignores to local repository with single pass (#880)
+      while IFS=$'\t' read -r repo pkg; do
+          [[ $repo == "$db_name" || $repo == "-" ]] && pkg_i+=("$pkg")
+      done < <(split_pkgspec "$ignore_file")
   fi
 
   if (( ${#pkg_i[@]} )); then

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -41,6 +41,9 @@
   + remove `-E`, `--env` (deprecated in v8)
 
 * `aur-sync`
+  + use pkgspec `<REPOSITORY>/<PACKAGE>` format for `--ignore-file`
+    - support for sections (introduced with v6.3) is removed (#880)
+    - <PACKAGE> ignores apply to all local repositories
   + add `--rebase`, `--reset` options for `aur-fetch`
   + exit 22 on dependency cycles (v7 regression)
   + filter dependency graph by pkgname, not depends (v7 regression)


### PR DESCRIPTION
This allows to use shell substitution for `--ignore-file` (no random seek required) while still allowing to use per-repository ignores.

Closes #880