### PR TITLE
build: do not use generated configs for elevated commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ETCDIR ?= /etc
 AURUTILS_LIB_DIR ?= $(LIBDIR)/$(PROGNM)
 AURUTILS_VERSION ?= $(shell git describe --tags || true)
 ifeq ($(AURUTILS_VERSION),)
-AURUTILS_VERSION := 10
+AURUTILS_VERSION := 11
 endif
 
 .PHONY: shellcheck install build completion aur

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -27,12 +27,6 @@ args_csv() {
     printf '%s' "${str%,}"
 }
 
-db_replaces() {
-    bsdcat "$1" | awk '/%REPLACES%/ {
-        while(getline && NF != 0) { print; }
-    }'
-}
-
 diag_moved_packages() {
     # Print diagnostic on non-moved packages (#794)
     cat <<EOF >&2
@@ -344,22 +338,6 @@ if (( chroot )); then
     # queue. A full system upgrade is run on the /root container to
     # avoid lenghty upgrades for makechrootpkg -u.
     run_msg 2 aur chroot --create --update "${chroot_args[@]}"
-else
-    # Generate pacman.conf for isolated upgrade of local repository.
-    { printf '[options]\n'
-      pacconf "${pacconf_args[@]}" --raw --options
-
-      printf '[%s]\nUsage = All\n' "$db_name"
-      pacconf "${pacconf_args[@]}" --raw --repo="$db_name" SigLevel Server
-
-      # Allow secondary repositories as targets for -Syu (#956)
-      while IFS= read -r repo; do
-          printf '[%s]\nUsage = Install\n' "$repo"
-          pacconf "${pacconf_args[@]}" --raw --repo="$repo" SigLevel Server
-      done < <(
-          pacconf "${pacconf_args[@]}" --repo-list | grep -Fxv "$db_name"
-      )
-    } >"$tmp"/local.conf
 fi
 
 if [[ -v queue ]]; then
@@ -493,10 +471,31 @@ while IFS= read -ru "$fd" path; do
     if (( chroot )) || (( no_sync )); then
         continue
     else
-        replaces=$(grep -Fxf <(db_replaces "$db_path") <(pacman -Qq) | paste -s -d, -)
+        # Propagate database to pacman
+        sudo pacsync "$db_name" "${pacconf_args[@]}"
+        sudo pacsync "$db_name" "${pacconf_args[@]}" --dbext=.files
 
-        sudo pacman -Fy  --config="$tmp"/local.conf
-        sudo pacman -Syu --config="$tmp"/local.conf --ignore="$replaces" --noconfirm
+        # Verify if packages on the host can be upgraded from the local repository
+        targets=()
+
+        while IFS='/' read -r repo name; do
+            [[ $repo == "$db_name" ]] && targets+=("$repo/$name")
+        done < <(
+            pacman -Sup --print-format '%r/%n' "${pacconf_args[@]}"
+        )
+        wait "$!"
+
+        if (( ${#targets[@]} )); then
+            msg >&2 'Upgrading installed local repository packages'
+
+            # Answer all questions (including package replacements) with No
+            if ! printf '%s\n' "${targets[@]}" | \
+                sudo pacman -S --noconfirm "${pacconf_args[@]}" -
+            then
+                error 'Failed to upgrade local repository'
+                exit 1
+            fi
+        fi
     fi
 done
 

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Alad Wenter <https://github.com/AladW>
 pkgname=aurutils-git
-pkgver=9.6.r1.g4b5916e
+pkgver=10b.r2.g15375b13
 pkgrel=1
 pkgdesc='helper tools for the arch user repository'
 url='https://github.com/AladW/aurutils'

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,8 @@
+## 11
+
+* `aur-build`
+  + retrieve local repository upgrades with `pacman -Sup`
+
 ## 10
 
 * `aur`

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -1,4 +1,4 @@
-.TH AUR\-BUILD 1 2022-03-25 AURUTILS
+.TH AUR\-BUILD 1 2022-07-12 AURUTILS
 .SH NAME
 aur\-build \- build packages to a local repository
 .
@@ -382,17 +382,16 @@ of built packages, defaulting to
 .
 .SH NOTES
 .SS Repository updates
-When building locally (outside a container),
-.B "pacman \-Syu"
-is run with
-.BR pacman.conf (8)
-only containing the local repository. This is comparable to
+When building on the host (outside of a container), any installed
+packages in the local repository are upgraded to the latest available
+version with
+.BR pacsync <repository>
+followed by
+.BR "pacman \-S \-\-noconfirm" .
+This is comparable to
 .BR "makepkg \-i" ,
-but without subsequent package installation (if a package was
-installed before, it is updated to the latest available version). An
-interesting side-effect is that pacman considers packages inside the
-official repositories "local", and warns if they are newer than any
-custom counterpart. Packages which define a
+but packages are only upgraded (installed) if they were installed priorly.
+Packages which define a
 .I replaces
 field are ignored if the target package is installed on the local system.
 .


### PR DESCRIPTION
When using `sudoers(5)` to remove password prompts for select commands, `pacman --config=/tmp/...` command-lines are variable and thus require whitelisting `/usr/bin/pacman` (opening up `sudo pacman -U` and `sudo pacman --config`), or `--config` with arbitrary arguments (e.g. `--config=/tmp/bad.conf`).

Use a different mechanism to limit upgrades to the local repository, which uses fixed command-lines:

1. Propagate new databases with `pacsync custom`
2. Check if any installed packages are to be upgraded with `pacman -Quq`
3. Restrict the targets to the local repository with `pacsift --repo=custom`
4. Finally, install upgrades with `pacinstall --no-confirm`

For replacements, it suffices to use `pacinstall --resolve-replacements=none`. Compare the (unpublished) pacman commit:

https://github.com/eli-schwartz/pacman/commit/80b118b48b38dd55224d33d54867c533c23b0040

WIP/experimental: pacutils 0.11.1 removes prompt messages with `--no-confirm`, and this only really makes sense if the above `makepkg` commit is merged upstream (`aur build -rs`).