### PR TITLE
lib: add `aur-fetch--mirror`

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -5,8 +5,8 @@ shopt -s extglob
 argv0=fetch
 XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+AUR_FETCH_USE_MIRROR=${AUR_FETCH_USE_MIRROR:-0}
 AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
-AUR_ROOT=${AUR_ROOT:-$XDG_CACHE_HOME/aur}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 
 # Author information for merge commits
@@ -19,7 +19,7 @@ export GIT_COMMITTER_EMAIL=aurutils@localhost
 git_empty_object=$(git hash-object -t tree /dev/null)
 
 # default options
-existing=0 recurse=0 discard=0 local_mirror=0 sync=fetch
+existing=0 recurse=0 discard=0 sync=fetch
 
 results() {
     local mode=$1 prev=$2 current=$3 path=$4 dest=$5
@@ -57,7 +57,7 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='efrS'
 opt_long=('auto' 'merge' 'reset' 'rebase' 'discard' 'existing' 'results:' 'ff'
-          'ff-only' 'no-ff' 'no-commit' 'recurse' 'mirror')
+          'ff-only' 'no-ff' 'no-commit' 'recurse')
 opt_hidden=('dump-options' 'sync:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -83,8 +83,6 @@ while true; do
             sync=reset ;;
         --results)
             shift; results_file=$(realpath -- "$1") ;;
-        --mirror)
-            local_mirror=1 ;;
         # git options
         --ff)
             merge_args+=(-ff) ;;
@@ -143,17 +141,20 @@ fi
 # Update revisions in local AUR mirror
 declare -A local_clones
 
-if (( local_mirror )); then
+# With an AUR mirror, updates are retrieved in two steps. First, updates to the
+# mirror are synchronized with `git-fetch`. Secondly, local clones of the miror
+# are created and are updated with `git-fetch` and `git-merge` as usual.
+if (( AUR_FETCH_USE_MIRROR )); then
     while read -r IFS=':' pkg head; do
         local_clones[$pkg]=$head
-    done < <(env AUR_ROOT="$AUR_ROOT" aur fetch--mirror --lclone "${packages[@]}")
+    done < <(aur fetch--mirror --lclone "${packages[@]}")
     wait "$!"
 fi
 
 # Main loop
 for pkg in "${packages[@]}"; do
     unset -f git
-    if (( local_mirror )); then  # branch origin/$pkg -> master
+    if (( AUR_FETCH_USE_MIRROR )); then  # branch origin/$pkg -> master
         upstream=origin/$pkg
     else
         upstream=origin/master
@@ -166,20 +167,17 @@ for pkg in "${packages[@]}"; do
 
     # Clone package if not existing
     elif [[ ! -d $pkg/.git ]]; then
-        printf >&2 "Cloning into '%s'\n" "$pkg"
-
         # Differentiate between local (fetch--mirror) and aurweb clones
         if [[ ! ${local_clones[$pkg]} ]]; then
-            git clone --quiet "$AUR_LOCATION/$pkg" || exit 1
+            git clone "$AUR_LOCATION/$pkg" || exit 1
             head=$(git -C "$pkg" rev-parse --verify quiet HEAD)
         else
+            printf "Cloning into '%s'\n" "$pkg"
             head=${local_clones[$pkg]}
         fi >&2
 
         if [[ $head ]]; then
             git -C "$pkg" --no-pager log --pretty=reference -1
-        else
-            printf 'warning: You appear to have cloned an empty repository.\n'
         fi >&2
 
         # XXX: race with multiple instances

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -3,8 +3,10 @@
 [[ -v AUR_DEBUG ]] && set -o xtrace
 shopt -s extglob
 argv0=fetch
-AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
+XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+AUR_LOCATION=${AUR_LOCATION:-https://aur.archlinux.org}
+AUR_ROOT=${AUR_ROOT:-$XDG_CACHE_HOME/aur}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[1]}(): }'
 
 # Author information for merge commits
@@ -17,7 +19,7 @@ export GIT_COMMITTER_EMAIL=aurutils@localhost
 git_empty_object=$(git hash-object -t tree /dev/null)
 
 # default options
-existing=0 recurse=0 discard=0 sync=fetch
+existing=0 recurse=0 discard=0 local_mirror=0 sync=fetch
 
 results() {
     local mode=$1 prev=$2 current=$3 path=$4 dest=$5
@@ -55,7 +57,7 @@ source /usr/share/makepkg/util/parseopts.sh
 
 opt_short='efrS'
 opt_long=('auto' 'merge' 'reset' 'rebase' 'discard' 'existing' 'results:' 'ff'
-          'ff-only' 'no-ff' 'no-commit' 'recurse')
+          'ff-only' 'no-ff' 'no-commit' 'recurse' 'mirror')
 opt_hidden=('dump-options' 'sync:')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -81,6 +83,8 @@ while true; do
             sync=reset ;;
         --results)
             shift; results_file=$(realpath -- "$1") ;;
+        --mirror)
+            local_mirror=1 ;;
         # git options
         --ff)
             merge_args+=(-ff) ;;
@@ -124,15 +128,31 @@ if (( ! ${#merge_args[@]} )); then
     merge_args=(--ff-only)
 fi
 
-# Main loop
 if (( recurse )); then
-    aur depends --pkgbase "$@" # stdin handled by aur-depends
+    mapfile -t packages < <(aur depends --pkgbase "$@")
+    wait "$!"
+
 elif (( $# == 1 )) && [[ $1 == "-" || $1 == "/dev/stdin" ]]; then
-    tee # noop
+    mapfile -t packages
 else
-    printf '%s\n' "$@"
-fi | while read -r pkg; do
+    packages=("$@")
+    set --
+fi
+
+# Update revisions in local AUR mirror
+if (( local_mirror )); then
+    mkdir -p "$AUR_ROOT"
+    env AUR_ROOT="$AUR_ROOT" aur fetch--mirror "${packages[@]}"  # flock $AUR_ROOT
+fi
+
+# Main loop
+for pkg in "${packages[@]}"; do
     unset -f git
+    if (( local_mirror )); then  # branch origin/$pkg -> master
+        upstream=origin/$pkg
+    else
+        upstream=origin/master
+    fi
 
     # Verify if the repository is hosted on AUR (#959)
     if (( existing )) && ! git ls-remote --exit-code "$AUR_LOCATION/$pkg" >/dev/null; then
@@ -143,8 +163,17 @@ fi | while read -r pkg; do
         # Avoid issues with filesystem boundaries (#274)
         git() { command git -C "$pkg" "$@"; }
 
+        # Automatically convert clones to local clones and vice-versa
+        if (( local_mirror )); then
+            git remote set-url origin "$AUR_ROOT"
+            git remote set-branches origin "$pkg"
+        else
+            git remote set-url origin "$AUR_LOCATION/$pkg".git
+            git remote set-branches origin '*'
+        fi
+
         # Retrieve new upstream commits
-        git fetch -v origin >&2 || exit
+        git fetch origin >&2 || exit
 
         # Store original HEAD for --results output
         orig_head=$(git rev-parse --verify --quiet HEAD)
@@ -165,10 +194,10 @@ fi | while read -r pkg; do
                 ;;&  # proceed to merge or rebase
             rebase)
                 dest='HEAD'
-                git rebase -v "${rebase_args[@]}" origin/master ;;
+                git rebase "${rebase_args[@]}" "$upstream" ;;
             merge)
                 dest='HEAD'
-                git merge -v "${merge_args[@]}" origin/master ;;
+                git merge "${merge_args[@]}" "$upstream" ;;
             reset)
                 dest='master@{u}'
                 git reset --hard 'master@{u}' ;;
@@ -186,18 +215,24 @@ fi | while read -r pkg; do
         fi
 
     # Otherwise, try to clone anew
-    elif git clone "$AUR_LOCATION/$pkg" >&2; then
+    else
+        # XXX: per-package locks are too fine-gained for (fast) local clones,
+        # but suitable for regular clones
+        printf >&2 "Cloning into '%s'\n" "$pkg"
+        if (( local_mirror )); then
+            git clone -q --branch="$pkg" --single-branch "$AUR_ROOT" "$pkg" || exit 1
+            git branch -m master # compatibility to aurweb
+        else
+            git clone -q "$AUR_LOCATION/$pkg" || exit 1
+        fi >&2
+
         if head=$(git -C "$pkg" rev-parse --verify --quiet HEAD); then
             git -C "$pkg" --no-pager log --pretty=reference -1 >&2
         fi
-        head=${head:-$git_empty_object}
 
         if [[ -v results_file ]]; then
-            results 'clone' "$git_empty_object" "$head" "$PWD/$pkg" "$results_file"
+            results 'clone' "$git_empty_object" "${head:-$git_empty_object}" "$PWD/$pkg" "$results_file"
         fi
-    else
-        printf >&2 '%s: failed to clone repository %s\n' "$argv0" "$pkg"
-        exit 1
     fi
 done
 

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -141,9 +141,13 @@ else
 fi
 
 # Update revisions in local AUR mirror
+declare -A local_clones
+
 if (( local_mirror )); then
-    mkdir -p "$AUR_ROOT"
-    env AUR_ROOT="$AUR_ROOT" aur fetch--mirror "${packages[@]}"  # flock $AUR_ROOT
+    while read -r IFS=':' pkg head; do
+        local_clones[$pkg]=$head
+    done < <(env AUR_ROOT="$AUR_ROOT" aur fetch--mirror --lclone "${packages[@]}")
+    wait "$!"
 fi
 
 # Main loop
@@ -160,22 +164,37 @@ for pkg in "${packages[@]}"; do
         printf >&2 '%s: warning: package %s is not in AUR, skipping\n' "$argv0" "$pkg"
         continue
 
-    elif [[ -d $pkg/.git ]]; then
+    # Clone package if not existing
+    elif [[ ! -d $pkg/.git ]]; then
+        printf >&2 "Cloning into '%s'\n" "$pkg"
+
+        # Differentiate between local (fetch--mirror) and aurweb clones
+        if [[ ! ${local_clones[$pkg]} ]]; then
+            git clone --quiet "$AUR_LOCATION/$pkg" || exit 1
+            head=$(git -C "$pkg" rev-parse --verify quiet HEAD)
+        else
+            head=${local_clones[$pkg]}
+        fi >&2
+
+        if [[ $head ]]; then
+            git -C "$pkg" --no-pager log --pretty=reference -1
+        else
+            printf 'warning: You appear to have cloned an empty repository.\n'
+        fi >&2
+
+        # XXX: race with multiple instances
+        if [[ -v results_file ]]; then
+            results 'clone' "$git_empty_object" "${head:-$git_empty_object}" "$PWD/$pkg" "$results_file"
+        fi
+
+    # Update existing git repository
+    else
         # Per-package lock
         exec {fd}< "$pkg"/.git
         flock --wait 5 "$fd" || exit 1
 
         # Avoid issues with filesystem boundaries (#274)
         git() { command git -C "$pkg" "$@"; }
-
-        # Automatically convert clones to local clones and vice-versa
-        if (( local_mirror )); then
-            git remote set-url origin "$AUR_ROOT"
-            git remote set-branches origin "$pkg"
-        else
-            git remote set-url origin "$AUR_LOCATION/$pkg".git
-            git remote set-branches origin '*'
-        fi
 
         # Retrieve new upstream commits
         git fetch origin >&2 || exit
@@ -219,26 +238,6 @@ for pkg in "${packages[@]}"; do
             results "$sync_pkg" "$orig_head" "$head" "$PWD/$pkg" "$results_file"
         fi
         exec {fd}<&- # release lock
-
-    # Otherwise, try to clone anew
-    else
-        # XXX: per-package locks are too fine-gained for (fast) local clones,
-        # but suitable for regular clones
-        printf >&2 "Cloning into '%s'\n" "$pkg"
-        if (( local_mirror )); then
-            git clone -q --branch="$pkg" --single-branch "$AUR_ROOT" "$pkg" || exit 1
-            git branch -m master # compatibility to aurweb
-        else
-            git clone -q "$AUR_LOCATION/$pkg" || exit 1
-        fi >&2
-
-        if head=$(git -C "$pkg" rev-parse --verify --quiet HEAD); then
-            git -C "$pkg" --no-pager log --pretty=reference -1 >&2
-        fi
-
-        if [[ -v results_file ]]; then
-            results 'clone' "$git_empty_object" "${head:-$git_empty_object}" "$PWD/$pkg" "$results_file"
-        fi
     fi
 done
 

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -119,6 +119,7 @@ if (( ! $# )); then
     exit 1
 fi
 
+# XXX: race with concurrent processes
 if [[ -v results_file ]]; then
     : >"$results_file" || exit 1 # truncate file
 fi
@@ -160,6 +161,10 @@ for pkg in "${packages[@]}"; do
         continue
 
     elif [[ -d $pkg/.git ]]; then
+        # Per-package lock
+        exec {fd}< "$pkg"/.git
+        flock --wait 5 "$fd" || exit 1
+
         # Avoid issues with filesystem boundaries (#274)
         git() { command git -C "$pkg" "$@"; }
 
@@ -213,6 +218,7 @@ for pkg in "${packages[@]}"; do
         if [[ -v results_file ]]; then
             results "$sync_pkg" "$orig_head" "$head" "$PWD/$pkg" "$results_file"
         fi
+        exec {fd}<&- # release lock
 
     # Otherwise, try to clone anew
     else

--- a/lib/aur-fetch--mirror
+++ b/lib/aur-fetch--mirror
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -o errexit
+[[ -v AUR_DEBUG ]] && set -o xtrace
+argv0=fetch--mirror
+AUR_MIRROR=${AUR_MIRROR:-https://github.com/archlinux/aur}
+AUR_MIRROR_TTL=${AUR_MIRROR_TTL:-600}
+startdir=$PWD
+
+if ! { [[ -v AUR_ROOT ]] && [[ -d $AUR_ROOT ]]; }; then
+    printf >&2 '%s: AUR_ROOT must point to a directory\n' "$argv0"
+    exit 2
+fi
+
+# Update local mirror
+exec {fd}< "$AUR_ROOT"
+{ flock --wait 5 "$fd" || exit 1
+
+  # Shallow clone
+  [[ ! -d $AUR_ROOT/.git ]] && git clone --depth=1 "$AUR_MIRROR" "$AUR_ROOT"
+  cd "$AUR_ROOT"
+
+  # Keep a refcache to filter out packages which are not in AUR. This is
+  # includes unlisted packages (unlike `aur pkglist --pkgbase`)
+  printf -v now '%(%s)T' -1
+  ttl=$AUR_MIRROR_TTL
+
+  if ! cachetime=$(stat -c %Y remote-pkgbase 2>/dev/null) || (( now > (cachetime + ttl) )); then
+      git ls-remote origin 'refs/heads/*' | awk -F/ '{print $3}' >'remote-pkgbase'
+  fi
+
+  # Retrieve list of active remotes
+  mapfile -t active_branches < <(
+      git config --get-all remote.origin.fetch | awk -F'[/:]' '$3 != "main" {print $3}'
+  )
+  # Only consider AUR targets
+  mapfile -t target_branches < <(
+      printf '%s\n' "$@" | grep -Fxf 'remote-pkgbase'
+  )
+
+  # Set remote branches as union of active remotes and arguments. If '*' is set
+  # instead, `git fetch origin` in $AUR_ROOT will pull in the entire history.
+  git remote set-branches origin --add main
+  printf '%s\n' "${target_branches[@]}" "${active_branches[@]}" | sort -u \
+      | xargs -d '\n' git remote set-branches origin
+
+  # Retrieve objects
+  git fetch origin "${target_branches[@]}"
+  
+  # Create branches tracked by local clones
+  for b in "${target_branches[@]}"; do
+	  git branch "$b" origin/"$b"
+  done
+} >&2
+
+exec {fd}<&- # release lock

--- a/lib/aur-fetch--mirror
+++ b/lib/aur-fetch--mirror
@@ -2,54 +2,112 @@
 set -o errexit
 [[ -v AUR_DEBUG ]] && set -o xtrace
 argv0=fetch--mirror
+XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 AUR_MIRROR=${AUR_MIRROR:-https://github.com/archlinux/aur}
-AUR_MIRROR_TTL=${AUR_MIRROR_TTL:-600}
+AUR_MIRROR_TTL=${AUR_MIRROR_TTL:-300}
+AUR_ROOT=${AUR_ROOT:-$XDG_CACHE_HOME/aur}
 startdir=$PWD
+local_clones=0
 
-if ! { [[ -v AUR_ROOT ]] && [[ -d $AUR_ROOT ]]; }; then
-    printf >&2 '%s: AUR_ROOT must point to a directory\n' "$argv0"
-    exit 2
+if [[ $1 = '--lclone' ]]; then
+    local_clones=1
+    shift
 fi
 
-# Update local mirror
+# --------------------------------------------------
+# Step 1. Create a sparse checkout of the AUR mirror
+git_active_remotes() {
+    git config --get-all remote.origin.fetch | awk -F'[/:]' '{print $3}'
+}
+
+# XXX: this includes refs/heads (which we do not use) but unlike
+# git-config this accepts multiple arguments in one call
+git_set_branches() {
+    git remote set-branches origin --add main # ensure at least 1 remote
+    sort -u | xargs -d '\n' git remote set-branches origin
+}
+
+git_ls_remote_ttl() {
+    local cachetime now ttl=$AUR_MIRROR_TTL
+    printf -v now '%(%s)T' -1
+
+    if ! cachetime=$(stat -c %Y "$1" 2>/dev/null) || (( now > (cachetime + ttl) )); then
+        git ls-remote origin 'refs/heads/*' | awk -F/ '{print $3}'
+    fi
+}
+
 exec {fd}< "$AUR_ROOT"
 { flock --wait 5 "$fd" || exit 1
 
   # Shallow clone
-  [[ ! -d $AUR_ROOT/.git ]] && git clone --depth=1 "$AUR_MIRROR" "$AUR_ROOT"
+  [[ ! -d $AUR_ROOT ]] && git clone --depth=1 --bare "$AUR_MIRROR" "$AUR_ROOT"
   cd "$AUR_ROOT"
 
   # Keep a refcache to filter out packages which are not in AUR. This is
   # includes unlisted packages (unlike `aur pkglist --pkgbase`)
-  printf -v now '%(%s)T' -1
-  ttl=$AUR_MIRROR_TTL
-
-  if ! cachetime=$(stat -c %Y remote-pkgbase 2>/dev/null) || (( now > (cachetime + ttl) )); then
-      git ls-remote origin 'refs/heads/*' | awk -F/ '{print $3}' >'remote-pkgbase'
-  fi
+  git_ls_remote_ttl 'remote-pkgbase' >'remote-pkgbase'
 
   # Retrieve list of active remotes
-  mapfile -t active_branches < <(
-      git config --get-all remote.origin.fetch | awk -F'[/:]' '$3 != "main" {print $3}'
-  )
+  mapfile -t active_remotes < <(git_active_remotes | grep -v 'main')
+
   # Only consider AUR targets
-  mapfile -t target_branches < <(
-      printf '%s\n' "$@" | grep -Fxf 'remote-pkgbase'
-  )
+  mapfile -t target_remotes < <(printf '%s\n' "$@" | grep -Fxf 'remote-pkgbase')
 
   # Set remote branches as union of active remotes and arguments. If '*' is set
   # instead, `git fetch origin` in $AUR_ROOT will pull in the entire history.
-  git remote set-branches origin --add main
-  printf '%s\n' "${target_branches[@]}" "${active_branches[@]}" | sort -u \
-      | xargs -d '\n' git remote set-branches origin
+  printf '%s\n' "${target_remotes[@]}" "${active_remotes[@]}" | git_set_branches
 
   # Retrieve objects
-  git fetch origin "${target_branches[@]}"
-  
-  # Create branches tracked by local clones
-  for b in "${target_branches[@]}"; do
-      git branch --force "$b" origin/"$b"
-  done
+  git fetch origin "${target_remotes[@]}"
+
+  # Resetting branches is only needed when .git/config contains both refs/heads
+  # and refs/remotes/origin, i.e. when using git-clone. `--lclone` uses git-init
+  # and refspec manipulation instead.
+  # for b in "${target_remotes[@]}"; do
+  #     git branch --force "$b" origin/"$b"
+  # done
 } >&2
 
-exec {fd}<&- # release lock
+# ------------------------------------------------------------
+# Step 2. Propagate each branch in the mirror to a local clone
+(( ! local_clones )) && exit
+results=()
+
+git_srcdest_origin() {
+    local refspec=refs/remotes/origin/$1
+
+    git config remote.origin.fetch "+$refspec:$refspec"
+    git fetch --quiet
+    git checkout -B master "$refspec"
+}
+
+for b in "${target_remotes[@]}"; do
+    cd "$startdir"
+
+    # XXX: "Cloning into an existing directory is only allowed if the
+    # directory is empty"
+    if [[ ! -d $b/.git ]] && mkdir "$b"; then
+        cd "$b"
+        git init
+        git remote add origin "$AUR_ROOT"
+
+        # Compared to git clone --local, using $refspec as both source and
+        # destination allows updates from `git-fetch` in $AUR_ROOT to be
+        # directly visible in local clones.  $AUR_ROOT does not require
+        # local branches or refs/heads for this to work.
+        git_srcdest_origin "$b"
+
+        # Export results to aur-fetch
+        head=$(git rev-parse --verify --quiet HEAD)
+        results+=("$b:$head")
+    fi >&2
+done
+
+# The lock is only released here, because we do not want an instance to modify
+# AUR_ROOT while local git-clones are still underway. Additionally, local clones
+# use cp(1) and are thus a cheap operation. See --local in git-clone(1).
+exec {fd}<&-
+
+if (( ${#results[@]} )); then
+    printf '%s\n' "${results[@]}"
+fi

--- a/lib/aur-fetch--mirror
+++ b/lib/aur-fetch--mirror
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o errexit
 [[ -v AUR_DEBUG ]] && set -o xtrace
-argv0=fetch--mirror
+#argv0=fetch--mirror
 XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 AUR_MIRROR=${AUR_MIRROR:-https://github.com/archlinux/aur}
 AUR_MIRROR_TTL=${AUR_MIRROR_TTL:-300}
@@ -32,7 +32,7 @@ git_ls_remote_ttl() {
     printf -v now '%(%s)T' -1
 
     if ! cachetime=$(stat -c %Y "$1" 2>/dev/null) || (( now > (cachetime + ttl) )); then
-        git ls-remote origin 'refs/heads/*' | awk -F/ '{print $3}'
+        git ls-remote origin 'refs/heads/*' | awk -F/ '{print $3}' >"$1"
     fi
 }
 
@@ -45,7 +45,7 @@ exec {fd}< "$AUR_ROOT"
 
   # Keep a refcache to filter out packages which are not in AUR. This is
   # includes unlisted packages (unlike `aur pkglist --pkgbase`)
-  git_ls_remote_ttl 'remote-pkgbase' >'remote-pkgbase'
+  git_ls_remote_ttl 'remote-pkgbase'
 
   # Retrieve list of active remotes
   mapfile -t active_remotes < <(git_active_remotes | grep -v 'main')

--- a/lib/aur-fetch--mirror
+++ b/lib/aur-fetch--mirror
@@ -48,7 +48,7 @@ exec {fd}< "$AUR_ROOT"
   
   # Create branches tracked by local clones
   for b in "${target_branches[@]}"; do
-	  git branch "$b" origin/"$b"
+      git branch --force "$b" origin/"$b"
   done
 } >&2
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -113,7 +113,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:' 'root:'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
           'makepkg-args:' 'format:' 'no-check' 'keep-going:' 'user:'
-          'rebase' 'reset' 'ff' 'mirror')
+          'rebase' 'reset' 'ff')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rm-deps' 'gpg-sign' 'margs:' 'nocheck'
@@ -184,8 +184,6 @@ while true; do
             fetch_args+=(--rebase) ;;
         --reset)
             fetch_args+=(--reset) ;;
-        --mirror)
-            fetch_args+=(--mirror) ;;
         # build options
         -c|--chroot)
             build_args+=(--chroot) ;;

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -113,7 +113,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:' 'root:'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
           'makepkg-args:' 'format:' 'no-check' 'keep-going:' 'user:'
-          'rebase' 'reset' 'ff')
+          'rebase' 'reset' 'ff' 'mirror')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rm-deps' 'gpg-sign' 'margs:' 'nocheck'
@@ -184,6 +184,8 @@ while true; do
             fetch_args+=(--rebase) ;;
         --reset)
             fetch_args+=(--reset) ;;
+        --mirror)
+            fetch_args+=(--mirror) ;;
         # build options
         -c|--chroot)
             build_args+=(--chroot) ;;

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -5,6 +5,12 @@
     - `pacman -Syu --config` is replaced by `pacsync <repo>` and `pacman -S <repo>/<pkg>`
     - local repository upgrades are now unaffected by `--pacman-conf`
 
+* `aur-fetch`
+  + add `aur-fetch--mirror` helper for `aur.git` mirrors
+    - defaults to `github.com/archlinux/aur`
+    - enabled with `AUR_FETCH_USE_MIRROR=1`
+  + run flock(1) on existing repositories
+
 * `aur-graph`
   + selectively disable/enable depends with `aur graph -v <TYPE>=[0|1]`
     - supported types: `DEPENDS`, `MAKEDEPENDS`, `CHECKDEPENDS`, `OPTDEPENDS`

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -195,6 +195,57 @@ and
 .I <head_to>
 will be identical.
 .
+.SH ENVIRONMENT
+.TP
+.B AUR_LOCATION
+URI where repositories are cloned from. Defaults to
+.IR https://aur.archlinux.org .
+.
+.TP
+.B AUR_MIRROR
+URI to an AUR mirror, a
+.BR git (1)
+repository where each package is contained in a
+.BR git\-branch (1).
+Defaults to
+.MT https://github.com/archlinux/aur
+.ME .
+.
+.TP
+.B AUR_MIRROR_TTL
+When updating an AUR mirror, a list of all branches is retrieved with
+.BR git\-ls\-remote
+to validate arguments. The
+.B AUR_MIRROR_TTL
+variable defines (in seconds) how often this command is run. For accurate
+results, this should roughly equal the synchronization interval between AUR and
+its mirrors. Defaults to
+.IR 300 .
+.
+.TP
+.B AUR_FETCH_USE_MIRROR
+If this variable is set to a positive value, clone repositories from an AUR
+mirror instead of
+.BR AUR_LOCATION .
+Upstream changes are merged from
+.I origin/<package>
+instead of
+.IR origin/master .
+.IP
+Remotes of existing
+.BR git (1)
+repositories are preserved. When enabling or disabling
+.BR AUR_FETCH_MIRROR ,
+repositories should be converted manually with
+.B git\-remote set\-url
+and
+.BR "git\-remote set\-branches origin" .
+.
+.TP
+.B AUR_ROOT
+Directory where an AUR mirror is cloned to. Defaults to
+.IR XDG_CACHE_HOME/aur .
+.
 .SH SEE ALSO
 .ad l
 .nh


### PR DESCRIPTION
Add machinery to support read-only mirrors of `aur.git`, such as https://github.com/archlinux/aur. The basic idea is inspired by `asp`:

1. Keep a shallow clone of `aur.git` (`git clone --depth=1`) in `AUR_ROOT` (defaults to `$XDG_CACHE_HOME/aur`)
2. Add remotes to package branches as needed
3. Run `git-fetch` to pull in new revisions for each branch
4. Create local clones for each branch, where each clone fetches from `+refs/remotes/orgin/<package>:refs/remotes/origin/<package>`

The last step ensures there is no mismatch between revisions in `aur.git` and branch `HEAD`s in the shallow clone. In other words, running `git-fetch` in the shallow clone followed by `git-pull` in the local branch clones suffices to update to new revisions. To filter out any invalid arguments, a list of all branches is cached with a default TTL of 300 seconds.

No automatic conversion between `aur.archlinux.org/<package>.git` and `aur-fetch--mirror` clones is done by either `aur-fetch` or `aur-fetch--mirror`. Such a conversion reduces generality (forcing git repos to have either a remote to `aur.archlinux.org` or `AUR_ROOT`) and might introduce subtle bugs. 

Because of this, usage of read-only mirrors in `aur-fetch` is controlled with an `AUR_FETCH_USE_MIRROR` environment variable. 

----
To use `AUR_ROOT` one can either start from scratch (obviously), or convert repositories in `AURDEST` as follows:
```bash
#!/bin/bash -e
cd "${AURDEST:-$HOME/.cache/aurutils/sync}"

for pkg in *; do
    refspec=refs/remotes/origin/$pkg
    old_upstream=$(git -C "$pkg" rev-parse --verify --quiet 'master@{u}')

    git -C "$pkg" remote set-url "$AUR_ROOT".git
    git -C "$pkg" config remote.origin.fetch "+$refspec:$refspec"
    git -C "$pkg" fetch
    git -C "$pkg" branch -f master "$refspec"
    git -C "$pkg" branch -r --contains "$old_upstream"  # check that $AUR_ROOT is not behind
    #git -C "$pkg" checkout master      # when discarding local commits
    #git -C "$pkg" merge origin/master  # when merging
done
```
To convert back to `aur.archlinux.org` clones:
```bash
#!/bin/bash -e
cd "${AURDEST:-$HOME/.cache/aurutils/sync}"

for pkg in *; do
   git -C "$pkg" remote set-url "https://aur.archlinux.org/$pkg.git"
   git -C "$pkg" remote set-branches origin '*'
   git -C "$pkg" fetch
   git -C "$pkg" branch -f master origin/master
done
```