### PR TITLE
view: improve diagnostics, add `view-delta`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,30 @@ directories are available. This suggests to use a persistent directory for
 `AURDEST`, instead of the default `$XDG_CACHE_HOME/aurutils/sync` used by
 `aur-sync(1)`.
 
+## view-delta
+
+`aur-view(1)` uses `vifm(1)` or a comparable file manager set in
+`AUR_PAGER` to inspect and edit build files. 
+
+`view-delta` assumes that files are not edited before the build process,
+and takes the following approach:
+
+1. display diffs side-by side with `git-delta`;
+2. display remaining files with `bat` for syntax highlighting.
+
+A pager (defaults to `less`) is used for navigation. To allow aborting
+the inspection process with a non-zero exit code, a confirmation prompt
+is displayed.
+
+`view-delta` can be used as any other file manager taking a directory
+argument:
+
+```bash
+view-delta <path to build files>  # directly
+AUR_PAGER=view-delta aur view ... # with aur-view
+AUR_PAGER=view-delta aur sync ... # with aur-view wrappers
+```
+
 ## sync-list
 
 When using `aur-sync(1)` or `aur-build(1)`, packages accumulate in (one or

--- a/examples/view-delta
+++ b/examples/view-delta
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -o errexit
+shopt -s extglob
+
+# Helper function to take complements of pkgbase arrays
+filter_packages() { grep -Fxvf <(printf '%s\n' "$@") -; }
+
+# Directory with diffs and PKGBUILD subdirs
+cd "$1"
+diffs=(@(*.diff|*.log))
+pkgbases=(*/)
+pkgbases=("${pkgbases[@]%/}")
+
+# Show diffs in 2 panes
+if [[ -f ${diffs[0]} ]]; then
+    delta --side-by-side --line-numbers "${diffs[@]}"
+
+    # Remove diffs from remaining targets (new or unchanged dirs)
+    mapfile -t pkgbases < <(
+        printf '%s\n' "${diffs[@]%%.*}" | filter_packages "${pkgbases[@]}")
+fi
+
+# Show remaining targets in a concatenated fashion
+if (( ${#pkgbases[@]} )); then
+    find -L "${pkgbases[@]}" -maxdepth 1 -type f -exec bat {} +
+fi
+
+# Show an exit prompt
+read -rp $'Press Return to continue or Ctrl+d to abort\n'

--- a/lib/aur-view
+++ b/lib/aur-view
@@ -126,14 +126,14 @@ for pkg in "${packages[@]}"; do
         heads[$pkg]=$head
     else
         error '%s: %s: revision %s not found' "$argv0" "$pkg" "$revision"
-        exit 22
+        exit 2
     fi
 
     if [[ -f $AUR_VIEW_DB/$pkg ]] && read -r view < "$AUR_VIEW_DB/$pkg"; then
         # Check if hash points to a valid object
         if ! git cat-file -e "$view"; then
             diag_invalid "$pkg"
-            exit 22
+            exit 2
         fi
 
         if [[ $view != "$head" ]]; then

--- a/lib/aur-view
+++ b/lib/aur-view
@@ -43,8 +43,7 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
 fi
 
 opt_short='a:'
-# TODO: add --confirm? (overrides AUR_CONFIRM_PAGER)
-opt_long=('format:' 'arg-file:' 'revision:' 'no-patch')
+opt_long=('format:' 'arg-file:' 'revision:' 'no-patch' 'confirm')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -70,6 +69,8 @@ while true; do
             patch=0 ;;
         --revision)
             shift; revision=$1 ;;
+        --confirm)
+            AUR_CONFIRM_PAGER=1 ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'

--- a/lib/aur-view
+++ b/lib/aur-view
@@ -10,6 +10,18 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 # default options
 log_fmt='diff' revision='HEAD' log_args=() patch=1
 
+diag_invalid() {
+    cat >&2 <<EOF
+Error:
+    aur-view encountered an invalid git revision. This may happen when
+    the upstream URL of a repository changed.  If so, the old revision
+    should be removed manually.
+
+    The following file was checked:
+EOF
+    printf '%8s%s\n' ' ' "$1"
+}
+
 trap_exit() {
     if [[ ! -v AUR_DEBUG ]]; then
         rm -rf -- "$tmp"
@@ -119,7 +131,7 @@ for pkg in "${packages[@]}"; do
     if [[ -f $AUR_VIEW_DB/$pkg ]] && read -r view < "$AUR_VIEW_DB/$pkg"; then
         # Check if hash points to a valid object
         if ! git cat-file -e "$view"; then
-            error '%s: %s: invalid revision' "$argv0" "$pkg"
+            diag_invalid "$pkg"
             exit 22
         fi
 

--- a/makepkg/PKGBUILD
+++ b/makepkg/PKGBUILD
@@ -17,7 +17,9 @@ optdepends=('bash-completion: bash completion'
             'zsh: zsh completion'
             'devtools: aur-chroot'
             'vifm: default pager'
-            'ninja: aur-sync ninja support')
+            'ninja: aur-sync ninja support'
+            'bat: view-delta example script'
+            'git-delta: view-delta example script')
 
 pkgver() {
     cd aurutils

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -16,8 +16,15 @@
     - supported types: `DEPENDS`, `MAKEDEPENDS`, `CHECKDEPENDS`, `OPTDEPENDS`
     - forwarded by `aur-sync` (`--optdepends`, `--no-check`)
 
+* `aur-view`
+  + print diagnostic on invalid git revision (#894)
+  + exit code on unknown/invalid revision is now 2 (from 22)
+
 * `completion`
   + support extending `zsh` completion for third party commands (#1016)
+
+* `examples`
+  + add `view-delta`
 
 ## 10
 

--- a/man1/aur-view.1
+++ b/man1/aur-view.1
@@ -11,8 +11,14 @@ aur\-view \- inspect git repositories
 .
 .SH DESCRIPTION
 .B aur\-view
-presents git repositories to the user for inspection. A file
-manager or pager is determined in the following order:
+presents
+.BR git (1)
+repositories stored in a common directory for inspection. Only
+repositories whose names match
+.BR aur\-view
+arguments are shown.
+.PP
+The used file manager or pager is determined in the following order:
 .IP \(bu 4
 The value of
 .BR AUR_PAGER ", "
@@ -105,6 +111,28 @@ If set, display an additional confirmation prompt after the file
 manager has exited successfully. This may be used for (GUI) file
 managers not supporting an exit status greater zero to indicate
 unreviewed files.
+.
+.SH NOTES
+After browsing to a different directory in the file manager, the view on
+argument directories is replaced by a view on the original directory. To
+alleviate this issue,
+.B aur\-view
+keeps a list of symbolic links in a temporary directory, which point to
+argument repositories. This directory also includes any generated diffs.
+.PP
+If the upstream URL of a
+.BR git (1)
+repository changed, stored
+.B aur\-view
+revisions are potentially invalidated. Specifically,
+.BR git\-cat\-file (1)
+aborts when given a non-existing object. The offending revision can be
+removed manually in this case:
+.EX
+
+  $ rm -rf ~/.local/share/aurutils/view/<package>
+
+.XE
 .
 .SH SEE ALSO
 .ad l

--- a/man1/aur-view.1
+++ b/man1/aur-view.1
@@ -72,12 +72,30 @@ command-line.
 .SH ENVIRONMENT
 .TP
 .B AUR_VIEW_DB
+The directory where inspected
+.BR git (1)
+revisions are stored. Defaults to
+.BR $XDG_DATA_HOME/aurutils/view .
 .
 .TP
 .B AUR_PAGER
 The file manager used to view and edit build files. This variable is
 split on white space to allow program options, for example:
 .IR "AUR_PAGER=less \-K" .
+If unset,
+.B aur\-view
+defaults to
+.BR vifm (1).
+This two-pane file manager allows to quickly navigate between files in
+the left pane, and file previews in the right pane. Simultaneously,
+files can be edited with
+.BR vim (1).
+Other comparable file managers include
+.BR mc (1),
+.BR nnn (1),
+.BR ranger (1),
+and
+.BR xplr (1).
 .
 .TP
 .B AUR_CONFIRM_PAGER


### PR DESCRIPTION
* Add a diagnostic if `aur-view` encounters an invalid revision
* Add `examples/view-delta` as alternative (read-only) review mechanism with `git-delta` and `bat`
* Change `exit 22` to `exit 2` on invalid arguments