### PR TITLE
build: fix `MAKEPKG`

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -218,6 +218,12 @@ if [[ $UID == 0 ]] && ! { [[ -v build_user ]] && [[ -v AUR_ASROOT ]]; }; then
     exit 1
 fi
 
+# Disable elevation when running as root
+if [[ $UID == 0 ]]; then
+    #shellcheck disable=SC2209
+    AUR_PACMAN_AUTH=command
+fi
+
 # Assign environment variables
 : "${db_ext=$AUR_DBEXT}" "${db_root=$AUR_DBROOT}" "${db_repo=$AUR_REPO}"
 
@@ -225,15 +231,6 @@ fi
 if [[ $MAKEPKG ]]; then
     # shellcheck disable=SC2086
     makepkg() { command -- $MAKEPKG "$@"; }
-fi
-
-# Custom elevation command
-if [[ $UID == 0 ]]; then
-    sudo() { command -- "$@"; }
-
-elif [[ $AUR_PACMAN_AUTH ]]; then
-    # shellcheck disable=SC2086
-    sudo() { command -- $AUR_PACMAN_AUTH "$@"; }
 fi
 
 # shellcheck disable=SC2174
@@ -481,7 +478,8 @@ while IFS= read -ru "$fd" path; do
         # Like `makepkg --syncdeps`, this affects the host and so uses the host
         # pacman configuration. --pacman-conf (which may also point to
         # a world-writeable file) is not applied.
-        sudo aur build--sync "$db_name"
+        #shellcheck disable=SC2086
+        ${AUR_PACMAN_AUTH:-sudo} aur build--sync "$db_name"
     fi
 done
 

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -227,12 +227,6 @@ fi
 # Assign environment variables
 : "${db_ext=$AUR_DBEXT}" "${db_root=$AUR_DBROOT}" "${db_repo=$AUR_REPO}"
 
-# Custom makepkg command
-if [[ $MAKEPKG ]]; then
-    # shellcheck disable=SC2086
-    makepkg() { command -- $MAKEPKG "$@"; }
-fi
-
 # shellcheck disable=SC2174
 mkdir -pm 0700 "${TMPDIR:-/tmp}/aurutils-$UID"
 tmp=$(mktemp -d --tmpdir "aurutils-$UID/$argv0.XXXXXXXX")
@@ -368,9 +362,10 @@ while IFS= read -ru "$fd" path; do
     pkglist=()
 
     # Run pkgver before --packagelist (#500)
+    # XXX: race with concurrent processes
     if (( run_pkgver )); then
-        # XXX: race with concurrent processes
-        as_user makepkg -od "${makepkg_common_args[@]}" >&2
+        #shellcheck disable=SC2086
+        as_user ${MAKEPKG:-makepkg} -od "${makepkg_common_args[@]}" >&2
     fi
 
     # Check if the package is already built, but unlike makepkg, do not exit
@@ -416,8 +411,9 @@ while IFS= read -ru "$fd" path; do
             PKGDEST="$var_tmp" LOGDEST="$var_tmp" \
                 run_msg 2 aur chroot --build "${chroot_args[@]}"
         else
+            #shellcheck disable=SC2086
             PKGDEST="$var_tmp" LOGDEST="$var_tmp" \
-                run_msg 3 as_user makepkg "${makepkg_common_args[@]}" "${makepkg_args[@]}"
+                run_msg 3 as_user ${MAKEPKG:-makepkg} "${makepkg_common_args[@]}" "${makepkg_args[@]}"
         fi
 
         cd "$var_tmp"
@@ -450,6 +446,7 @@ while IFS= read -ru "$fd" path; do
         # No candidate signature, generate one
         elif (( sign_pkg )); then
             as_user gpg "${gpg_args[@]}" --output "$p_base".sig "$p"
+
             printf >&2 '%s: created signature file %q\n' "$argv0" "$p_base".sig
             siglist+=("$p_base".sig)
         fi

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -435,14 +435,18 @@ For example, create the
 file with the following contents:
 .PP
 .EX
+    # rule for installing dependencies with makepkg --syncdeps
     build ALL = (root) NOPASSWD: /usr/bin/pacman
-    build ALL = (root) NOPASSWD: /usr/lib/aurutils/aur-build--sync
+
+    # rule for updating the local repository
+    build ALL = (root) NOPASSWD: /usr/bin/aur build-sync *
 .EE
 .PP
+The wildcard can be replaced by the name of the local repository.
 .BR aur\-build (1)
 and related programs such as
 .BR aur\-sync (1)
-may now be run as the new
+can now run as the new
 .I build
 user.
 For example:


### PR DESCRIPTION
`as_user` uses env(1) and will thus bypass any shell functions.