### PR TITLE
fetch: run git-checkout unconditionally with --rebase

### DIFF
--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -211,21 +211,19 @@ for pkg in "${packages[@]}"; do
         # Retrieve per-package configuration (defaults to global setting, #1007)
         sync_pkg=$(sync_package_config "$sync" "$pkg")
 
-        # Reset working tree if new commits will be merged (--discard)
-        reset_on_update() {
-            git merge-base --is-ancestor "$1" HEAD || git checkout ./
-        }
-
         # Merge in new history
         case $sync_pkg in
-            rebase|merge)
-                (( discard )) && reset_on_update 'master@{u}'
-                ;;&  # proceed to merge or rebase
             rebase)
                 dest='HEAD'
+                if (( discard )); then
+                    git checkout ./  # git-rebase requires a clean worktree
+                fi
                 git rebase "${rebase_args[@]}" "$upstream" ;;
             merge)
                 dest='HEAD'
+                if (( discard )); then
+                    git merge-base --is-ancestor 'master@{u}' HEAD || git checkout ./
+                fi
                 git merge "${merge_args[@]}" "$upstream" ;;
             reset)
                 dest='master@{u}'

--- a/lib/aur-fetch
+++ b/lib/aur-fetch
@@ -31,16 +31,11 @@ results() {
 }
 
 sync_package_config() {
-    local sync=$1 pkg=$2
-
-    if [[ $sync == 'auto' ]] && [[ $(git config --get --type bool aurutils.rebase) == 'true' ]]; then
-        printf >&2 '%s: aurutils.rebase is set for %s\n' "$argv0" "$pkg"
+    if [[ $(git config --get --type bool aurutils.rebase) == 'true' ]]; then
+        printf >&2 '%s: aurutils.rebase is set for %s\n' "$argv0" "$1"
         printf '%s' rebase
-
-    elif [[ $sync == 'auto' ]]; then
-        printf '%s' merge
     else
-        printf '%s' "$sync"
+        printf '%s' merge
     fi
 }
 
@@ -208,8 +203,12 @@ for pkg in "${packages[@]}"; do
         orig_head=$(git rev-parse --verify --quiet HEAD)
         orig_head=${orig_head:-$git_empty_object}
 
-        # Retrieve per-package configuration (defaults to global setting, #1007)
-        sync_pkg=$(sync_package_config "$sync" "$pkg")
+        # Retrieve per-package configuration (#1007)
+        if [[ $sync == 'auto' ]]; then
+            sync_pkg=$(sync_package_config "$pkg")
+        else
+            sync_pkg=$sync
+        fi
 
         # Merge in new history
         case $sync_pkg in

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -14,6 +14,7 @@
     - defaults to `github.com/archlinux/aur`
     - enabled with `AUR_FETCH_USE_MIRROR=1`
   + run flock(1) when modifying existing repositories
+  + run git-checkout(1) when using `--sync=rebase` with `--discard` (#1006)
 
 * `aur-graph`
   + selectively disable/enable depends with `aur graph -v <TYPE>=[0|1]`

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -73,7 +73,7 @@ so that no commits are applied to the index even when a fast-forward is possible
 for details.
 .
 .TP
-.BR \-\-rebase ", " \-\-sync=rebase
+.BR \-\-sync=rebase ", " \-\-rebase
 Run
 .BR git\-rebase (1)
 instead of
@@ -109,7 +109,7 @@ and
 otherwise.
 .
 .TP
-.BR \-\-reset ", " \-\-sync=reset
+.BR \-\-sync=reset ", " \-\-reset
 Retrieve new revisions with
 .B git\-fetch origin
 and
@@ -124,20 +124,26 @@ When using
 .BR \-\-sync=merge
 or
 .BR \-\-sync=rebase ,
-uncommitted changes may cause the operation to fail. The
-.B \-\-discard
-option discards these changes with
-.B git \-\-reset HEAD
-.I if
-either
-.B git\-merge
-or
+uncommitted changes may cause the operation to fail. Furthermore,
 .B git\-rebase
-would result in new commits. This is done by checking if
-.B master@{upstream}
-is an ancestor of the
-.B HEAD
-commit.
+expects a clean work tree.
+.IP
+With
+.BR \-\-sync=merge ,
+the
+.B \-\-discard
+option checks if new upstream commits are available with
+.BR git\-merge\-base .
+If so, uncommited changes are discarded with
+.BR git\-checkout .
+.IP
+With
+.BR \-\-sync=rebase ,
+the
+.B \-\-discard
+option runs
+.BR git\-checkout
+unconditionally.
 .
 .TP
 .BR \-\-existing


### PR DESCRIPTION
git-rebase expects a clean worktree, unlike git-merge.

Closes #1006