### PR TITLE
fixed manpage suggesting a wrong jq directive to parse aur query

### DIFF
--- a/man1/aur.1
+++ b/man1/aur.1
@@ -354,7 +354,7 @@ As above, but for orphaned packages:
 .PP
 .EX
     $ pacman \-Slq custom | aur query \-t info - | \e
-          jq \-r \(aq.[].results[] | select(.Maintainer == null)\(aq
+          jq \-r \(aq.results[] | select(.Maintainer == null)\(aq
 .EE
 .PP
 Update packages in the


### PR DESCRIPTION
fixed manpage suggesting a wrong jq directive to parse aur query, it reports a dictionary first, not an array