### PR TITLE
examples: add `build-asroot`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -89,3 +89,19 @@ unused upgrades with `aur-sync -u`. Cleanups can then be done periodically:
 $ grep -Fxvf list.txt <(aur repo --list | cut -f1) | xargs -r repo-purge -f custom
 ```
 
+## build-asroot
+
+`aur-build` operates as a regular user, with the following exceptions:
+
+* installation of package dependencies with `makepkg -s`;
+* updating the local repository with `aur-build--sync`;
+* interacting with an nspawn container with `aur-chroot`.
+
+Instead of elevating to the root user with `sudo` for these tasks, the script can run as root and drop privileges. `build-asroot` accomplishes this with `setpriv`.
+
+To simplify the exposition, `build-asroot` does not take containers and package signing into account. Specifically:
+
+* `makepkg --pkglist` may be run *after* `makepkg`, because `makepkg` checks for existing packages (unlike `aur-chroot`);
+* existing packages are not (re-)added to the local repository or signed.
+
+To replicate `makepkg -s`, dependencies are retrieved with `aur build--pkglist --srcinfo` and installed with `pacinstall`. After the build is done, the transaction is then done in the reverse order with `pacremove`.

--- a/examples/build-asroot
+++ b/examples/build-asroot
@@ -5,8 +5,8 @@ argv0=build-asroot
 startdir=$PWD
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
-# default arguments
-makepkg_args=(-L)
+# default options
+makepkg_args=(-L) pactrans_args=(--no-confirm) repo_add_args=(-R) checkdepends=1
 
 # Allow to drop permissions for commands as needed (#907)
 as_user() {
@@ -29,52 +29,49 @@ as_user() {
 
 # Save transaction so that it can easily be undone later
 get_transaction() {
-    (( ! $# )) && return 0
-    env LANG=C pacinstall --print-only "$@" | awk '$0 ~ /^removing/ || $0 ~ /^installing/ { print }'
-    return "${PIPESTATUS[0]}"
+    if (( ! $# )); then
+        env LANG=C pacinstall "${pactrans_args[@]}" --print-only "$@" |
+            awk '$0 ~ /^removing/ || $0 ~ /^installing/ { print }'
+        return "${PIPESTATUS[0]}"
+    fi
+}
+
+install_depends() {
+    #global remove_args install_args
+    if (( ${#remove_args[@]} + ${#install_args[@]} )); then
+        pacinstall "${pactrans_args[@]}" --as-deps "${install_args[@]}" --remove "${remove_args[@]}"
+    fi
 }
 
 remove_depends() {
+    #global remove_args install_args
     if (( ${#remove_args[@]} + ${#install_args[@]} )); then
         pacremove "${pactrans_args[@]}" "${install_args[@]##*/}" --install "${remove_args[@]}"
     fi
 }
 
-usage() {
-    printf >&2 'usage: %s -d <repo> [-a <queue>] -U <user> [-nCfR]\n' "$argv0"
-    exit 1
-}
-
-# simple option parsing
-checkdepends=1
-unset queue build_user db_name repo_add_args pactrans_args
+# Simple option parsing
+unset queue build_user db_name
 
 orig_argv=("$@")
-while getopts :a:U:d:CfRn OPT; do
+while getopts :a:U:d:f OPT; do
     case $OPT in
-        d) db_name=$OPTARG ;;
         a) queue=$OPTARG ;;
+        d) db_name=$OPTARG ;;
         U) build_user=$OPTARG ;;
-        n) pactrans_args+=(--no-confirm) ;; # TODO: support --resolve-conflicts
-        C) makepkg_args+=(--nocheck); checkdepends=0 ;;
         f) makepkg_args+=(-f) ;;
-        R) repo_add_args+=(-R) ;;
-        *) usage ;;
+        *) printf >&2 '%s: invalid option\n' "$argv0"
+           exit 1;;
     esac
 done
 shift $(( OPTIND - 1 ))
 
-if [[ ! -v db_name ]] || [[ -z $db_name ]]; then
-    printf >&2 '%s: repository must be specified\n' "$argv0"
-    exit 1
+if (( $(id -u "$build_user") == 0 )); then
+    printf '%s: build user is privileged\n' "$argv0"
+    exit 2
 fi
 
-if [[ ! -v build_user ]] || (( $(id -u "$build_user") == 0 )); then
-    printf >&2 '%s: unprivileged user must be specified\n' "$argv0"
-    exit 1
-fi
-
-# Elevate permissions
+# elevate permissions
 if (( EUID != 0 )); then
     exec ${AUR_PACMAN_AUTH:-sudo} -- "${BASH_SOURCE[0]}" "${orig_argv[@]}"
 fi
@@ -92,12 +89,6 @@ else
     exec {fd}< <(printf '\n')
 fi
 
-# repository root and startdir should be different
-if [[ $startdir == "$db_root" ]]; then
-    printf >&2 '%s: root and build directory must differ\n' "$argv0"
-    exit 1
-fi
-
 # process queue
 unset remove_args install_args
 trap 'remove_depends' EXIT
@@ -110,29 +101,24 @@ while IFS= read -ru "$fd" path; do
     depends=()
     while IFS= read -r value; do
         depends+=("$value")
-    done < <(as_user aur build--pkglist --srcinfo | pacini - "${deptypes[@]}" | awk -F' = ' '{print $2}')
-    wait "$!"
+    done < <(
+        as_user aur build--pkglist --srcinfo | pacini - "${deptypes[@]}" | awk -F' = ' '{print $2}')
 
     # check which dependencies are missing on the host
     mapfile -t depends_missing < <(pacman -T "${depends[@]}")
-    # discard exit status
 
     # precompute the transaction and install dependencies
-    if (( ${#depends_missing[@]} )); then
-        while read -r type package _; do
-            case $type in
-                removing) 
-                    remove_args+=("${package##local/}")  ;;
-                installing) 
-                    install_args+=("$package") ;;
-            esac
-        done < <(get_transaction "${depends_missing[@]}")
-        wait "$!"
+    while read -r type package _; do
+        case $type in
+            removing)
+                remove_args+=("${package##local/}") ;;
+            installing)
+                install_args+=("$package") ;;
+        esac
+    done < <(get_transaction "${depends_missing[@]}")
+    wait "$!"
 
-        if (( ${#remove_args[@]} + ${#install_args[@]} )); then
-            pacinstall "${pactrans_args[@]}" --as-deps "${install_args[@]}" --remove "${remove_args[@]}"
-        fi
-    fi
+    install_depends
 
     # build the package
     makepkg_ret=0
@@ -145,7 +131,7 @@ while IFS= read -ru "$fd" path; do
     fi
 
     # perform dependency transaction in reverse order
-    # XXX: restore original installation reason for removed packages?
+    # Note: the install reason for removed packages is not preserved.
     remove_depends
     unset install_args remove_deps
 

--- a/examples/build-asroot
+++ b/examples/build-asroot
@@ -1,0 +1,163 @@
+#!/bin/bash
+[[ -v AUR_DEBUG ]] && set -o xtrace
+set -o errexit
+argv0=build-asroot
+startdir=$PWD
+PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
+# default arguments
+makepkg_args=(-L)
+
+# Allow to drop permissions for commands as needed (#907)
+as_user() {
+    local USER HOME SHELL
+
+    if [[ $UID == 0 ]] && [[ -v build_user ]]; then
+        # runuser --pty messes up the terminal with AUR_DEBUG set, use setpriv(1)
+        # and replicate the runuser(1) behavior for setting the environment
+        { IFS= read -r USER
+          IFS= read -r HOME
+          IFS= read -r SHELL
+        } < <(getent passwd "$build_user" | awk -F: '{printf("%s\n%s\n%s\n", $1, $6, $7); }')
+
+        setpriv --reuid "$build_user" --regid "$build_user" --init-groups \
+                env USER="$USER" HOME="$HOME" LOGNAME="$USER" SHELL="$SHELL" "$@"
+    else
+        env "$@"
+    fi
+}
+
+# Save transaction so that it can easily be undone later
+get_transaction() {
+    (( ! $# )) && return 0
+    env LANG=C pacinstall --print-only "$@" | awk '$0 ~ /^removing/ || $0 ~ /^installing/ { print }'
+    return "${PIPESTATUS[0]}"
+}
+
+remove_depends() {
+    if (( ${#remove_args[@]} + ${#install_args[@]} )); then
+        pacremove "${pactrans_args[@]}" "${install_args[@]##*/}" --install "${remove_args[@]}"
+    fi
+}
+
+usage() {
+    printf >&2 'usage: %s -d <repo> [-a <queue>] -U <user> [-nCfR]\n' "$argv0"
+    exit 1
+}
+
+# simple option parsing
+checkdepends=1
+unset queue build_user db_name repo_add_args pactrans_args
+
+orig_argv=("$@")
+while getopts :a:U:d:CfRn OPT; do
+    case $OPT in
+        d) db_name=$OPTARG ;;
+        a) queue=$OPTARG ;;
+        U) build_user=$OPTARG ;;
+        n) pactrans_args+=(--no-confirm) ;; # TODO: support --resolve-conflicts
+        C) makepkg_args+=(--nocheck); checkdepends=0 ;;
+        f) makepkg_args+=(-f) ;;
+        R) repo_add_args+=(-R) ;;
+        *) usage ;;
+    esac
+done
+shift $(( OPTIND - 1 ))
+
+if [[ ! -v db_name ]] || [[ -z $db_name ]]; then
+    printf >&2 '%s: repository must be specified\n' "$argv0"
+    exit 1
+fi
+
+if [[ ! -v build_user ]] || (( $(id -u "$build_user") == 0 )); then
+    printf >&2 '%s: unprivileged user must be specified\n' "$argv0"
+    exit 1
+fi
+
+# Elevate permissions
+if (( EUID != 0 )); then
+    exec ${AUR_PACMAN_AUTH:-sudo} -- "${BASH_SOURCE[0]}" "${orig_argv[@]}"
+fi
+
+db_path=$(as_user aur repo -d "$db_name" --path)
+db_root=$(dirname "$db_path")
+
+# set kinds of dependencies that will be installed before the build
+deptypes=(depends makedepends)
+(( checkdepends )) && deptypes+=(checkdepends)
+
+if [[ -v queue ]]; then
+    exec {fd}< "$queue"
+else
+    exec {fd}< <(printf '\n')
+fi
+
+# repository root and startdir should be different
+if [[ $startdir == "$db_root" ]]; then
+    printf >&2 '%s: root and build directory must differ\n' "$argv0"
+    exit 1
+fi
+
+# process queue
+unset remove_args install_args
+trap 'remove_depends' EXIT
+
+while IFS= read -ru "$fd" path; do
+    cd "$startdir"
+    cd "$path"
+
+    # retrieve dependencies as build user
+    depends=()
+    while IFS= read -r value; do
+        depends+=("$value")
+    done < <(as_user aur build--pkglist --srcinfo | pacini - "${deptypes[@]}" | awk -F' = ' '{print $2}')
+    wait "$!"
+
+    # check which dependencies are missing on the host
+    mapfile -t depends_missing < <(pacman -T "${depends[@]}")
+    # discard exit status
+
+    # precompute the transaction and install dependencies
+    if (( ${#depends_missing[@]} )); then
+        while read -r type package _; do
+            case $type in
+                removing) 
+                    remove_args+=("${package##local/}")  ;;
+                installing) 
+                    install_args+=("$package") ;;
+            esac
+        done < <(get_transaction "${depends_missing[@]}")
+        wait "$!"
+
+        if (( ${#remove_args[@]} + ${#install_args[@]} )); then
+            pacinstall "${pactrans_args[@]}" --as-deps "${install_args[@]}" --remove "${remove_args[@]}"
+        fi
+    fi
+
+    # build the package
+    makepkg_ret=0
+    as_user PKGDEST="$db_root" makepkg "${makepkg_args[@]}" || makepkg_ret=$?
+
+    if (( makepkg_ret == 13 )); then
+        continue  # $E_ALREADY_BUILT
+    elif (( makepkg_ret > 0 )); then
+        exit "$ret"
+    fi
+
+    # perform dependency transaction in reverse order
+    # XXX: restore original installation reason for removed packages?
+    remove_depends
+    unset install_args remove_deps
+
+    # retrieve paths to built packages
+    mapfile -t pkglist < <(as_user PKGDEST="$db_root" aur build--pkglist)
+    wait "$!"
+
+    # update local repository
+    as_user env -C "$db_root" repo-add "${repo_add_args[@]}" "$db_path" "${pkglist[@]}"
+
+    # update host and pacman database
+    aur build--sync "$db_name"
+done
+
+exec {fd}<&-

--- a/examples/build-asroot
+++ b/examples/build-asroot
@@ -5,7 +5,7 @@ argv0=build-asroot
 startdir=$PWD
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
-# default options
+# Default options
 makepkg_args=(-L) pactrans_args=(--no-confirm) repo_add_args=(-R) checkdepends=1
 
 # Allow to drop permissions for commands as needed (#907)
@@ -27,7 +27,6 @@ as_user() {
     fi
 }
 
-# Save transaction so that it can easily be undone later
 get_transaction() {
     if (( ! $# )); then
         env LANG=C pacinstall "${pactrans_args[@]}" --print-only "$@" |
@@ -71,7 +70,7 @@ if (( $(id -u "$build_user") == 0 )); then
     exit 2
 fi
 
-# elevate permissions
+# Elevate permissions
 if (( EUID != 0 )); then
     exec ${AUR_PACMAN_AUTH:-sudo} -- "${BASH_SOURCE[0]}" "${orig_argv[@]}"
 fi
@@ -79,17 +78,20 @@ fi
 db_path=$(as_user aur repo -d "$db_name" --path)
 db_root=$(dirname "$db_path")
 
-# set kinds of dependencies that will be installed before the build
+# Types of dependencies that will be installed before the build.
 deptypes=(depends makedepends)
 (( checkdepends )) && deptypes+=(checkdepends)
 
+# If a queue file is specified, use it for reading targets. Otherwise, default
+# to the current directory.
 if [[ -v queue ]]; then
     exec {fd}< "$queue"
 else
     exec {fd}< <(printf '\n')
 fi
 
-# process queue
+# A trap is defined here so that when build-asroot is interrupted, any installed
+# dependencies are removed. This behavior matches makepkg --rmdeps.
 unset remove_args install_args
 trap 'remove_depends' EXIT
 
@@ -97,17 +99,23 @@ while IFS= read -ru "$fd" path; do
     cd "$startdir"
     cd "$path"
 
-    # retrieve dependencies as build user
+    # Retrieve dependencies as build user with makepkg --printsrcinfo. Alternatively,
+    # dependencies can be retrieved directly from .SRCINFO, in cases where it
+    # matches the PKGBUILD exactly (AUR packages with no local changes).
     depends=()
     while IFS= read -r value; do
         depends+=("$value")
     done < <(
+        #pacini .SRCINFO "${deptypes[@]}" | awk -F' = ' '{print $2}'
         as_user aur build--pkglist --srcinfo | pacini - "${deptypes[@]}" | awk -F' = ' '{print $2}')
 
-    # check which dependencies are missing on the host
+    # Check which dependencies are missing on the host.
     mapfile -t depends_missing < <(pacman -T "${depends[@]}")
 
-    # precompute the transaction and install dependencies
+    # Precomputing the transaction allows to undo it later in reverse order.
+    # In particular, dependencies are installed and removed in a single transaction.
+    # Semantics are defined by the `--resolve-conflicts` and `--resolve-replacements`
+    # options for `pactrans`.
     while read -r type package _; do
         case $type in
             removing)
@@ -120,22 +128,29 @@ while IFS= read -ru "$fd" path; do
 
     install_depends
 
-    # build the package
+    # Privileges are now dropped to a regular user to build the package. It is
+    # assumed that this user has at least read access to the PKGBUILD. If the
+    # PKGBUILD has a `pkgver()` function, write access is also needed.
     makepkg_ret=0
     as_user PKGDEST="$db_root" makepkg "${makepkg_args[@]}" || makepkg_ret=$?
 
+    # A direct invocation of `makepkg` has a wide range of exit codes (see
+    # /usr/share/makepkg/util/error.sh). 13 signifies that a package in `PKGDEST`
+    # is already available. Note that `makepkg --sign` will not create a new
+    # signature in such a case.
     if (( makepkg_ret == 13 )); then
         continue  # $E_ALREADY_BUILT
     elif (( makepkg_ret > 0 )); then
-        exit "$ret"
+        exit "$ret" # general error
     fi
 
-    # perform dependency transaction in reverse order
+    # Perform dependency transaction in reverse order.
     # Note: the install reason for removed packages is not preserved.
     remove_depends
     unset install_args remove_deps
 
-    # retrieve paths to built packages
+    # Retrieve paths to built packages. To avoid linting the PKGBUILD a second
+    # time, `aur-build--pkglist` is preferred over `makepkg --packagelist`.
     mapfile -t pkglist < <(as_user PKGDEST="$db_root" aur build--pkglist)
     wait "$!"
 

--- a/examples/build-asroot
+++ b/examples/build-asroot
@@ -138,11 +138,11 @@ while IFS= read -ru "$fd" path; do
     # /usr/share/makepkg/util/error.sh). 13 signifies that a package in `PKGDEST`
     # is already available. Note that `makepkg --sign` will not create a new
     # signature in such a case.
-    if (( makepkg_ret == 13 )); then
-        continue  # $E_ALREADY_BUILT
-    elif (( makepkg_ret > 0 )); then
-        exit "$ret" # general error
-    fi
+    case $makepkg_ret in
+        13) continue ;; # $E_ALREADY_BUILT
+         0) ;; # success
+         *) exit "$makepkg_ret" ;; # general error
+    esac
 
     # Perform dependency transaction in reverse order.
     # Note: the install reason for removed packages is not preserved.

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -7,6 +7,7 @@
   + add `exist:` to `--results` output
     - remove `--dry-run`
   + remove experimental `AUR_ASROOT` functionality (#1023)
+    - add `examples/build-asroot`
   + updates for aur-build(1)
 
 * `aur-chroot`
@@ -63,7 +64,8 @@
   + support extending `zsh` completion for third party commands (#1016)
 
 * `examples`
-  + add `view-delta` (optdepends: `bat`, `diff-so-fancy`)
+  + add `view-delta` (requires: `bat`, `diff-so-fancy`)
+  + add `build-asroot`
 
 ## 10
 


### PR DESCRIPTION
This is a (customizable) replacement for the removed `AUR_ASROOT` functionality, aimed at host builds.

edit: this is a fair bit larger than the other example scripts - essentially a re-implementation of `aur-build` for specific purposes.