### PR TITLE
`view`: add `--prefix`

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -113,7 +113,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:' 'root:'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
           'makepkg-args:' 'format:' 'no-check' 'keep-going:' 'user:'
-          'rebase' 'reset' 'ff' 'exclude:' 'columns')
+          'rebase' 'reset' 'ff' 'exclude:' 'columns' 'prefix')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rm-deps' 'gpg-sign' 'margs:' 'nocheck'
@@ -132,10 +132,6 @@ while true; do
             rotate=1 ;;
         --continue)
             download=0 ;;
-        --format)
-            shift; view_args+=(--format "$1") ;;
-        --exclude)
-            shift; view_args+=(--exclude "$1") ;;
         --ignore)
             shift; IFS=, read -a pkg -r <<< "$1"
             pkg_i+=("${pkg[@]}") ;;
@@ -188,6 +184,13 @@ while true; do
             fetch_args+=(--rebase) ;;
         --reset)
             fetch_args+=(--reset) ;;
+        # view options
+        --format)
+            shift; view_args+=(--format "$1") ;;
+        --exclude)
+            shift; view_args+=(--exclude "$1") ;;
+        --prefix)
+            view_args+=(--prefix) ;;  # experimental
         # build options
         -c|--chroot)
             build_args+=(--chroot) ;;

--- a/lib/aur-view
+++ b/lib/aur-view
@@ -8,7 +8,7 @@ AUR_VIEW_DB=${AUR_VIEW_DB:-$XDG_DATA_HOME/aurutils/$argv0}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # default options
-log_fmt='diff' log_args=() excludes=() patch=1
+log_fmt='diff' log_args=() excludes=() patch=1 prefix=0
 
 diag_invalid() {
     cat >&2 <<EOF
@@ -43,7 +43,7 @@ if [[ ! -v NO_COLOR ]] && [[ ! -v AUR_DEBUG ]]; then
 fi
 
 opt_short='a:'
-opt_long=('format:' 'arg-file:' 'revision:' 'no-patch' 'confirm' 'exclude:')
+opt_long=('format:' 'arg-file:' 'revision:' 'no-patch' 'confirm' 'exclude:' 'prefix')
 opt_hidden=('dump-options')
 
 if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
@@ -51,7 +51,7 @@ if ! parseopts "$opt_short" "${opt_long[@]}" "${opt_hidden[@]}" -- "$@"; then
 fi
 set -- "${OPTRET[@]}"
 
-unset queue revision
+unset queue revision prefix
 while true; do
     case "$1" in
         -a|--arg-file)
@@ -65,14 +65,16 @@ while true; do
                     error '%s: invalid --format option: %s' "$argv0" "$1"
                     usage ;;
             esac ;;
+        --confirm)
+            AUR_CONFIRM_PAGER=1 ;;
         --no-patch)
             patch=0 ;;
+        --prefix)
+            prefix=1 ;;
         --revision)
             shift; revision=$1 ;;
         --exclude)
             shift; excludes+=("$1") ;;
-        --confirm)
-            AUR_CONFIRM_PAGER=1 ;;
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
             printf -- '%s' "${opt_short}" | sed 's/.:\?/-&\n/g'
@@ -131,6 +133,11 @@ for pkg in "${packages[@]}"; do
         exit 2
     fi
 
+    unset path_args
+    if (( prefix )); then
+        path_args=(--src-prefix="$pkg/" --dst-prefix="$pkg/")
+    fi
+
     if [[ -f $AUR_VIEW_DB/$pkg ]] && read -r view < "$AUR_VIEW_DB/$pkg"; then
         # Check if hash points to an existing object
         if ! git cat-file -e "$view"; then
@@ -139,7 +146,7 @@ for pkg in "${packages[@]}"; do
         fi
 
         if [[ $view != "$head" ]]; then
-            git --no-pager "$log_fmt" --stat "${log_args[@]}" \
+            git --no-pager "$log_fmt" --stat "${log_args[@]}" "${path_args[@]}" \
                 "$view..$head" -- "${excludes[@]}" > "$tmp/$pkg.$log_fmt"
         fi
 

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -57,7 +57,7 @@
   + add `--columns`
 
 * `aur-view`
-  + add `--exclude`
+  + add `--exclude`, `--prefix`
   + print diagnostic on invalid git revision (#894)
 
 * `aur-format`

--- a/man1/aur-view.1
+++ b/man1/aur-view.1
@@ -1,4 +1,4 @@
-.TH AUR-VIEW 1 2022-03-12 AURUTILS
+.TH AUR-VIEW 1 2022-10-04 AURUTILS
 .SH NAME
 aur\-view \- inspect git repositories
 .
@@ -72,6 +72,16 @@ Suppress patch output, only showing a summary.
 .BI \-\-revision= REV
 The revision used for comparing changes. Defaults to
 .IR HEAD .
+.
+.TP
+.BI \-\-prefix
+Prepend paths from command-line arguments or
+.B \-\-arg\-file
+to
+.BR git\-diff (1)
+and
+.BR git\-log (1)
+output.
 .
 .TP
 .BI \-a " FILE" "\fR,\fP \-\-arg\-file=" FILE


### PR DESCRIPTION
This allows to distinguish source files for different packages when concatenating diffs, e.g. for use with `examples/view-delta`.