### PR TITLE
`depends`: add `--assume-installed`

### DIFF
--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use v5.20;
 
+use List::Util qw(first);
 use AUR::Json qw(parse_json_aur write_json);
 use AUR::Query qw(query_multi);
 use AUR::Options qw(add_from_stdin);
@@ -125,6 +126,50 @@ sub chain_mod {
     return \%mod;
 }
 
+# Recursively remove nodes from dependency graph (#592)
+# Operates on modified graph: provides are solved first
+sub prune {
+    my ($mod, $installed) = @_;
+
+    # XXX: use Schwartzian transform
+    map {
+        # Every reverse dependency needs to be checked against every pkgname
+        # that is assumed to be installed (quadratic complexity)
+        my $reqby = $mod->{$_}->{'RequiredBy'};  # reference to RequiredBy{ Depends [] }
+
+        for my $deptype (keys %{$reqby}) {  # list returned by keys is a copy
+            my @pruned = ();
+
+            for my $dep (@{$reqby->{$deptype}}) {
+                my $found = first { $dep eq $_ } @{$installed};
+
+                if (not defined ($found)) {
+                    push(@pruned, $dep);
+                }
+            }
+            if (scalar @pruned) {
+                @{$reqby->{$deptype}} = @pruned;
+            }
+            else {
+                delete $reqby->{$deptype};
+            }
+        }
+    } keys %{$mod};
+
+    map {
+        my $name = $_;
+        if (not scalar keys %{$mod->{$name}->{'RequiredBy'}}) {
+            delete $mod->{$name};  # remove targets that are no longer required
+        }
+        my $found = first { $name eq $_ } @{$installed};
+        if (defined $found) {
+            delete $mod->{$name};  # remove targets that are installed
+        }
+    } keys %{$mod}; # list returned by keys is a copy
+
+    return $mod;
+}
+
 # tsv output for usage with aur-sync (aurutils <=10)
 sub table_v10_compat {
     my ($results, $types) = @_;
@@ -189,20 +234,22 @@ unless(caller) {
     my $opt_show_all     = 0;  # implies $opt_pkgname = 1
     my $opt_reverse      = 0;
     my $opt_provides     = 1;
+    my $opt_installed    = [];
 
     GetOptions(
-        'no-depends'      => sub { $opt_depends = 0 },
-        'no-makedepends'  => sub { $opt_makedepends = 0 },
-        'no-checkdepends' => sub { $opt_checkdepends = 0 },
-        'optdepends'      => \$opt_optdepends,
-        'no-provides'     => sub { $opt_provides = 0 },
-        'n|pkgname'       => \$opt_pkgname,
-        'b|pkgbase'       => sub { $opt_pkgname = 0 },
-        'G|graph'         => sub { },  # noop
-        't|table'         => sub { $opt_mode = "table" },
-        'J|json'          => sub { $opt_mode = "json" },
-        'r|reverse'       => \$opt_reverse,
-        'a|all'           => \$opt_show_all
+        'assume-installed=s' => $opt_installed,
+        'no-depends'         => sub { $opt_depends = 0 },
+        'no-makedepends'     => sub { $opt_makedepends = 0 },
+        'no-checkdepends'    => sub { $opt_checkdepends = 0 },
+        'optdepends'         => \$opt_optdepends,
+        'no-provides'        => sub { $opt_provides = 0 },
+        'n|pkgname'          => \$opt_pkgname,
+        'b|pkgbase'          => sub { $opt_pkgname = 0 },
+        'G|graph'            => sub { },  # noop
+        't|table'            => sub { $opt_mode = "table" },
+        'J|json'             => sub { $opt_mode = "json" },
+        'r|reverse'          => \$opt_reverse,
+        'a|all'              => \$opt_show_all
     ) or exit(1);
 
     # Handle '-' to take packages from stdin
@@ -220,9 +267,16 @@ unless(caller) {
     push(@types, 'CheckDepends') if $opt_checkdepends;
     push(@types, 'OptDepends')   if $opt_optdepends;
 
+    # Array notation for --assume-installed
+    @{$opt_installed} = map { split(',', $_) } @{$opt_installed};
+
     # Resolve dependency tree
     my $results = chain_mod(chain(\@ARGV, \@types, 30), $opt_provides, $opt_show_all);
 
+    # Remove transitive dependencies for installed targets (#592)
+    if (scalar @{$opt_installed}) {
+        $results = prune($results, $opt_installed);
+    }
     if ($opt_mode eq 'pairs') {
         pairs($results, ($opt_pkgname or $opt_show_all) ? 'Name' : 'PackageBase', $opt_reverse);
     }

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -301,12 +301,17 @@ fi
 { if [[ -r $ignore_file ]] && [[ ! -d $ignore_file ]]; then
       select_ignores_pkgspec "$db_name" "$ignore_file"
   fi
-  (( ${#pkg_i[@]} )) && printf '%s\n' "${pkg_i[@]}"
+  if (( ${#pkg_i[@]} )); then
+      printf '%s\n' "${pkg_i[@]}"
+  fi
 } | complement <(printf '%s\n' "$@") >"$tmp"/igni
 
 if [[ -s $tmp/igni ]]; then
-    printf '%s: packages ignored: ' "$argv0"
-    awk -v ORS=' ' '{print} END {printf("\n")}' "$tmp"/igni
+    mapfile -t pkg_i < "$tmp"/igni
+    printf '%s: packages ignored: %s\n' "$argv0" "${pkg_i[*]}"
+
+    # Ignore dependencies from ignored targets (#592)
+    depends_args+=(--assume-installed "$(args_csv "${pkg_i[@]}")")
 fi >&2
 
 # db_info: $1 pkgname $2 pkgver
@@ -341,7 +346,7 @@ fi
 # pkginfo: $1 pkgname $2 pkgbase $3 pkgver
 cut -f2,5 --complement "$tmp"/depends | sort -u >"$tmp"/pkginfo
 
-{ cat "$tmp"/igni # ignored packages
+{ cat "$tmp"/igni # ignored packages (already included by aur-depends --assume-installed)
 
   # Packages with equal or newer versions are taken as complement
   # for the queue. If chkver_argv is enabled, packages on the

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -306,6 +306,7 @@ fi
   fi
 } | complement <(printf '%s\n' "$@") >"$tmp"/igni
 
+# Diagnostic on which packages are ignored
 if [[ -s $tmp/igni ]]; then
     mapfile -t pkg_i < "$tmp"/igni
     printf '%s: packages ignored: %s\n' "$argv0" "${pkg_i[*]}"
@@ -314,11 +315,15 @@ if [[ -s $tmp/igni ]]; then
     depends_args+=(--assume-installed "$(args_csv "${pkg_i[@]}")")
 fi >&2
 
-# db_info: $1 pkgname $2 pkgver
-( set -o pipefail
-  aur repo-parse -p "$db_path" --list | select_ignores "$tmp"/igni -
-) >"$tmp"/db_info
+# Retrieve list of local repository packages ($1 pkgname $2 pkgver)
+aur repo-parse -p "$db_path" --list | select_ignores "$tmp"/igni - >"$tmp"/db_info
+repo_err=${PIPESTATUS[0]}
 
+if (( repo_err )); then
+   exit "$repo_err"
+fi
+
+# Build list of AUR targets
 { if (( $# )); then
       # append command-line arguments
       printf '%s\n' "$@"
@@ -334,6 +339,7 @@ fi >&2
   fi
 } >"$tmp"/argv
 
+# Build AUR dependency graph
 if [[ -s $tmp/argv ]]; then
     # shellcheck disable=SC2094
     # depends: $1 pkgname $2 required_by $3 pkgbase $4 pkgver $5 depends_type

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -8,12 +8,18 @@
   + remove `--user` (`-U`)
   + only run as root with `AUR_ASROOT` set
 
+* `aur-depends`
+  + add `--assume-installed`
+
 * `aur-srcver`
   + accept arbitrary source directories as arguments
   + add `--arg-file` (`-a`), `--null` (`-z`), `--margs`
   + add `AUR_MAKEPKG` environment variable
   + only run as root with `AUR_ASROOT` set
   + exit 1 if any `makepkg` job failed
+
+* `aur-sync`
+  + `--ignore` now removes dependencies of ignored targets
 
 * `examples`
   + update `sync-asroot` to use `AUR_BUILD_PKGLIST`


### PR DESCRIPTION
`RequiredBy` gives for every node in the dependency graph all predecessor node that depend on it. The `--assume-installed` flag removes all specified targets from the graph, as well as from all `RequiredBy` arrays. This is done by scanning the targets for every reverse dependency.

When afterwards a node has an empty `RequiredBy` array, it is considered as no longer required and removed from the dependency graph. As a result, dependencies for `--assume-installed` targets are also removed from the graph. All this is done after `provides` are solved (`chain_mod`) unless `--no-provides` is supplied.

A direct use for this is expanding `aur-sync --ignore` to also remove dependencies of ignored targets. Later changes could use a similar mechanism to remove transitive dependencies for `aur-repo-filter` targets (issue #592).