### PR TITLE
Fix for Dockerfile smell DL3048

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM archlinux:latest
-LABEL Name=aurutils
+LABEL name=aurutils
 
 # packages, time zone
 RUN pacman -Syu --noconfirm --needed base base-devel


### PR DESCRIPTION
Hi!
The Dockerfile placed at "docker/Dockerfile" contains the best practice violation [DL3048](https://github.com/hadolint/hadolint/wiki/DL3048) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3048 occurs when the pattern used for the label keys does not match the format recommended by official guidelines.
In this pull request, we propose a fix for that smell generated by our fixing tool. We verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the label keys are refactored to match the correct format.

This change is only aimed at fixing that specific smell. In the case the fix is not valid or useful, please briefly indicate the reason along with suggestions for possible improvements.

Thanks in advance.