### PR TITLE
`sync-asroot`: support `AUR_PAGER=ranger`

### DIFF
--- a/examples/sync-asroot
+++ b/examples/sync-asroot
@@ -24,9 +24,6 @@ while getopts :U:d:k:fSuN OPT; do
 done
 shift $(( OPTIND-1 ))
 
-ninja_dir=$(mktemp -d) || exit
-trap 'rm -rf "$ninja_dir"' EXIT
-
 # 1. define unprivileged commands ------------------------------------------------->
 build_user=${build_user:-${SUDO_USER:-$USER}}
 build_args+=(-U "$build_user")
@@ -37,13 +34,15 @@ build_env=(AUR_MAKEPKG="runuser -u $build_user -- makepkg"
            AUR_BUILD_PKGLIST="runuser -u $build_user -- aur build--pkglist")
 
 # 2. retrieve sources ------------------------------------------------------------->
-cd "$ninja_dir"
+ninja_dir=$(runuser -u "$build_user" -- mktemp -d) || exit
+trap 'rm -rf "$ninja_dir"' EXIT
+
 runuser -u "$build_user" -- \
-    env AURDEST="$AURDEST" aur sync "${sync_args[@]}" "$@" --columns >graph || exit 1
+    env AURDEST="$AURDEST" AUR_EXEC_PATH=/home/archie/source/repos/aurutils/lib aur sync "${sync_args[@]}" "$@" --columns >"$ninja_dir"/graph || exit 1
 
 # 3. build queue ------------------------------------------------------------------>
-if [[ -s graph ]]; then
-    runuser -u "$build_user" -- aur sync--ninja "$AURDEST" <graph >build.ninja -- \
+if [[ -s $ninja_dir/graph ]]; then
+    runuser -u "$build_user" -- aur sync--ninja "$AURDEST" <"$ninja_dir"/graph >"$ninja_dir"/build.ninja -- \
         env AUR_ASROOT=1 "${build_env[@]}" aur build "${build_args[@]}"
 
     env NINJA_STATUS='[%s/%t] ' ninja -C "$ninja_dir" -k "$keep_going"

--- a/examples/sync-asroot
+++ b/examples/sync-asroot
@@ -38,7 +38,7 @@ ninja_dir=$(runuser -u "$build_user" -- mktemp -d) || exit
 trap 'rm -rf "$ninja_dir"' EXIT
 
 runuser -u "$build_user" -- \
-    env AURDEST="$AURDEST" AUR_EXEC_PATH=/home/archie/source/repos/aurutils/lib aur sync "${sync_args[@]}" "$@" --columns >"$ninja_dir"/graph || exit 1
+    env AURDEST="$AURDEST" AUR_EXEC_PATH=/home/archie/source/repos/aurutils/lib aur sync "${sync_args[@]}" "$@" --columns --save "$ninja_dir"/graph || exit 1
 
 # 3. build queue ------------------------------------------------------------------>
 if [[ -s $ninja_dir/graph ]]; then

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -117,7 +117,7 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:' 'root:'
           'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
           'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
           'makepkg-args:' 'format:' 'no-check' 'keep-going:' 'user:'
-          'rebase' 'reset' 'ff' 'exclude:' 'columns' 'prefix')
+          'rebase' 'reset' 'ff' 'exclude:' 'columns' 'prefix' 'save:')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nosync' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rm-deps' 'gpg-sign' 'margs:' 'nocheck'
@@ -129,7 +129,7 @@ else
     usage
 fi
 
-unset pkg pkg_i repo repo_p ignore_file
+unset pkg pkg_i repo repo_p ignore_file out_file
 while true; do
     case "$1" in
         # sync options
@@ -148,6 +148,8 @@ while true; do
             build=0 ;;
         --columns)
             build=0; columns=1 ;;
+        --save)
+            shift; out_file=$1 ;;
         --optdepends)
             depends_args+=(--optdepends)
             graph_args+=(-v OPTDEPENDS=1) ;;
@@ -281,6 +283,13 @@ mkdir -p -- "$AURDEST"
 if (( $# + update + repo_targets == 0 )); then
     printf >&2 '%s: no targets specified\n' "$argv0"
     exit 1
+fi
+
+# Write --no-build / --columns results to a file (#1077)
+if [[ -v out_file ]]; then
+    out_file=$(realpath -- "$out_file")
+else
+    out_file=/dev/stdout
 fi
 
 # Retrieve path to local repo (#448, #700)
@@ -445,7 +454,7 @@ fi
 
 # Input for aur-sync--ninja
 if (( columns )); then
-    swap "$tmp"/graph | sort -k1b,1 -k1 -u
+    swap "$tmp"/graph | sort -k1b,1 -k1 -u >"$out_file"
 
 # Build dependency tree with ninja (#908)
 elif (( AUR_SYNC_USE_NINJA )); then
@@ -490,7 +499,7 @@ elif (( build )); then
 else
     while read -r pkg; do
         [[ $pkg ]] && printf '%s\n' "$(pwd -P)/$pkg"
-    done < "$tmp"/queue
+    done <"$tmp"/queue >"$out_file"
 fi
 
 # vim: set et sw=4 sts=4 ft=sh:


### PR DESCRIPTION
* `ninja_dir` was created as root instead of the build user. `aur-sync--ninja` could then not retrieve files in this directory.
* `ranger` does not like its standard output redirected. Add a `--save` option to `aur-sync` to avoid redirections in `sync-asroot`.

Fixes #1077 