### PR TITLE
`sync-rebuild`: add `--vcs`

### DIFF
--- a/examples/sync-rebuild
+++ b/examples/sync-rebuild
@@ -32,7 +32,7 @@ def xdg_cache_home(user=None):
     return cache_home
 
 
-def run_readline(command, check=True):
+def run_readline(command, check=True, cwd=None):
     """Run the output from a command line-by-line.
 
     `aur` programs typically use newline delimited output. Here, this function
@@ -40,7 +40,7 @@ def run_readline(command, check=True):
     one local repository package.
 
     """
-    with subprocess.Popen(command, stdout=subprocess.PIPE) as process:
+    with subprocess.Popen(command, stdout=subprocess.PIPE, cwd=cwd) as process:
         while True:
             output = process.stdout.readline()
             if output == b'' and process.poll() is not None:
@@ -122,14 +122,14 @@ def update_pkgrel(buildscript, pkgrel=None, increment=0.1):
 def rebuild_packages(repo_targets, db_name, start_dir, vcs=False, fail_fast=False, user=None, *build_args):
     """Rebuild a series of packages in successive order.
     """
-    build_cmd   = ['aur', 'build'] + list(*build_args)
-    pkglist_cmd = ['aur', 'build--pkglist', '--srcinfo']
+    build_cmd  = ['aur', 'build'] + list(*build_args)
+    srcver_cmd = ['aur', 'srcver']
 
     if db_name is not None:
         build_cmd.extend(('--database', db_name))
 
     if user is not None:
-        pkglist_cmd = ['runuser', '-u', user, '--'] + pkglist_cmd
+        srcver_cmd = ['runuser', '-u', user, '--'] + srcver_cmd
 
     # Check that `pkgver` is consistent between local repository and .SRCINFO
     rebuilds = {}
@@ -142,15 +142,18 @@ def rebuild_packages(repo_targets, db_name, start_dir, vcs=False, fail_fast=Fals
         # Retrieve metdata from local repository entry
         pkgbase = pkg['PackageBase']
         pkgver, pkgrel = pkg['Version'].rsplit('-', 1)
-
-        # Regenerate .SRCINFO for VCS packages
-        if vcs:
-            with open(os.path.join(srcdir, '.SRCINFO')) as outfile:
-                subprocess.run(pkglist_cmd, stdout=outfile, check=True, cwd=src_dir)
-
-        # Retrieve metadata from .SRCINFO
         src_dir = os.path.join(start_dir, pkgbase)
-        src_pkgver, _ = srcinfo_get_version(os.path.join(src_dir, '.SRCINFO'))
+
+        # Run pkgver() function for VCS packages
+        if vcs:
+            for n, pkg_str in enumerate(run_readline(srcver_cmd, cwd=src_dir)):
+                if n > 0:
+                    raise RuntimeError('ambiguous aur-srcver output')
+                src_pkgver = pkg_str.decode('utf-8').split('\t')[1].rsplit('-', 1)[0]
+
+        # Use .SRCINFO for other packages (faster)
+        else:
+            src_pkgver, _ = srcinfo_get_version(os.path.join(src_dir, '.SRCINFO'))
 
         # Set backup file for PKGBUILD
         buildscript = os.path.join(src_dir, 'PKGBUILD')

--- a/examples/sync-rebuild
+++ b/examples/sync-rebuild
@@ -119,16 +119,18 @@ def update_pkgrel(buildscript, pkgrel=None, increment=0.1):
 
 
 # TODO: use vercmp to ensure rebuilds, abort reverse depends when depends fails (sync--ninja)
-def rebuild_packages(repo_targets, db_name, start_dir, fail_fast=False, user=None, *build_args):
+def rebuild_packages(repo_targets, db_name, start_dir, vcs=False, fail_fast=False, user=None, *build_args):
     """Rebuild a series of packages in successive order.
     """
-    build_cmd = ['aur', 'build'] + list(*build_args)
+    build_cmd   = ['aur', 'build'] + list(*build_args)
+    pkglist_cmd = ['aur', 'build--pkglist', '--srcinfo']
 
     if db_name is not None:
         build_cmd.extend(('--database', db_name))
 
     if user is not None:
         build_cmd.extend(('--user', user))
+        pkglist_cmd = ['runuser', '-u', user, '--'] + pkglist_cmd
 
     # Check that `pkgver` is consistent between local repository and .SRCINFO
     rebuilds = {}
@@ -141,6 +143,11 @@ def rebuild_packages(repo_targets, db_name, start_dir, fail_fast=False, user=Non
         # Retrieve metdata from local repository entry
         pkgbase = pkg['PackageBase']
         pkgver, pkgrel = pkg['Version'].rsplit('-', 1)
+
+        # Regenerate .SRCINFO for VCS packages
+        if vcs:
+            with open(os.path.join(srcdir, '.SRCINFO')) as outfile:
+                subprocess.run(pkglist_cmd, stdout=outfile, check=True, cwd=src_dir)
 
         # Retrieve metadata from .SRCINFO
         src_dir = os.path.join(start_dir, pkgbase)
@@ -225,7 +232,7 @@ def chown_pw_name(name, path):
     os.chown(path, uid, gid)
 
 
-def main(targets, db_name, start_dir, fail_fast, run_sync, chroot, user):
+def main(targets, db_name, start_dir, vcs, fail_fast, run_sync, chroot, user):
     # Ensure all sources are available. Only packages are cloned that are
     # already available in the local repository.
     sync_cmd = ['aur', 'sync', '--no-build', '--no-ver-argv']
@@ -287,13 +294,13 @@ def main(targets, db_name, start_dir, fail_fast, run_sync, chroot, user):
 
             # Build in dependency order
             rebuilds, failed = rebuild_packages(repo_targets_ordered, db_name, start_dir, 
-                                                fail_fast, user, build_args)
+                                                vcs, fail_fast, user, build_args)
         else:
             not_aur = []
 
             # Build in sequential (argument) order
             rebuilds, failed = rebuild_packages(repo_targets, db_name, start_dir, 
-                                                fail_fast, user, build_args)
+                                                vcs, fail_fast, user, build_args)
 
         if len(not_aur) > 0:
             print(f'{ARGV0}: the following targets are not in AUR:', file=sys.stderr)
@@ -324,6 +331,7 @@ if __name__ == '__main__':
     parser.add_argument('-d', '--database')
     parser.add_argument('-c', '--chroot', action='store_true')
     parser.add_argument('-U', '--user')
+    parser.add_argument('--vcs', action='store_true')
     parser.add_argument('--fail-fast', action='store_true')
     parser.add_argument('--no-sync', action='store_false')
     parser.add_argument('targets', nargs='+')
@@ -349,4 +357,4 @@ if __name__ == '__main__':
         aurdest = os.path.join(xdg_cache_home(args.user), 'aurutils/sync')
 
     main({i:1 for i in args.targets}, args.database, aurdest, 
-         args.fail_fast, args.no_sync, args.chroot, args.user)
+         args.vcs, args.fail_fast, args.no_sync, args.chroot, args.user)

--- a/examples/sync-rebuild
+++ b/examples/sync-rebuild
@@ -129,7 +129,6 @@ def rebuild_packages(repo_targets, db_name, start_dir, vcs=False, fail_fast=Fals
         build_cmd.extend(('--database', db_name))
 
     if user is not None:
-        build_cmd.extend(('--user', user))
         pkglist_cmd = ['runuser', '-u', user, '--'] + pkglist_cmd
 
     # Check that `pkgver` is consistent between local repository and .SRCINFO
@@ -187,7 +186,8 @@ def rebuild_packages(repo_targets, db_name, start_dir, vcs=False, fail_fast=Fals
                     'AUR_REPO_ADD'     : f'runuser -u {user} -- repo-add',
                     'AUR_BUILD_PKGLIST': f'runuser -u {user} -- aur build--pkglist'
                 }
-                subprocess.run(build_cmd, check=True, cwd=src_dir, env=dict(os.environ, **asroot_env))
+                subprocess.run([*build_cmd, '--user', user], check=True, cwd=src_dir, 
+                               env=dict(os.environ, **asroot_env))
 
             # Build process completed successfully, remove backup PKGBUILD if it
             # was created above


### PR DESCRIPTION
This allows to regenerate `.SRCINFO` for packages with a `pkgver` function, so that a correct comparison between `.SRCINFO` and local repository package can be made.