### PR TITLE
`build--pkglist`: load PKGBUILD by absolute path

### DIFF
--- a/lib/aur-build--pkglist
+++ b/lib/aur-build--pkglist
@@ -53,10 +53,13 @@ while true; do
     shift
 done
 
+# source follows $PATH, compute absolute path to PKGBUILD (#1115)
+buildscript="$(realpath --strip -- "${buildscript-PKGBUILD}")"
+
 # Sourcing the PKGBUILD should be done without set -e or other modes
 # to match makepkg behavior (e.g. aur/cemu, aur/nicotine-plus-git)
 # shellcheck disable=SC1090
-source_safe "${buildscript-PKGBUILD}"
+source_safe "$buildscript"
 PKGDEST=${PKGDEST:-$PWD}
 pkgbase=${pkgbase:-${pkgname[0]}}
 


### PR DESCRIPTION
This avoids doing the wrong thing if a PKGBUILD happens to be somewhere in $PATH, in which case a `source PKGBUILD` will load it instead of the one in $PWD.

Fixes #1115.