### PR TITLE
readme: Better explain where to find setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Upgrade notices are posted to the
 
 ## USAGE
 
-Documentation is included as groff manuals. [`aur(1)`](man1/aur.1) contains a
-general overview, instructions on creating a local repository, and
-several examples.
+Documentation is included as [man pages](https://wiki.archlinux.org/title/Man_page)
+with groff typesetting. They provide a general overview of the various utilities
+with several examples.
+Detailed instructions on how to set up a local repository can be found in the
+section `CREATING A LOCAL REPOSITORY` of the [`aur(1)`](man1/aur.1) man page.
 
 ## TROUBLESHOOTING
 


### PR DESCRIPTION
First of all, thank you for your work! I use `aurutils` every day.

I wanted to contribute to smooth the adoption process for newcomers. The previous `USAGE` section of `README.md` had a few minor shortcomings (in my opinion):

1. It links to the source code of the [`aur(1)`](man1/aur.1) man page, which is hardly readable. 
2. It refers to `aur(1)` for installation instructions, but these are reported in a section at the very end of the page. Therefore, they can be missed easily.

This commit tries to address the above, by;

1. Adding the explicit bash command to open the manual.
2. Adding the name of the manual section where the instructions are located, so that they can be found easily.