### PR TITLE
fetch: check valid return of aur-depends

### DIFF
--- a/lib/aurweb/aur-fetch
+++ b/lib/aurweb/aur-fetch
@@ -164,11 +164,14 @@ done < <(
                 printf '%s\n' "$@"
             fi
         )
-        wait "$!"  # tsort exit
     )
-    wait "$!"
 )
 wait "$!" || exit
+
+# Check aur-depends retrieved something (#1214)
+if (( recurse )) && ! (( ${#packages[@]} )); then
+    exit 2
+fi
 
 # Update revisions in local AUR mirror
 declare -A is_local_clone


### PR DESCRIPTION
* The tsort exit does not need to be checked explicitly, since an output is available even on a cycle.
* Check aur-depends returned something by checking the packages array.

Closes #1214