### PR TITLE
graph: detect sections on keywords

### DIFF
--- a/lib/util/aur-graph
+++ b/lib/util/aur-graph
@@ -65,8 +65,9 @@ BEGIN {
 
 $1 == "pkgbase" {
     pkgbase = $3
-
     pkgver = ""
+
+    # SRCINFO(5), "Section headers"
     in_split_pkg = 0
     delete(arch)
 
@@ -107,11 +108,11 @@ index($1, "optdepends") == 1 && !in_split_pkg {
     }
 }
 
-NF == 0 {
-    in_split_pkg = 1
-}
 
 $1 == "pkgname" {
+    # SRCINFO(5), "Section headers"
+    in_split_pkg = 1
+
     pkg_map[$3] = pkgbase # node
     ver_map[$3] = pkgver  # weight
 }


### PR DESCRIPTION
Priorly, aur-graph would detect if a pkgname section by the presence of a blank line. However, these are removed by pacini, causing dependencies from split packages to be incorrectly considered.

Specifically, when a split package contains an empty dependency field (depends =) an exit condition is triggered.

The correct approach is to delimit by pkgbase or pkgname keywords, as described in SRCINFO(5).

Fixes #1228