### PR TITLE
aur-fetch: guard packages array assignment to avoid empty pkgbase errors

### DIFF
--- a/lib/aurweb/aur-fetch
+++ b/lib/aurweb/aur-fetch
@@ -142,7 +142,11 @@ while read -r remote path; do
     #         packages["$pkgbase"]=$remote
     #     fi
 
-    packages["$pkgbase"]=$remote
+    if [[ -n $pkgbase ]]; then
+        packages["$pkgbase"]="$remote"
+    else
+        warn "empty pkgbase for remote '%s', skipping\n" "$remote"
+    fi
 done < <(
     # Look ma, no pipes.
     trurl --get '{url} {path}' --url-file - < <(


### PR DESCRIPTION
Add check for empty pkgbase before assigning remote.

The simple guard fixes issues when a malformed or empty URL is passed through `trurl`, without changing behavior for valid package URLs.