### PR TITLE
fetch: use pipes and command groups

### DIFF
--- a/lib/aurweb/aur-fetch
+++ b/lib/aurweb/aur-fetch
@@ -144,8 +144,15 @@ while read -r remote path; do
 
     packages["$pkgbase"]=$remote
 done < <(
-    # Look ma, no pipes.
-    trurl --get '{url} {path}' --url-file - < <(
+    {
+        if (( recurse )); then
+            aur depends --reverse "$@" | tsort
+        elif [[ $# = 1 && $1 = - || $1 = /dev/stdin ]]; then
+            cat
+        else
+            printf '%s\n' "$@"
+        fi
+    } | {
         while IFS= read -r pkg; do
             if [[ $pkg != *://* ]]; then
                 printf '%s/%s\n' "$AUR_LOCATION" "$pkg"
@@ -154,17 +161,8 @@ done < <(
             else
                 printf '%s\n' "$pkg"
             fi
-            printf '%s\n' "$pkg"
-        done < <(
-            if (( recurse )); then
-                aur depends --reverse "$@" | tsort
-            elif [[ $# = 1 && $1 = - || $1 = /dev/stdin ]]; then
-                cat
-            else
-                printf '%s\n' "$@"
-            fi
-        )
-    )
+        done
+    } | trurl --get '{url} {path}' --url-file -
 )
 wait "$!" || exit
 


### PR DESCRIPTION
> It appeared that trurl was reading stdin before cat and so corrupting the inputs to the outer while loop.
>
> Instead of a well formed "remote path" format it would see http://nx/ / and http://samsung-unified-driver/ /.  Using pipes and command groups seems to address this problem.

https://github.com/aurutils/aurutils/issues/1230#issuecomment-3425906879

Fixes #1230