### PR TITLE
`view`: limit orderfile to local git-diff calls

### DIFF
--- a/lib/util/aur-view
+++ b/lib/util/aur-view
@@ -93,7 +93,7 @@ mkdir -p -- "$AUR_VIEW_DB"
 orderfile=$XDG_CONFIG_HOME/aurutils/$argv0/orderfile
 mkdir -p -- "${orderfile%/*}"
 
-if [[ ! -s $orderfile ]]; then
+if [[ ! -f $orderfile ]]; then
     printf 'PKGBUILD\n' > "$orderfile"
 fi
 
@@ -126,9 +126,6 @@ declare -A heads
 for pkg in "${packages[@]}"; do
     git() { command git -C "$pkg" "$@"; }
 
-    # Point git to current orderFile path (#1167)
-    git config diff.orderFile "$orderfile"
-
     # Ensure every directory is a git repository (--continue)
     if head=$(git rev-parse "${revision:-HEAD}"); then
         heads[$pkg]=$head
@@ -151,7 +148,9 @@ for pkg in "${packages[@]}"; do
         fi
 
         if [[ $view != "$head" ]]; then
-            git --no-pager "$log_fmt" --stat "${log_args[@]}" "${path_args[@]}" \
+            # Point git to current orderFile path (#1167)
+            # Preserve default order for outside git calls (#1239)
+            git -O"$orderfile" --no-pager "$log_fmt" --stat "${log_args[@]}" "${path_args[@]}" \
                 "$view..$head" -- "${excludes[@]}" > "$tmp/$pkg.$log_fmt"
         fi
 


### PR DESCRIPTION
Setting the orderfile in the git configuration extends its use to outside (user) `git-diff` calls, which can lead to unexpected results (issue #1239).

Also create the file if it does not exist, instead of `!(exists && nonempty) == (not exists || empty)`.