### PR TITLE
Dead code

### DIFF
--- a/perl/AUR/Depends.pm
+++ b/perl/AUR/Depends.pm
@@ -188,10 +188,6 @@ sub graph {
 
     # Iterate over packages
     for my $name (keys %{$pkgdeps}) {
-        # Add a loop to command-line targets (#402, #1065, #1136)
-        if (defined $pkgdeps->{$name} and $pkgdeps->{$name} eq $name) {
-            $dag{$name}{$name} = 'Self';
-        }
 
         # Iterate over dependencies
         for my $dep (@{$pkgdeps->{$name}}) {


### PR DESCRIPTION
pkgdeps is pre seeded at line 69 of Depends.pm
`    for my $target (@{$targets}) {
        push(@{$pkgdeps{$target}}, [$target, 'Self']);
    }`
The following at line 192 is dead code  pkgdeps->{$name} is an array ref will never eq $name
`        if (defined $pkgdeps->{$name} and $pkgdeps->{$name} eq $name) {
            $dag{$name}{$name} = 'Self';
        }
`
It is still handled (untested)  at line 219
`                if (not $verify or vercmp($prov_ver, $dep_req, $dep_op)) {
                    $dag{$prov_name}{$name} = $dep_type;
                }
`
because in the self edge preseeded dep_op is undef and at line 53 in Vercmp.pm we have
`    if (not defined $ver2 or not defined $op) {
        return "true";  # unversioned dependency
    }`

