### PR TITLE
AUR::Depends: fix malformed POD directive in tsort() docs

### DIFF
--- a/perl/AUR/Depends.pm
+++ b/perl/AUR/Depends.pm
@@ -300,7 +300,7 @@ sub prune {
 
 Topological sorting adapted from PerlPowerTools.
 
-=Performs depth-first traversal by default.
+Performs depth-first traversal by default.
 
 =over
 


### PR DESCRIPTION
## Summary
- `perl/AUR/Depends.pm` line 303 starts with `=Performs...` in column 0, which POD parsers treat as an unknown directive. Drop the leading `=` so it parses as a plain paragraph.

`podchecker` before: `*** ERROR: unknown directive '=Performs'`
`podchecker` after: `pod syntax OK`

## Test plan
- [x] `podchecker perl/AUR/Depends.pm` reports OK
- [x] `prove -I. perl/t` still passes