### PR TITLE
aur-depends: anchor self-edges to explicit targets (fix #1255)

### DIFF
--- a/lib/aurweb/aur-depends
+++ b/lib/aurweb/aur-depends
@@ -24,8 +24,12 @@ sub solve {
     # Targets to be removed from the graph
     my @to_prune;
 
-    # Remove virtual dependencies from dependency graph (#1063)
-    push @to_prune, keys %{$pkgmap} if $opt_provides;
+    # Remove virtual dependencies from dependency graph (#1063), but
+    # keep explicit targets even if a sibling target Provides them (#1255).
+    if ($opt_provides) {
+        my %is_target = map { $_ => 1 } @{$targets};
+        push @to_prune, grep { not $is_target{$_} } keys %{$pkgmap};
+    }
 
     # Remove transitive dependencies for installed targets (#592)
     push @to_prune, @{$opt_installed} if $opt_installed && @{$opt_installed};

--- a/perl/AUR/Depends.pm
+++ b/perl/AUR/Depends.pm
@@ -206,7 +206,7 @@ sub graph {
                 # $provides is false.
                 my  ($prov_name, $prov_ver) = ($dep_name, $dep_ver[0]);
 
-                if ($provides and defined $pkgmap->{$dep_name}) {
+                if ($provides and $dep_type ne 'Self' and defined $pkgmap->{$dep_name}) {
                     ($prov_name, $prov_ver) = @{$pkgmap->{$dep_name}};
                 }
 


### PR DESCRIPTION
Fix #1255: when one explicit target Provides another, the explicit target loses its node in the resolved graph.

Reproduction: `bitlbee-libpurple-git` is an AUR package that Provides: bitlbee, and bitlbee is also an AUR package. On master, `aur depends bitlbee bitlbee-libpurple-git --json` returns a JSON object where `.bitlbee.RequiredBy` is null.

## Changes

### `graph()` in `perl/AUR/Depends.pm`

Skip provider redirection on Self edges:

```perl
if ($provides and $dep_type ne 'Self' and defined $pkgmap->{$dep_name}) {
    ($prov_name, $prov_ver) = @{$pkgmap->{$dep_name}};
}
```

Without this, the Self edge that `recurse()` seeds for each command-line target was rewritten from `dag{target}{target} = 'Self'` to `dag{provider}{target} = 'Self'`, leaving the explicit target with no node of its own.

### `solve()` in `lib/aurweb/aur-depends`

When building the prune list from `pkgmap` keys, exclude explicit targets:

```perl
if ($opt_provides) {
    my %is_target = map { $_ => 1 } @{$targets};
    push @to_prune, grep { not $is_target{$_} } keys %{$pkgmap};
}
```

Without this, the just-anchored Self edge gets wiped, since the target name is also a `pkgmap` key and `prune()` removes anything keyed under one.

## Why both halves

Either one alone produces a different broken state. Verified by running the actual `aur-depends` script in four configurations against the same recursed AUR data:

| variant | bitlbee in results? | bitlbee.RequiredBy |
|---|---|---|
| master (no fix) | yes | absent (the bug) |
| graph fix only | **no** (target dropped from output) | n/a |
| solve filter only | yes | absent, edge attributed to wrong owner |
| both fixes | yes | `{bitlbee: 'Self'}` (correct) |

## Verification

```
$ aur depends bitlbee bitlbee-libpurple-git --json | jq '.bitlbee.RequiredBy'
{
  "bitlbee": "Self"
}
```

## Test plan

- [x] `perl/t/depends.t` passes (42 tests, including the fixture suite from #1253)
- [x] Real-world reproduction `aur depends bitlbee bitlbee-libpurple-git` produces the correct DAG
- [ ] Fixture-based regression tests (`test-depends-provides-regression` branch) to be submitted as a follow-up PR after this lands
