### PR TITLE
tests: regression coverage for #1255 (provider prunes explicit target)

### DIFF
--- a/perl/t/depends_provides.t
+++ b/perl/t/depends_provides.t
@@ -15,8 +15,15 @@ use FindBin qw($Bin);
 use File::Spec;
 
 my $script = File::Spec->catfile($Bin, '..', '..', 'lib', 'aurweb', 'aur-depends');
-do $script;
-BAIL_OUT("unable to compile $script: $@") if $@;
+my $rv = do $script;
+if (not defined $rv) {
+    # do() returns undef for both compile errors ($@ set) and
+    # I/O failures ($! set). Keep them distinct so a misplaced
+    # script doesn't masquerade as a syntax problem.
+    BAIL_OUT("unable to compile $script: $@") if $@;
+    BAIL_OUT("unable to read $script: $!")    if $!;
+    BAIL_OUT("do $script returned undef (script ended in falsy value?)");
+}
 BAIL_OUT("$script loaded but solve() not defined") if not exists &solve;
 
 sub solve_with_db {
@@ -30,9 +37,30 @@ sub solve_with_db {
     return solve($targets, $types, $callback, $opt_verify, $opt_provides, []);
 }
 
-subtest 'explicit target stays anchored when sibling target provides it' => sub {
-    local $TODO = 'issue #1255: explicit targets should survive provider pruning';
+# Drive the full aur-depends pipeline past solve(): populate
+# RequiredBy from $dag and run pairs() on $results, capturing
+# stdout. Mirrors the `unless(caller)` main block in
+# lib/aurweb/aur-depends so formatter regressions (RequiredBy
+# population, pair emission, pkgbase dedup) surface here too.
+sub pairs_output {
+    my ($results, $dag, $key, $reverse) = @_;
 
+    for my $name (keys %{$dag}) {
+        $results->{$name}->{RequiredBy} = $dag->{$name};
+    }
+
+    my $buf = '';
+    open(my $save, '>&', \*STDOUT) or die "dup stdout: $!";
+    close STDOUT;
+    open(STDOUT, '>', \$buf)       or die "redirect stdout: $!";
+    pairs($results, $key, $reverse);
+    close STDOUT;
+    open(STDOUT, '>&', $save)      or die "restore stdout: $!";
+
+    return [ sort split /\n/, $buf ];
+}
+
+subtest 'explicit target stays anchored when sibling target provides it' => sub {
     my %db = (
         foo  => { Name => 'foo',  Version => '1.0-1',
                   Depends => ['libx'] },
@@ -46,23 +74,28 @@ subtest 'explicit target stays anchored when sibling target provides it' => sub 
     my ($results, $dag, $dag_foreign) = solve_with_db(
         ['foo', 'bar'], ['Depends'], \%db, 0, 1);
 
+    # These hold on current master and must keep holding — they
+    # stay outside any TODO guard so a regression fails loudly.
     is_deeply($dag_foreign, {}, 'no foreign dependencies in repro');
     ok(defined $results->{foo}, 'foo remains in %results');
     ok(defined $results->{bar}, 'bar remains in %results');
 
-    # Full DAG shape in one is_deeply so autoviv side-effects
-    # from chained \$dag->{X}{Y} probes cannot mask a missing
-    # node.
-    is_deeply(
-        $dag,
-        {
-            foo  => { foo => 'Self' },
-            libx => { foo => 'Depends' },
-            bar  => { bar => 'Self' },
-            liby => { bar => 'Depends' },
-        },
-        'DAG shape: foo + bar self-edges with their dependencies',
-    );
+    # Only the DAG-shape expectation is the aspirational bug
+    # check. is_deeply against the full shape avoids autoviv
+    # side effects.
+    TODO: {
+        local $TODO = 'issue #1255: explicit targets should survive provider pruning';
+        is_deeply(
+            $dag,
+            {
+                foo  => { foo => 'Self' },
+                libx => { foo => 'Depends' },
+                bar  => { bar => 'Self' },
+                liby => { bar => 'Depends' },
+            },
+            'DAG shape: foo + bar self-edges with their dependencies',
+        );
+    }
 };
 
 subtest 'explicit targets remain intact when provides are disabled' => sub {
@@ -87,8 +120,6 @@ subtest 'explicit targets remain intact when provides are disabled' => sub {
 };
 
 subtest 'explicit target survives when a dependency also provides it' => sub {
-    local $TODO = 'issue #1255: explicit targets should survive provider pruning';
-
     my %db = (
         foo => { Name => 'foo', Version => '1.0-1',
                  Depends => ['bar'] },
@@ -99,19 +130,59 @@ subtest 'explicit target survives when a dependency also provides it' => sub {
     my ($results, $dag, $dag_foreign) = solve_with_db(
         ['foo'], ['Depends'], \%db, 0, 1);
 
+    # Invariants that already hold — outside any TODO so a
+    # regression here fails loudly.
     is_deeply($dag_foreign, {}, 'no foreign dependencies in repro');
     ok(defined $results->{foo}, 'foo stays in %results');
-    ok(defined $results->{bar}, 'bar stays in %results');
 
-    # Assert the whole shape in a single is_deeply rather than a
-    # sequence of \$dag->{X}{Y} probes. Individual probes would
-    # autovivify \$dag->{X}={}, masking an empty-DAG regression
-    # and making a later "scalar keys %{\$dag} == 2" check pass
-    # by accident.
-    is_deeply(
-        $dag,
-        { foo => { foo => 'Self' }, bar => { foo => 'Depends' } },
-        'DAG shape: foo self-edge plus foo -> bar dependency',
+    TODO: {
+        local $TODO = 'issue #1255: explicit targets should survive provider pruning';
+
+        ok(defined $results->{bar}, 'bar stays in %results');
+
+        # is_deeply against the full shape avoids the
+        # autovivification mask that per-key \$dag->{X}{Y}
+        # probes would otherwise create.
+        is_deeply(
+            $dag,
+            { foo => { foo => 'Self' }, bar => { foo => 'Depends' } },
+            'DAG shape: foo self-edge plus foo -> bar dependency',
+        );
+
+        # Formatter-layer coverage: with the DAG intact, pairs()
+        # should emit one line per edge. Today it emits nothing
+        # because the DAG is empty after prune().
+        my $lines = pairs_output($results, $dag, 'Name', 0);
+        is_deeply($lines,
+            [ "bar\tfoo", "foo\tfoo" ],
+            'pairs() emits self-edge and dependency line',
+        );
+    }
+};
+
+subtest 'formatter control: pairs() emits expected lines for non-buggy DAG' => sub {
+    # Provides-disabled path produces a clean DAG. Verify the
+    # pairs()/RequiredBy output layer under a known-good shape so
+    # an output regression there fails outside any TODO guard.
+    my %db = (
+        foo => { Name => 'foo', Version => '1.0-1', PackageBase => 'foo' },
+        bar => { Name => 'bar', Version => '2.0-1', PackageBase => 'bar',
+                 Provides => ['foo=1.0'] },
+    );
+
+    my ($results, $dag) = solve_with_db(
+        ['foo', 'bar'], ['Depends'], \%db, 0, 0);
+
+    my $by_name = pairs_output($results, $dag, 'Name', 0);
+    is_deeply($by_name,
+        [ "bar\tbar", "foo\tfoo" ],
+        'pairs() by Name: one self-edge per target',
+    );
+
+    my $by_base = pairs_output($results, $dag, 'PackageBase', 0);
+    is_deeply($by_base,
+        [ "bar\tbar", "foo\tfoo" ],
+        'pairs() by PackageBase: one self-edge per target',
     );
 };
 

--- a/perl/t/depends_provides.t
+++ b/perl/t/depends_provides.t
@@ -15,7 +15,9 @@ use FindBin qw($Bin);
 use File::Spec;
 
 my $script = File::Spec->catfile($Bin, '..', '..', 'lib', 'aurweb', 'aur-depends');
-do $script or BAIL_OUT("unable to load $script: " . ($@ || $!));
+do $script;
+BAIL_OUT("unable to compile $script: $@") if $@;
+BAIL_OUT("$script loaded but solve() not defined") if not exists &solve;
 
 sub solve_with_db {
     my ($targets, $types, $db, $opt_verify, $opt_provides) = @_;
@@ -46,15 +48,21 @@ subtest 'explicit target stays anchored when sibling target provides it' => sub 
 
     is_deeply($dag_foreign, {}, 'no foreign dependencies in repro');
     ok(defined $results->{foo}, 'foo remains in %results');
-    ok(defined $dag->{foo}, 'foo keeps a DAG node');
-    is($dag->{foo}{foo}, 'Self', 'foo keeps its self-edge');
-    ok(defined $dag->{libx}, 'foo dependency stays in DAG');
-    is($dag->{libx}{foo}, 'Depends', 'libx remains required by foo');
-
     ok(defined $results->{bar}, 'bar remains in %results');
-    ok(defined $dag->{bar}, 'bar keeps a DAG node');
-    is($dag->{bar}{bar}, 'Self', 'bar keeps its self-edge');
-    is($dag->{liby}{bar}, 'Depends', 'liby remains required by bar');
+
+    # Full DAG shape in one is_deeply so autoviv side-effects
+    # from chained \$dag->{X}{Y} probes cannot mask a missing
+    # node.
+    is_deeply(
+        $dag,
+        {
+            foo  => { foo => 'Self' },
+            libx => { foo => 'Depends' },
+            bar  => { bar => 'Self' },
+            liby => { bar => 'Depends' },
+        },
+        'DAG shape: foo + bar self-edges with their dependencies',
+    );
 };
 
 subtest 'explicit targets remain intact when provides are disabled' => sub {
@@ -69,9 +77,13 @@ subtest 'explicit targets remain intact when provides are disabled' => sub {
 
     is_deeply($dag_foreign, {}, 'no foreign dependencies');
     ok(defined $results->{foo}, 'foo preserved when provides are disabled');
-    is($dag->{foo}{foo}, 'Self', 'foo self-edge intact');
     ok(defined $results->{bar}, 'bar also preserved');
-    is($dag->{bar}{bar}, 'Self', 'bar self-edge intact');
+
+    is_deeply(
+        $dag,
+        { foo => { foo => 'Self' }, bar => { bar => 'Self' } },
+        'DAG shape: both targets anchored, no cross-edges',
+    );
 };
 
 subtest 'explicit target survives when a dependency also provides it' => sub {
@@ -90,11 +102,17 @@ subtest 'explicit target survives when a dependency also provides it' => sub {
     is_deeply($dag_foreign, {}, 'no foreign dependencies in repro');
     ok(defined $results->{foo}, 'foo stays in %results');
     ok(defined $results->{bar}, 'bar stays in %results');
-    ok(defined $dag->{foo}, 'foo keeps a DAG node');
-    is($dag->{foo}{foo}, 'Self', 'foo keeps its self-edge');
-    ok(defined $dag->{bar}, 'bar remains buildable');
-    is($dag->{bar}{foo}, 'Depends', 'bar remains required by foo');
-    is(scalar keys %{$dag}, 2, 'build order remains available');
+
+    # Assert the whole shape in a single is_deeply rather than a
+    # sequence of \$dag->{X}{Y} probes. Individual probes would
+    # autovivify \$dag->{X}={}, masking an empty-DAG regression
+    # and making a later "scalar keys %{\$dag} == 2" check pass
+    # by accident.
+    is_deeply(
+        $dag,
+        { foo => { foo => 'Self' }, bar => { foo => 'Depends' } },
+        'DAG shape: foo self-edge plus foo -> bar dependency',
+    );
 };
 
 done_testing();

--- a/perl/t/depends_provides.t
+++ b/perl/t/depends_provides.t
@@ -1,0 +1,101 @@
+#!/usr/bin/env perl
+#
+# Regression coverage for issue #1255 against the real aur-depends
+# solve() path. The TODO subtests document the intended graph shape
+# once explicit targets stop being pruned when another resolved
+# package provides them.
+#
+# Authors: Avinash H. Duduskar <https://github.com/Strykar>
+#
+use strict;
+use warnings;
+use v5.20;
+use Test::More;
+use FindBin qw($Bin);
+use File::Spec;
+
+my $script = File::Spec->catfile($Bin, '..', '..', 'lib', 'aurweb', 'aur-depends');
+do $script or BAIL_OUT("unable to load $script: " . ($@ || $!));
+
+sub solve_with_db {
+    my ($targets, $types, $db, $opt_verify, $opt_provides) = @_;
+
+    my $callback = sub {
+        my ($deps) = @_;
+        return map { $db->{$_} } grep { defined $db->{$_} } @{$deps};
+    };
+
+    return solve($targets, $types, $callback, $opt_verify, $opt_provides, []);
+}
+
+subtest 'explicit target stays anchored when sibling target provides it' => sub {
+    local $TODO = 'issue #1255: explicit targets should survive provider pruning';
+
+    my %db = (
+        foo  => { Name => 'foo',  Version => '1.0-1',
+                  Depends => ['libx'] },
+        bar  => { Name => 'bar',  Version => '2.0-1',
+                  Provides => ['foo=1.0'],
+                  Depends => ['liby'] },
+        libx => { Name => 'libx', Version => '1.0-1' },
+        liby => { Name => 'liby', Version => '1.0-1' },
+    );
+
+    my ($results, $dag, $dag_foreign) = solve_with_db(
+        ['foo', 'bar'], ['Depends'], \%db, 0, 1);
+
+    is_deeply($dag_foreign, {}, 'no foreign dependencies in repro');
+    ok(defined $results->{foo}, 'foo remains in %results');
+    ok(defined $dag->{foo}, 'foo keeps a DAG node');
+    is($dag->{foo}{foo}, 'Self', 'foo keeps its self-edge');
+    ok(defined $dag->{libx}, 'foo dependency stays in DAG');
+    is($dag->{libx}{foo}, 'Depends', 'libx remains required by foo');
+
+    ok(defined $results->{bar}, 'bar remains in %results');
+    ok(defined $dag->{bar}, 'bar keeps a DAG node');
+    is($dag->{bar}{bar}, 'Self', 'bar keeps its self-edge');
+    is($dag->{liby}{bar}, 'Depends', 'liby remains required by bar');
+};
+
+subtest 'explicit targets remain intact when provides are disabled' => sub {
+    my %db = (
+        foo => { Name => 'foo', Version => '1.0-1' },
+        bar => { Name => 'bar', Version => '2.0-1',
+                 Provides => ['foo=1.0'] },
+    );
+
+    my ($results, $dag, $dag_foreign) = solve_with_db(
+        ['foo', 'bar'], ['Depends'], \%db, 0, 0);
+
+    is_deeply($dag_foreign, {}, 'no foreign dependencies');
+    ok(defined $results->{foo}, 'foo preserved when provides are disabled');
+    is($dag->{foo}{foo}, 'Self', 'foo self-edge intact');
+    ok(defined $results->{bar}, 'bar also preserved');
+    is($dag->{bar}{bar}, 'Self', 'bar self-edge intact');
+};
+
+subtest 'explicit target survives when a dependency also provides it' => sub {
+    local $TODO = 'issue #1255: explicit targets should survive provider pruning';
+
+    my %db = (
+        foo => { Name => 'foo', Version => '1.0-1',
+                 Depends => ['bar'] },
+        bar => { Name => 'bar', Version => '2.0-1',
+                 Provides => ['foo=1.0'] },
+    );
+
+    my ($results, $dag, $dag_foreign) = solve_with_db(
+        ['foo'], ['Depends'], \%db, 0, 1);
+
+    is_deeply($dag_foreign, {}, 'no foreign dependencies in repro');
+    ok(defined $results->{foo}, 'foo stays in %results');
+    ok(defined $results->{bar}, 'bar stays in %results');
+    ok(defined $dag->{foo}, 'foo keeps a DAG node');
+    is($dag->{foo}{foo}, 'Self', 'foo keeps its self-edge');
+    ok(defined $dag->{bar}, 'bar remains buildable');
+    is($dag->{bar}{foo}, 'Depends', 'bar remains required by foo');
+    is(scalar keys %{$dag}, 2, 'build order remains available');
+};
+
+done_testing();
+# vim: set et sw=4 sts=4 ft=perl:


### PR DESCRIPTION
Draft companion to issue [#1255](https://github.com/aurutils/aurutils/issues/1255) and fix PR [#1256](https://github.com/aurutils/aurutils/pull/1256). Adds `perl/t/depends_provides.t` which loads the real `lib/aurweb/aur-depends` via `do` and exercises in-tree `solve()` plus the formatter layer (`pairs()` / `RequiredBy`) against three small in-memory package DBs.

## Structure

The aspirational DAG-shape and `pairs()` assertions are wrapped in `TODO: { local \$TODO = '...'; ... }` blocks scoped as tightly as possible. Everything that already holds on current master — `\$dag_foreign` emptiness, `%results` membership of explicit targets — lives **outside** the TODO guard so any regression there fails loudly.

Today the TODO-wrapped assertions are expected-fail. Once [#1256](https://github.com/aurutils/aurutils/pull/1256) (or any equivalent fix) lands, they flip to **unexpected-pass** and `prove` forces an intentional TODO removal.

## Scenarios

1. **Sibling target provides an explicit target** (`['foo','bar']`, `bar` provides `foo`) — DAG shape under TODO.
2. **Provides disabled** (`\$provides=0`) — control path, no TODO, passes today.
3. **Target's own dependency provides it** (`['foo']`, `foo` depends on `bar`, `bar` provides `foo`) — DAG shape + `pairs()` output under TODO.
4. **Formatter control** — pins `pairs()` output (by `Name` and by `PackageBase`) on the clean `\$provides=0` DAG outside any TODO, so a regression in `RequiredBy` population or pair dedup surfaces without a guard.

## Why draft

No fix is proposed here. This PR is executable documentation of the behavior described in #1255, safe to ship independently of the fix's merge timeline. Marked draft so it can sit alongside the issue on the maintainer's schedule.

## Test plan
- [x] `cd perl && prove -I. t/depends_provides.t` — all 4 subtests pass; TODO assertions correctly report as expected-fail with meaningful `is_deeply` diffs.
- [x] Cherry-picking PR #1256 on top flips the TODO assertions to unexpected-pass, matching the intended signal.
- [x] Control subtests (`\$provides=0` path, formatter output) pass today with no TODO guard.

## Notes on test hardening included here

- `is_deeply` against the full DAG shape instead of chained `\$dag->{X}{Y}` probes — avoids autovivification side effects that would mask an empty-DAG regression.
- `do \$script` bootstrap distinguishes compile errors (`\$@`), I/O failures (`\$!`), and scripts that load but don't define `solve()`.
- Formatter-layer coverage drives `pairs()` through the same `RequiredBy` population the main block does.