### PR TITLE
Update bash-completion to the 2.12 API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ shellcheck: aur
 
 test: aur shellcheck
 	@tests/parseopt-consistency
+	@tests/completion
 	@$(MAKE) -C perl test
 
 install-aur: aur

--- a/completions/bash/aurutils.in
+++ b/completions/bash/aurutils.in
@@ -1,79 +1,127 @@
 #!/bin/bash
+#
+# Template for the aurutils bash completion. Generates `bash/aur`,
+# installed to /usr/share/bash-completion/completions/. Requires
+# bash-completion 2.12+ at runtime.
 
 cat <<'EOF'
+# aurutils bash completion — requires bash-completion >= 2.12
 _aur_completion()
 {
-    local cur prev words cword
-    _get_comp_words_by_ref cur prev words cword
+    # comp_args is populated by _comp_initialize and declared local
+    # here so it doesn't leak into the global scope.
+    # shellcheck disable=SC2034
+    local cur prev words cword was_split comp_args
+    _comp_initialize -s -- "$@" || return
 
     declare -A default_cmds
+    declare -A arg_types
+    declare -A choices
+    declare -A positional
+    declare -A delim_types
 
 EOF
 source ./command_opts.sh
 default_opts
 cat <<'EOF'
 
-    # complete subcommands
     if [[ $cword -eq 1 ]]; then
-        COMPREPLY=( $(compgen -W "${!default_cmds[*]}" -- "$cur") )
+        _comp_compgen -- -W "${!default_cmds[*]}"
         return
     fi
 
-    # If there's an override for subcommand, use it
-    if declare -F "_aurutils_${words[1]/-/_/}" >/dev/null ; then
-        "_aurutils_${words[1]}"
+    local cmd=${words[1]}
+
+    if [[ -n ${delim_types[$cmd,$prev]:-} ]]; then
+        local spec=${delim_types[$cmd,$prev]}
+        _aur_complete_delimited "${spec%%:*}" "${spec#*:}"
+        return
+    fi
+    if [[ -n ${arg_types[$cmd,$prev]:-} ]]; then
+        _aur_complete_type "${arg_types[$cmd,$prev]}"
+        return
+    fi
+    if [[ -n ${choices[$cmd,$prev]:-} ]]; then
+        _comp_compgen -- -W "${choices[$cmd,$prev]}"
         return
     fi
 
-    # Complete with the generated opts stored above, unless the previous option
-    # is stored with an : suffix, because the option requires an argument.
-    # Fallback to default (files) completion in such cases.
+    # Word was split on `=` by _comp_initialize -s but no spec matched.
+    # Don't fall through to offering more flags.
+    [[ $was_split ]] && return
 
-    _fallback_completion
+    if [[ $cur != -* && -n ${positional[$cmd]:-} ]]; then
+        _aur_complete_type "${positional[$cmd]}"
+        return
+    fi
+
+    _aur_fallback
 }
 
-_fallback_completion(){
-    opts=(${default_cmds[${words[1]}]})
+_aur_complete_type() {
+    case $1 in
+        file)      _comp_compgen_filedir ;;
+        dir)       _comp_compgen_filedir -d ;;
+        repo)      _comp_compgen -- -W "$(aur repo --repo-list 2>/dev/null)" ;;
+        pkgname)   _aur_packages ;;
+        pkgbase)   _aur_packages --pkgbase ;;
+        local_pkg) _aur_local_packages ;;
+        user)      _comp_compgen -- -u ;;
+        attr)      _comp_compgen -- -W "$(aur repo --list-attr 2>/dev/null)" ;;
+    esac
+}
+
+_aur_complete_delimited() {
+    local delim=$1 kind=$2
+    case $kind in
+        local_pkg) local repo pkgs=()
+                   while IFS= read -r repo; do
+                       mapfile -t -O "${#pkgs[@]}" pkgs < <(aur repo -lq -d "$repo" 2>/dev/null | cut -f1)
+                   done < <(aur repo --list-repo 2>/dev/null)
+                   _comp_delimited "$delim" -W "${pkgs[*]}" ;;
+        dir|file)  # _comp_delimited's path handling breaks on absolute
+                   # paths (it runs compgen -d without a path argument).
+                   # Strip the already-entered prefix, run filedir on
+                   # the tail, re-prepend. Works for both relative and
+                   # absolute paths.
+                   local prefix=""
+                   [[ $cur == *"$delim"* ]] && prefix=${cur%"$delim"*}$delim
+                   local saved=$cur
+                   cur=${cur##*"$delim"}
+                   if [[ $kind == dir ]]; then
+                       _comp_compgen_filedir -d
+                   else
+                       _comp_compgen_filedir
+                   fi
+                   cur=$saved
+                   local i
+                   for i in "${!COMPREPLY[@]}"; do
+                       COMPREPLY[i]=$prefix${COMPREPLY[i]}
+                   done ;;
+    esac
+}
+
+_aur_packages() {
+    [[ -z $cur || $cur == -* ]] && return
+    local pkgs
+    mapfile -t pkgs < <(aur pkglist --ttl 86400 --systime --plain "$@" 2>/dev/null)
+    _comp_compgen -- -W "${pkgs[*]}"
+}
+
+_aur_local_packages() {
+    local repo pkgs=()
+    while IFS= read -r repo; do
+        mapfile -t -O "${#pkgs[@]}" pkgs < <(aur repo -lq -d "$repo" 2>/dev/null | cut -f1)
+    done < <(aur repo --list-repo 2>/dev/null)
+    _comp_compgen -- -W "${pkgs[*]}"
+}
+
+_aur_fallback() {
+    local opts
+    read -ra opts <<<"${default_cmds[${words[1]}]}"
     if [[ ${opts[*]} != *$prev:* ]] || [[ $cword -eq 2 ]]; then
-        COMPREPLY=($(compgen -W "${opts[*]%:}" -- "$cur"));
+        _comp_compgen -- -W "${opts[*]%:}"
     fi
-}
-
-_complete_with_repos() {
-    opts=($(aur repo --repo-list))
-    COMPREPLY=($(compgen -W "${opts[*]}" -- "$cur"))
-}
-
-_aurutils_build() {
-    case $prev in
-        -d|--database|--repo)
-            _complete_with_repos ;;
-        *) _fallback_completion ;;
-    esac
-}
-
-_aurutils_repo() {
-    case $prev in
-        -d|--database|--repo)
-            _complete_with_repos ;;
-        *) _fallback_completion ;;
-    esac
-}
-
-_aurutils_repo_filter() {
-    case $prev in
-        -d|--database|--repo)
-            _complete_with_repos ;;
-        *) _fallback_completion ;;
-    esac
-}
-
-_aurutils_sync() {
-    case $prev in
-        -d|--database|--repo)
-            _complete_with_repos ;;
-        *) _fallback_completion ;;
-    esac
 }
 
 complete -o bashdefault -o default -o nosort -F _aur_completion aur

--- a/completions/command_opts.sh
+++ b/completions/command_opts.sh
@@ -17,4 +17,120 @@ default_opts() {
     done
 
     printf '    %s\n' "${corecommands[@]}"
+
+    emit_metadata
+}
+
+# Metadata tables, transcribed from the zsh completion so the bash
+# template can dispatch typed completers and static choice sets.
+# Keys are "$cmd,$flag". Types: file, dir, repo, pkgname, pkgbase,
+# local_pkg, user, attr. Missing entries fall back to file completion.
+emit_metadata() {
+    local data=(
+        # aur-build
+        "arg_types[build,--arg-file]='file'"
+        "arg_types[build,-a]='file'"
+        "arg_types[build,--database]='repo'"
+        "arg_types[build,-d]='repo'"
+        "arg_types[build,--root]='dir'"
+        "arg_types[build,--makepkg-conf]='file'"
+        "arg_types[build,--pacman-conf]='file'"
+        "arg_types[build,--directory]='dir'"
+        "arg_types[build,-D]='dir'"
+        "arg_types[build,--user]='user'"
+        "arg_types[build,-U]='user'"
+        "arg_types[build,--bind]='dir'"
+        "arg_types[build,--bind-rw]='dir'"
+        "arg_types[build,--buildscript]='file'"
+
+        # aur-chroot
+        "arg_types[chroot,--bind]='dir'"
+        "arg_types[chroot,--bind-rw]='dir'"
+        "arg_types[chroot,--directory]='dir'"
+        "arg_types[chroot,-D]='dir'"
+        "arg_types[chroot,--makepkg-conf]='file'"
+        "arg_types[chroot,-M]='file'"
+        "arg_types[chroot,--pacman-conf]='file'"
+        "arg_types[chroot,-C]='file'"
+        "positional[chroot]='pkgname'"
+
+        # aur-depends
+        "positional[depends]='pkgname'"
+
+        # aur-fetch
+        "arg_types[fetch,--results]='file'"
+        "choices[fetch,--sync]='reset merge rebase fetch'"
+        "positional[fetch]='pkgbase'"
+
+        # aur-pkglist: no typed args, positional is a free pattern
+
+        # aur-query
+        "choices[query,--by]='name name-desc maintainer depends makedepends optdepends checkdepends'"
+        "choices[query,-b]='name name-desc maintainer depends makedepends optdepends checkdepends'"
+        "choices[query,--type]='search info'"
+        "choices[query,-t]='search info'"
+        "positional[query]='pkgname'"
+
+        # aur-repo
+        "arg_types[repo,--attr]='attr'"
+        "arg_types[repo,-F]='attr'"
+        "arg_types[repo,--config]='file'"
+        "arg_types[repo,-c]='file'"
+        "arg_types[repo,--database]='repo'"
+        "arg_types[repo,-d]='repo'"
+        "arg_types[repo,--repo]='repo'"
+        "arg_types[repo,--root]='dir'"
+        "arg_types[repo,-r]='dir'"
+        "choices[repo,--format]='%a %b %c %C %d %D %e %f %F %g %M %n %O %P %U %v'"
+        "choices[repo,-f]='%a %b %c %C %d %D %e %f %F %g %M %n %O %P %U %v'"
+
+        # aur-repo-filter
+        "arg_types[repo-filter,--config]='file'"
+        "arg_types[repo-filter,--database]='repo'"
+        "arg_types[repo-filter,-d]='repo'"
+        "arg_types[repo-filter,--sysroot]='dir'"
+
+        # aur-search
+        "choices[search,--format]='%b %c %C %d %D %e %g %K %L %m %M %n %o %O %p %P %S %U %v %w'"
+        "choices[search,-f]='%b %c %C %d %D %e %g %K %L %m %M %n %o %O %p %P %S %U %v %w'"
+        "choices[search,--key]='Name Version NumVotes Description PackageBase URL Popularity OutOfDate Maintainer FirstSubmitted LastModified'"
+        "choices[search,-k]='Name Version NumVotes Description PackageBase URL Popularity OutOfDate Maintainer FirstSubmitted LastModified'"
+
+        # aur-srcver
+        "arg_types[srcver,--buildscript]='file'"
+        "positional[srcver]='pkgbase'"
+
+        # aur-sync (inherits build-shared args)
+        "arg_types[sync,--arg-file]='file'"
+        "arg_types[sync,-a]='file'"
+        "arg_types[sync,--database]='repo'"
+        "arg_types[sync,-d]='repo'"
+        "arg_types[sync,--root]='dir'"
+        "arg_types[sync,--makepkg-conf]='file'"
+        "arg_types[sync,--pacman-conf]='file'"
+        "arg_types[sync,--directory]='dir'"
+        "arg_types[sync,-D]='dir'"
+        "arg_types[sync,--user]='user'"
+        "arg_types[sync,-U]='user'"
+        "arg_types[sync,--bind]='dir'"
+        "arg_types[sync,--bind-rw]='dir'"
+        "arg_types[sync,--ignore-file]='file'"
+        "delim_types[sync,--ignore]=',:local_pkg'"
+        "delim_types[sync,--provides-from]=',:dir'"
+        "choices[sync,--format]='diff log'"
+        "positional[sync]='pkgname'"
+
+        # aur-vercmp
+        "arg_types[vercmp,--path]='file'"
+        "arg_types[vercmp,-p]='file'"
+        "choices[vercmp,--upair]='1 2'"
+        "choices[vercmp,-u]='1 2'"
+
+        # aur-view
+        "arg_types[view,--arg-file]='file'"
+        "arg_types[view,-a]='file'"
+        "choices[view,--format]='diff log'"
+        "positional[view]='dir'"
+    )
+    printf '    %s\n' "${data[@]}"
 }

--- a/tests/completion
+++ b/tests/completion
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# Unit tests for the bash completion. Requires bash-completion
+# 2.12+ on the system; dynamic-completer tests additionally
+# require the `aur` binary on PATH.
+
+script_dir=${BASH_SOURCE%/*}
+cd "$script_dir/.." || exit 2
+
+# Build the completion script.
+make -s -C completions bash >/dev/null
+
+# shellcheck disable=SC1091
+source /usr/share/bash-completion/bash_completion
+
+if ! declare -F _comp_initialize >/dev/null; then
+    echo "skip: bash-completion 2.12+ not available (_comp_initialize missing)"
+    exit 0
+fi
+
+# shellcheck disable=SC1091
+source completions/bash/aur
+
+PASS=0
+FAIL=0
+
+# Populate COMP_* variables for a command line and invoke the
+# completion function.
+_run() {
+    local line=$1
+    COMP_LINE=$line
+    # shellcheck disable=SC2206
+    COMP_WORDS=($line)
+    [[ $line == *" " ]] && COMP_WORDS+=("")
+    COMP_CWORD=$((${#COMP_WORDS[@]} - 1))
+    COMP_POINT=${#COMP_LINE}
+    COMPREPLY=()
+    _aur_completion "${COMP_WORDS[0]}" \
+                    "${COMP_WORDS[COMP_CWORD]}" \
+                    "${COMP_WORDS[COMP_CWORD-1]:-}" 2>/dev/null || true
+}
+
+# case_match DESC "line..." "grep -E pattern"
+case_match() {
+    local desc=$1 line=$2 pattern=$3
+    _run "$line"
+    if printf '%s\n' "${COMPREPLY[@]}" | grep -qE "$pattern"; then
+        PASS=$((PASS + 1))
+        printf 'ok   %s\n' "$desc"
+    else
+        FAIL=$((FAIL + 1))
+        printf 'FAIL %s\n     line: %q\n     got:  %s\n     want match: %s\n' \
+            "$desc" "$line" "${COMPREPLY[*]}" "$pattern"
+    fi
+}
+
+# case_no_match DESC "line..." "grep -E pattern"
+case_no_match() {
+    local desc=$1 line=$2 pattern=$3
+    _run "$line"
+    if printf '%s\n' "${COMPREPLY[@]}" | grep -qE "$pattern"; then
+        FAIL=$((FAIL + 1))
+        printf 'FAIL %s\n     line: %q\n     got unexpected: %s\n' \
+            "$desc" "$line" "${COMPREPLY[*]}"
+    else
+        PASS=$((PASS + 1))
+        printf 'ok   %s\n' "$desc"
+    fi
+}
+
+# -------- subcommand completion --------
+case_match "subcommand 'build' offered"   "aur "  '^build$'
+case_match "subcommand 'sync' offered"    "aur "  '^sync$'
+case_match "subcommand 'depends' offered" "aur "  '^depends$'
+case_match "subcommand 'repo-filter' offered" "aur " '^repo-filter$'
+
+# -------- static choice sets --------
+case_match "aur query --by name"          "aur query --by "    '^name$'
+case_match "aur query --by maintainer"    "aur query --by "    '^maintainer$'
+case_match "aur query -b name-desc"       "aur query -b "      '^name-desc$'
+case_match "aur query --type info"        "aur query --type "  '^info$'
+case_match "aur query --type search"      "aur query --type "  '^search$'
+case_match "aur fetch --sync rebase"      "aur fetch --sync "  '^rebase$'
+case_match "aur fetch --sync fetch"       "aur fetch --sync "  '^fetch$'
+case_match "aur search --key Name"        "aur search --key "  '^Name$'
+case_match "aur search --key NumVotes"    "aur search --key "  '^NumVotes$'
+case_match "aur vercmp --upair 1"         "aur vercmp --upair " '^1$'
+case_match "aur vercmp -u 2"              "aur vercmp -u "     '^2$'
+case_match "aur repo --format %a"         "aur repo --format " '^%a$'
+case_match "aur view --format diff"       "aur view --format " '^diff$'
+
+# -------- --opt=val form (auto-split by _comp_initialize -s) --------
+case_match "aur query --by=n narrows to name*"     "aur query --by=n"      '^name$'
+case_match "aur query --by=name-d -> name-desc"    "aur query --by=name-d" '^name-desc$'
+case_match "aur query --type=i -> info"            "aur query --type=i"    '^info$'
+case_match "aur fetch --sync=re -> rebase/reset"   "aur fetch --sync=re"   '^re(base|set)$'
+
+# -------- flag list / fallback --------
+case_match "aur build -- offers --chroot"          "aur build --"          '^--chroot$'
+case_match "aur build -- offers --sign"            "aur build --"          '^--sign$'
+case_match "aur sync -- offers --no-build"         "aur sync --"           '^--no-build$'
+
+# -------- user completion (system users) --------
+case_match "aur build --user offers 'root'"        "aur build --user "     '^root$'
+
+# -------- dynamic completers (require aur binary) --------
+if command -v aur >/dev/null 2>&1; then
+    case_match "aur repo -d lists at least one repo"  "aur repo -d "          '.'
+    case_match "aur repo -F lists ARCH"               "aur repo -F "          '^ARCH$'
+    case_match "aur repo --attr lists BASE"           "aur repo --attr "      '^BASE$'
+else
+    echo "skip: dynamic completers (no aur binary)"
+fi
+
+# -------- positional pkgname (prefix required to avoid 95k expansion) --------
+if command -v aur >/dev/null 2>&1; then
+    if aur pkglist --ttl 86400 --systime --plain 2>/dev/null | head -1 >/dev/null; then
+        # Use a short, common prefix that should always match something.
+        case_match "aur depends 'glib' prefix matches" "aur depends glib" '.'
+    fi
+fi
+
+# -------- delimited (comma-separated) values --------
+case_match "aur sync --provides-from= single path"    "aur sync --provides-from=/tm" '^/tmp/?$'
+case_match "aur sync --provides-from= mid-list path"  "aur sync --provides-from=/etc,/tm" '^/etc,/tmp/?$'
+if command -v aur >/dev/null 2>&1; then
+    case_match "aur sync --ignore= lists local pkgs"  "aur sync --ignore=" '.'
+    case_match "aur sync --ignore= mid-list local"    "aur sync --ignore=0ad,fir" '^0ad,fir'
+fi
+
+# -------- negative cases --------
+case_no_match "aur query --by does not offer flags" "aur query --by " '^--'
+case_no_match "aur fetch --sync is not a filename"  "aur fetch --sync " '^/'
+
+echo "---"
+printf 'PASS: %d  FAIL: %d\n' "$PASS" "$FAIL"
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
Brings the bash completion close to zsh's fidelity and moves it onto
the modern bash-completion 2.12 API.

Split into two commits so the test harness in the second can be
dropped without affecting the completion itself.

## Commit 1 — bash completion proper
`completions/bash/aurutils.in`, `completions/command_opts.sh`

- Typed argument completion: file, dir, repo, pkgname, pkgbase,
  local_pkg, user, attr. Tables live in `command_opts.sh`, values
  transcribed from the zsh completion so both shells share one
  metadata source.
- Static choice sets for `--by`, `--type`, `--key`, `--format`,
  `--sync`, `--upair`.
- Positional completion (pkgname / pkgbase / local package / dir)
  per subcommand.
- `_comp_initialize -s` replaces `_get_comp_words_by_ref`: handles
  COMPREPLY reset, redirect detection, and `--opt=val` splitting in
  one call. Drops the hand-written `--flag=VALUE` branch.
- `_comp_compgen`, `_comp_compgen_filedir`, `_comp_delimited`
  replace each `COMPREPLY=($(compgen ...))` and `_filedir` call.
- Comma-separated value completion for `aur sync --ignore=a,b,c`
  (local packages) and `--provides-from=/a,/b` (absolute + relative
  paths, mid-list suggestions).

## Commit 2 — optional test harness
`tests/completion`, `Makefile`

35 cases: subcommands, static choice sets, `--opt=val` split,
dynamic repo / attr / local-pkg completion, mid-list delimited
paths, negative cases. Wired into `make test`. Skips gracefully on
systems without bash-completion 2.12 or without the `aur` binary.

If the test harness isn't wanted, cherry-pick only the first commit.

## Test plan
- [x] `make -C completions bash`
- [x] `make test` — 35/0
- [x] `shellcheck` clean (same two warnings as master: SC2148, SC2206)
- [x] Manual verification in bash with real `aur` 20.5.8
