### PR TITLE
Options.pm: add dump_options and enable --dump-options in Perl scripts

### DIFF
--- a/completions/command_opts.sh
+++ b/completions/command_opts.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-have_optdump=('build' 'chroot' 'fetch' 'pkglist' 'repo' 'repo-filter'
+have_optdump=('build' 'chroot' 'depends' 'fetch' 'format' 'pkglist'
+              'query' 'repo' 'repo-filter' 'repo-parse' 'search'
               'srcver' 'sync' 'vercmp' 'view')
-no_optdump=('graph' 'format' 'repo-parse' 'query' 'depends' 'search')
+no_optdump=('graph')
 
 default_opts() {
     local cmd corecommands=() opts=()

--- a/lib/aurweb/aur-depends
+++ b/lib/aurweb/aur-depends
@@ -7,7 +7,7 @@ use List::Util   qw(first);
 use AUR::Json    qw(parse_json_aur write_json);
 use AUR::Query   qw(query_multi);
 use AUR::Depends qw(recurse prune graph);
-use AUR::Options qw(add_from_stdin);
+use AUR::Options qw(add_from_stdin dump_options);
 my $argv0 = 'depends';
 
 sub solve {
@@ -109,7 +109,10 @@ unless(caller) {
     my $opt_verify       = 0;
     my $opt_installed    = [];
 
-    GetOptions(
+    my $opt_dump;
+
+    my @opt_spec = (
+        'dump-options'             => \$opt_dump,
         'ignore|assume-installed=s' => $opt_installed,
         'no-depends'      => sub { $opt_depends = 0 },
         'no-makedepends'  => sub { $opt_makedepends = 0 },
@@ -124,8 +127,14 @@ unless(caller) {
         'J|json'          => sub { $opt_mode = "json" },
         'jsonl'           => sub { $opt_mode = "jsonl" },
         'r|reverse'       => \$opt_reverse,
-        'a|all|show-all'  => \$opt_show_all
-    ) or exit(1);
+        'a|all|show-all'  => \$opt_show_all,
+    );
+    GetOptions(@opt_spec) or exit(1);
+
+    if ($opt_dump) {
+        dump_options([grep { !ref } @opt_spec]);
+        exit;
+    }
 
     if (not scalar(@ARGV)) {
         say STDERR "$argv0: at least one argument required";

--- a/lib/aurweb/aur-query
+++ b/lib/aurweb/aur-query
@@ -4,7 +4,7 @@ use warnings;
 use v5.20;
 
 use AUR::Query qw(query query_multi);
-use AUR::Options qw(add_from_stdin);
+use AUR::Options qw(add_from_stdin dump_options);
 my $argv0 = 'query';
 
 unless (caller) {
@@ -12,12 +12,20 @@ unless (caller) {
     use Getopt::Long;
     my $opt_by;
     my $opt_type = "";
+    my $opt_dump;
 
-    GetOptions(
-        't|type=s' => \$opt_type,
-        'b|by=s'   => \$opt_by,
-        'r|raw'    => sub { } # noop
-    ) or exit(1);
+    my @opt_spec = (
+        'dump-options' => \$opt_dump,
+        't|type=s'     => \$opt_type,
+        'b|by=s'       => \$opt_by,
+        'r|raw'        => sub { },
+    );
+    GetOptions(@opt_spec) or exit(1);
+
+    if ($opt_dump) {
+        dump_options([grep { !ref } @opt_spec]);
+        exit;
+    }
 
     if (not length($opt_type)) {
         say STDERR "$argv0: type must be specified";

--- a/lib/aurweb/aur-search
+++ b/lib/aurweb/aur-search
@@ -12,7 +12,7 @@ use constant ST   => "\033\\";
 
 use AUR::Json    qw(parse_json_aur write_json);
 use AUR::Query   qw(query query_multi);
-use AUR::Options qw(add_from_stdin);
+use AUR::Options qw(add_from_stdin dump_options);
 my $argv0 = 'search';
 my $aur_location = $ENV{AUR_LOCATION} // 'https://aur.archlinux.org';
 
@@ -117,7 +117,10 @@ unless(caller) {
     my $opt_format    = '';
 
     # XXX: add option to disable set operations, --time-format
-    GetOptions (
+    my $opt_dump;
+
+    my @opt_spec = (
+        'dump-options'  => \$opt_dump,
         'a|any'         => sub { $opt_multiple  = 'union' },
         'i|info'        => sub { $opt_type      = 'info' },
         's|search'      => sub { $opt_type      = 'search' },
@@ -140,8 +143,14 @@ unless(caller) {
         'J|json|raw'    => sub { $opt_format    = 'json' },
         'color=s'       => \$opt_color,
         'r|reverse'     => \$opt_reverse,
-        'k|key=s'       => \$opt_sort_key
-    ) or exit(1);
+        'k|key=s'       => \$opt_sort_key,
+    );
+    GetOptions(@opt_spec) or exit(1);
+
+    if ($opt_dump) {
+        dump_options([grep { !ref } @opt_spec]);
+        exit;
+    }
 
     # Handle '-' to take packages from stdin
     add_from_stdin(\@ARGV, ['-', '/dev/stdin']);

--- a/lib/pacman/aur-repo-parse
+++ b/lib/pacman/aur-repo-parse
@@ -7,6 +7,7 @@ use Cwd 'abs_path';
 use File::Basename;
 
 use AUR::Json qw(write_json);
+use AUR::Options qw(dump_options);
 my $argv0 = 'repo-parse';
 
 my %repo_add_attributes = (
@@ -254,21 +255,30 @@ unless (caller) {
     my @opt_ignore;
     my $opt_ignore_by;
 
-    GetOptions('J|json'         => \$opt_json,
-               'jsonl'          => \$opt_jsonl,
-               'F|field|attr=s' => \$opt_attr,
-               'l|list'         => \$opt_list,
-               'q|quiet'        => \$opt_quiet,
-               't|table'        => \$opt_table,
-               'd|delim'        => \$opt_delim,
-               'list-attr'      => \$opt_list_attr,
-               'p|path=s'       => \@opt_db_path,
-               's|search=s'     => \$opt_search,
-               'search-by=s'    => \$opt_search_by,
-               'i|ignore=s'     => \@opt_ignore,
-               'ignore-by=s'    => \$opt_ignore_by
-        )
-        or exit(1);
+    my $opt_dump;
+
+    my @opt_spec = (
+        'dump-options'   => \$opt_dump,
+        'J|json'         => \$opt_json,
+        'jsonl'          => \$opt_jsonl,
+        'F|field|attr=s' => \$opt_attr,
+        'l|list'         => \$opt_list,
+        'q|quiet'        => \$opt_quiet,
+        't|table'        => \$opt_table,
+        'd|delim'        => \$opt_delim,
+        'list-attr'      => \$opt_list_attr,
+        'p|path=s'       => \@opt_db_path,
+        's|search=s'     => \$opt_search,
+        'search-by=s'    => \$opt_search_by,
+        'i|ignore=s'     => \@opt_ignore,
+        'ignore-by=s'    => \$opt_ignore_by,
+    );
+    GetOptions(@opt_spec) or exit(1);
+
+    if ($opt_dump) {
+        dump_options([grep { !ref } @opt_spec]);
+        exit;
+    }
 
     if (scalar(@ARGV) > 0 and ($ARGV[0] eq "-" or $ARGV[0] eq "/dev/stdin")) {
         $opt_stdin = 1;

--- a/lib/util/aur-format
+++ b/lib/util/aur-format
@@ -7,6 +7,7 @@ use POSIX qw(strftime);
 use v5.20;
 
 use AUR::Json qw(parse_json parse_json_aur);
+use AUR::Options qw(dump_options);
 my $argv0 = 'format';
 
 # Dictionary for formatter string - subset of package-query(1) format options
@@ -175,14 +176,23 @@ unless (caller) {
     my $opt_format;
     my $opt_time_fmt;
 
-    GetOptions(
+    my $opt_dump;
+
+    my @opt_spec = (
+        'dump-options'  => \$opt_dump,
         'f|format=s'    => sub { $opt_mode = 'format',
                                  $opt_format = $_[1] },
         'gron'          => sub { $opt_mode = 'gron' },
         'd|delim=s'     => \$opt_delim,
         'v|verbose'     => \$opt_verbose,
-        'time-format=s' => \$opt_time_fmt
-    ) or exit(1);
+        'time-format=s' => \$opt_time_fmt,
+    );
+    GetOptions(@opt_spec) or exit(1);
+
+    if ($opt_dump) {
+        dump_options([grep { !ref } @opt_spec]);
+        exit;
+    }
 
     if (not length($opt_time_fmt)) {
         $opt_time_fmt = "%a %b %e %H:%M:%S %Y";

--- a/perl/AUR/Options.pm
+++ b/perl/AUR/Options.pm
@@ -5,7 +5,7 @@ use v5.20;
 use Carp;
 
 use Exporter qw(import);
-our @EXPORT_OK = qw(add_from_stdin);
+our @EXPORT_OK = qw(add_from_stdin dump_options);
 our $VERSION = 'unstable';
 
 =head1 NAME
@@ -56,6 +56,37 @@ sub add_from_stdin {
         push(@{$array_ref}, <STDIN>);  # add arguments from stdin
         chomp(@{$array_ref});          # remove newlines
     }
+}
+
+=head2 dump_options()
+
+Print long and short options from a GetOptions spec list, one per
+line, matching the format of the bash --dump-options output.
+Argument-taking options carry a trailing C<:>.
+
+=cut
+
+sub dump_options {
+    my ($spec) = @_;
+    my (@long, @short);
+
+    for my $entry (@{$spec}) {
+        # Split "name|alias|alias2=s" into names and type
+        my ($names, $type) = split /[=:]/, $entry, 2;
+        my $suffix = defined $type ? ':' : '';
+
+        for my $name (split /\|/, $names) {
+            next if $name eq 'dump-options';
+
+            if (length($name) == 1) {
+                push @short, "-${name}${suffix}";
+            } else {
+                push @long, "--${name}${suffix}";
+            }
+        }
+    }
+    say for @long;
+    say for @short;
 }
 
 # vim: set et sw=4 sts=4 ft=perl:


### PR DESCRIPTION
The five Perl-based `aur-` scripts (`depends`, `search`, `query`, `format`, `repo-parse`) had no `--dump-options` support, so their completions were hardcoded as empty in `command_opts.sh`.

Add a `dump_options()` helper to `AUR::Options` that parses the `GetOptions` spec and prints flags in the same format the bash scripts already use. Each Perl script now accepts `--dump-options` and passes its spec through the helper.

Update `command_opts.sh` to include them in `have_optdump`. Only `aur-graph` (`gawk`, no flags) remains in `no_optdump`.

Co-Authored-By: Claude Opus