### PR TITLE
build, sync: pass additional arguments through to aur-chroot

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -115,7 +115,8 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:' 'root:'
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nosync' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rm-deps' 'gpg-sign' 'margs:' 'nocheck'
-            'no-checkdepends' 'nocheckdepends' 'optdepends' 'repo:' 'autokeyretrieve')
+            'no-checkdepends' 'nocheckdepends' 'optdepends' 'repo:' 'autokeyretrieve'
+            'base-packages:' 'cargs:' 'makechrootpkg-args:')
 
 if opts=$(getopt -o "$opt_short" -l "$(args_csv "${opt_long[@]}" "${opt_hidden[@]}")" -n "$argv0" -- "$@"); then
     eval set -- "$opts"
@@ -205,10 +206,14 @@ while true; do
             build_args+=(--force) ;;
         -C|--clean)
             build_args+=(--clean) ;;
+        --base-packages)
+            shift; build_args+=(--base-packages "$1") ;;
         --cleanbuild)
             build_args+=(--cleanbuild) ;;
         --makepkg-args|--margs)
             shift; build_args+=(--margs "$1") ;;
+        --makechrootpkg-args|--cargs)
+            shift; build_args+=(--cargs "$1") ;;
         --makepkg-conf)
             shift; build_args+=(--makepkg-conf "$1") ;;
         --pacman-conf)

--- a/lib/pacman/aur-build
+++ b/lib/pacman/aur-build
@@ -18,8 +18,8 @@ unset -v CDPATH
 chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 truncate=1 status=0
 
 # default arguments (empty)
-chroot_args=() chroot_build_args=() sync_args=() repo_args=() repo_add_args=()
-pkglist_args=() makepkg_args=() makepkg_common_args=() read_args=()
+chroot_args=() chroot_base_packages=() chroot_build_args=() sync_args=() repo_args=()
+repo_add_args=() pkglist_args=() makepkg_args=() makepkg_common_args=() read_args=()
 
 # default arguments
 gpg_args=(--detach-sign --no-armor --batch)
@@ -78,7 +78,7 @@ opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign' 'gpg-sign'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
           'syncdeps' 'clean' 'namcap' 'checkpkg' 'makepkg-args:' 'user:'
           'margs:' 'buildscript:' 'null' 'dbext:' 'cleanbuild' 'cargs:'
-          'makechrootpkg-args:' 'makepkg-gnupghome:' 'pool:')
+          'makechrootpkg-args:' 'makepkg-gnupghome:' 'pool:' 'base-packages:')
 opt_hidden=('dump-options' 'ignorearch' 'noconfirm' 'nocheck' 'nosync' 'repo:'
             'results:' 'results-append:' 'status')
 
@@ -129,6 +129,10 @@ while true; do
         # chroot options
         -D|--directory)
             shift; chroot_args+=(--directory "$1") ;;
+        --base-packages)
+            shift; IFS=, read -a base_packages -r <<< "$1"
+            chroot_base_packages+=("${base_packages[@]}")
+            ;;
         --bind)
             shift; chroot_args+=(--bind "$1") ;;
         --bind-rw)
@@ -337,7 +341,7 @@ if (( chroot )); then
     # Update pacman and makepkg configuration for the chroot build
     # queue. A full system upgrade is run on the /root container to
     # avoid lenghty upgrades for makechrootpkg -u.
-    aur chroot "${chroot_args[@]}" --create --update
+    aur chroot "${chroot_args[@]}" --create --update -- "${chroot_base_packages[@]}"
 fi
 
 # Early check for `makepkg` buildscript

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -196,6 +196,20 @@ for chroot builds
 .RB ( aur\-chroot " " \-\-cargs ).
 .
 .TP
+.BI \-\-base\-packages= PACKAGES
+Packages or package groups (comma-separated) to be passed to
+.B aur-chroot
+for chroot builds
+.RB ( aur\-chroot " " \-\-create " " \-\- " " [ "package..." ] ).
+.
+.IP
+See also
+.BR \-\-create
+in
+.BR aur\-chroot (1)
+for additional usage notes.
+.
+.TP
 .BR \-\-no\-sync
 Do not sync the local repository after building.
 .


### PR DESCRIPTION
The `aur chroot` command currently accepts positional arguments for base packages. This PR exposes them to `aur-build` (as `--base-packages`).

This is especially useful if the chroot lives on a tmpfs and needs to be recreated often and if the user needs additional packages handled at creation time.

The PR also exposes the new `--base-packages` (and `--cargs` while we’re at it) to `aur-sync`.

## Documentation

The new options need no additional mention in `aur-sync(1)` because the blanket statement covers them already:

> This section only lists common options. See aur-build(1) for more information.

## Usage examples

```sh
aur build -c --base-packages base-devel,less,vim
```

```sh
aur sync -cu --base-packages base-devel,less,vim --cargs -xfailure
```
