### PR TITLE
AUR::Exception: structured errors for Depends.pm

### DIFF
--- a/lib/aurweb/aur-depends
+++ b/lib/aurweb/aur-depends
@@ -4,10 +4,12 @@ use warnings;
 use v5.20;
 
 use List::Util   qw(first);
+use Scalar::Util qw(blessed);
 use AUR::Json    qw(parse_json_aur write_json);
 use AUR::Query   qw(query_multi);
 use AUR::Depends qw(recurse prune graph);
 use AUR::Options qw(add_from_stdin dump_options);
+use AUR::Exception;
 my $argv0 = 'depends';
 
 sub solve {
@@ -164,8 +166,17 @@ unless(caller) {
 
     # Retrieve AUR results
     #    JSON -> hash -> extract depends[] -> repeat until none -> prune
-    my ($results, $dag, $dag_foreign) = solve(\@ARGV, \@types, \&callback_query,
-        $opt_verify, $opt_provides, $opt_installed);
+    my ($results, $dag, $dag_foreign) = eval {
+        solve(\@ARGV, \@types, \&callback_query,
+              $opt_verify, $opt_provides, $opt_installed);
+    };
+    if (my $error = $@) {
+        if (blessed($error) && $error->isa('AUR::Exception')) {
+            say STDERR $error->message;
+            exit($error->exit_code);
+        }
+        die $error;  # re-throw unexpected errors
+    }
 
     # Add `RequiredBy` to results
     for my $name (keys %{$dag}) {

--- a/perl/AUR/Depends.pm
+++ b/perl/AUR/Depends.pm
@@ -7,6 +7,7 @@ use List::Util qw(first);
 use Carp;
 use Exporter qw(import);
 use AUR::Vercmp qw(vercmp);
+use AUR::Exception;
 
 use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
@@ -138,13 +139,11 @@ sub recurse {
     }
     # Check if results are available
     if (scalar keys %results == 0) {
-        say STDERR __PACKAGE__ . ": no packages found";
-        exit EX_FAILURE;
+        croak(AUR::Exception->new(__PACKAGE__ . ": no packages found", EX_FAILURE));
     }
     # Check if request limits have been exceeded
     if ($a == $aur_callback_max) {
-        say STDERR __PACKAGE__ . ": total requests: $a (out of range)";
-        exit EX_OUT_OF_RANGE;
+        croak(AUR::Exception->new(__PACKAGE__ . ": total requests: $a (out of range)", EX_OUT_OF_RANGE));
     }
     return \%results, \%pkgdeps, \%pkgmap;
 }
@@ -182,8 +181,7 @@ Parameters:
 sub graph {
     my ($results, $pkgdeps, $pkgmap, $verify, $provides) = @_;
     my (%dag, %dag_foreign);
-
-    my $dag_valid = 1;
+    my @invalid;
     $verify //= 1;  # run vercmp by default
 
     # Iterate over packages
@@ -220,8 +218,8 @@ sub graph {
                     $dag{$prov_name}{$name} = $dep_type;
                 }
                 else {
-                    say STDERR "invalid node: $prov_name=$prov_ver (required: $dep_op$dep_req by: $name)";
-                    $dag_valid = 0;
+                    push @invalid,
+                        "invalid node: $prov_name=$prov_ver (required: $dep_op$dep_req by: $name)";
                 }
             }
             # Dependency is foreign
@@ -230,8 +228,8 @@ sub graph {
             }
         }
     }
-    if (not $dag_valid) {
-        exit EX_FAILURE;
+    if (@invalid) {
+        croak(AUR::Exception->new(__PACKAGE__ . ": " . join("\n", @invalid), EX_FAILURE));
     }
     return \%dag, \%dag_foreign;
 }
@@ -320,8 +318,7 @@ sub tsort {
     my @output;
 
     if (scalar(@{$input}) % 2 == 1) {
-        say STDERR __PACKAGE__ . ": odd number of tokens";
-        exit EX_FAILURE;
+        croak(AUR::Exception->new(__PACKAGE__ . ": odd number of tokens", EX_FAILURE));
     }
 
     while (@{$input}) {
@@ -353,7 +350,9 @@ sub tsort {
 
         }
     }
-    say STDERR __PACKAGE__ . ": cycle detected\n" if grep {$npred{$_}} keys %npred;
+    if (grep {$npred{$_}} keys %npred) {
+        croak(AUR::Exception->new(__PACKAGE__ . ": cycle detected", EX_FAILURE));
+    }
 
     return @output;
 }

--- a/perl/AUR/Exception.pm
+++ b/perl/AUR/Exception.pm
@@ -1,0 +1,42 @@
+package AUR::Exception;
+use strict;
+use warnings;
+use v5.20;
+
+use overload '""' => \&message;
+
+our $VERSION = 'unstable';
+
+=head1 NAME
+
+AUR::Exception - Structured error with exit code for AUR modules
+
+=head1 SYNOPSIS
+
+  use AUR::Exception;
+  use Carp;
+
+  croak AUR::Exception->new("no packages found", 1);
+
+=head1 DESCRIPTION
+
+A lightweight exception class that carries a human-readable message
+and a numeric exit code. When stringified (e.g. inside C<die> or
+C<warn>), only the message is returned.
+
+=head1 AUTHORS
+
+Alad Wenter <https://github.com/AladW>
+
+=cut
+
+sub new {
+    my ($class, $message, $exit_code) = @_;
+    $exit_code //= 1;
+    return bless { message => $message, exit_code => $exit_code }, $class;
+}
+
+sub message   { return $_[0]->{message} }
+sub exit_code { return $_[0]->{exit_code} }
+
+# vim: set et sw=4 sts=4 ft=perl:


### PR DESCRIPTION
Add `AUR::Exception`, a small blessed class that carries a message
and an exit code (per the design in #1253).

`Depends.pm` now croaks with exception objects instead of printing
to stderr and calling `exit()` directly. `aur-depends` catches
these with `eval` and `blessed()`, prints the message, and exits
with the carried code. Unexpected errors are re-thrown.

The CLI surface (exit 1 for failures, exit 34 for callback limit)
stays the same.